### PR TITLE
Initial implementation of HearingResult model with basic specs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMMON_PLATFORM_URL=https://hmcts-common-platform-mock-api.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/Gemfile
+++ b/Gemfile
@@ -43,4 +43,5 @@ end
 
 group :test do
   gem 'rspec_junit_formatter'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -26,12 +26,15 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'faraday_middleware'
 
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'pry-rails', '~> 0.3.9'
   gem 'rspec-rails', '~> 4.0.0.beta3'
   gem 'rubocop', '~> 0.76.0', require: false
   gem 'rubocop-performance'
+  gem 'vcr'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    shoulda-matchers (4.1.2)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -200,6 +202,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.76.0)
   rubocop-performance
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,15 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     diff-lcs (1.3)
+    dotenv (2.7.4)
+    dotenv-rails (2.7.4)
+      dotenv (= 2.7.4)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    faraday (0.17.0)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -88,6 +96,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.13.0)
     msgpack (1.3.1)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
@@ -183,6 +192,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    vcr (5.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -193,6 +203,8 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
+  dotenv-rails
+  faraday_middleware
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-rails (~> 0.3.9)
@@ -205,6 +217,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  vcr
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Hearing < ApplicationRecord
+  validates :body, presence: true
+end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ApplicationService
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+
+  def call; end
+
+  private
+
+  def initialize(*args, &block); end
+end

--- a/app/services/hearing_result_fetcher.rb
+++ b/app/services/hearing_result_fetcher.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class HearingResultFetcher < ApplicationService
+  def initialize(hearing_id)
+    @hearing_id = hearing_id
+  end
+
+  def call
+    connection.get("/hearing/results/#{hearing_id}")
+  end
+
+  private
+
+  def connection
+    @connection ||= Faraday.new ENV.fetch('COMMON_PLATFORM_URL') do |conn|
+      conn.response :json, content_type: 'application/json'
+      conn.adapter Faraday.default_adapter
+    end
+  end
+
+  attr_reader :hearing_id
+end

--- a/app/services/hearing_result_recorder.rb
+++ b/app/services/hearing_result_recorder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HearingResultRecorder < ApplicationService
+  def initialize(hearing_id)
+    @hearing = Hearing.find_or_initialize_by(id: hearing_id)
+  end
+
+  def call
+    response = HearingResultFetcher.call(hearing.id)
+    hearing.body = response.body
+    hearing.save
+  end
+
+  private
+
+  attr_reader :hearing
+end

--- a/db/migrate/20191111162446_enable_extension_for_uuid.rb
+++ b/db/migrate/20191111162446_enable_extension_for_uuid.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnableExtensionForUuid < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/migrate/20191111162455_create_hearings.rb
+++ b/db/migrate/20191111162455_create_hearings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateHearings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hearings, id: :uuid do |t|
+      t.jsonb :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_11_11_162455) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
+
+  create_table "hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/spec/cassettes/hearing_result_fetcher/not_found.yml
+++ b/spec/cassettes/hearing_result_fetcher/not_found.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/hearing/results/6c0b7068-d4a7-4adc-a7a0-7bd5715b501d"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      server:
+      - openresty/1.15.8.2
+      date:
+      - Tue, 12 Nov 2019 17:05:26 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      cache-control:
+      - no-cache
+      x-request-id:
+      - dd8f09bd06655d63b730bec59381095a
+      x-runtime:
+      - '0.005580'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"Couldn''t find Hearing with ''id''=6c0b7068-d4a7-4adc-a7a0-7bd5715b501d"}'
+    http_version: 
+  recorded_at: Tue, 12 Nov 2019 17:05:26 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/hearing_result_fetcher/success.yml
+++ b/spec/cassettes/hearing_result_fetcher/success.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/hearing/results/ceb158e3-7171-40ce-915b-441e2c4e3f75"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - openresty/1.15.8.2
+      date:
+      - Tue, 12 Nov 2019 17:05:26 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      etag:
+      - W/"490eb618ba80a6d77b42b0f634c32cb1"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 18c5166ba29f14f582b811aecbe90800
+      x-runtime:
+      - '0.079200'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hearing":{"id":"ceb158e3-7171-40ce-915b-441e2c4e3f75","jurisdictionType":"CROWN","reportingRestrictionReason":null,"courtCentre":{"id":"be0a2b10-6bba-4ec2-ac41-63bea83adb2e","name":"Random
+        string","welshName":"Llinyn ar hap","roomId":"b3724149-5b25-49cc-85e8-feff6057b486","roomName":"Grand
+        Hall","welshRoomName":"Neuadd y Grand"},"hearingLanguage":"ENGLISH","hasSharedResults":null,"type":{"id":"25d256ab-86d9-4972-a5eb-4c8260f3516f","description":"This
+        is a description","code":"12D10JAS"},"isEffectiveTrial":null,"isBoxHearing":null,"hearingDays":[{"sittingDay":"2020-01-12T15:17:37.325Z","listingSequence":8,"listedDurationMinutes":10}]}}'
+    http_version: 
+  recorded_at: Tue, 12 Nov 2019 17:05:26 GMT
+recorded_with: VCR 5.0.0

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hearing, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:body) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationService do
+  subject { described_class.call('some', 'arguments') }
+
+  let(:described_instance) { instance_double('ApplicationService') }
+
+  before do
+    allow(ApplicationService).to receive(:new).and_return(described_instance)
+  end
+
+  it 'should initialize and call the instance' do
+    expect(ApplicationService).to receive(:new).with('some', 'arguments')
+    expect(described_instance).to receive(:call)
+    subject
+  end
+end

--- a/spec/services/hearing_result_fetcher_spec.rb
+++ b/spec/services/hearing_result_fetcher_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingResultFetcher do
+  subject { described_class.call(hearing_id) }
+
+  let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }
+
+  it 'returns the requested hearing info' do
+    VCR.use_cassette('hearing_result_fetcher/success') do
+      expect(subject.body['hearing']['id']).to eq(hearing_id)
+    end
+  end
+
+  context 'with a non existent id' do
+    let(:hearing_id) { '6c0b7068-d4a7-4adc-a7a0-7bd5715b501d' }
+
+    it 'returns a not found response' do
+      VCR.use_cassette('hearing_result_fetcher/not_found') do
+        expect(subject.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/services/hearing_result_recorder_spec.rb
+++ b/spec/services/hearing_result_recorder_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingResultRecorder do
+  subject { described_class.call(hearing_id) }
+
+  let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
+
+  let(:response) { double(body: { hearing: { id: hearing_id } }.to_json) }
+
+  before do
+    allow(HearingResultFetcher).to receive(:call).and_return(response)
+  end
+
+  it 'creates a Hearing' do
+    expect {
+      subject
+    }.to change(Hearing, :count).by(1)
+  end
+
+  context 'when the Hearing exists' do
+    let!(:hearing) { Hearing.create!(id: hearing_id, body: { amazing_body: true }) }
+
+    it 'does not create a new record' do
+      expect {
+        subject
+      }.to change(Hearing, :count).by(0)
+    end
+
+    it 'updates Hearing with new response' do
+      subject
+      expect(hearing.reload.body).to eq(response.body)
+    end
+  end
+end

--- a/spec/support/shoulda.rb
+++ b/spec/support/shoulda.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :faraday
+  c.configure_rspec_metadata!
+  c.filter_sensitive_data('<COMMON_PLATFORM_URL>') { ENV['COMMON_PLATFORM_URL'] }
+end


### PR DESCRIPTION
Add Hearing Model to store the `body` of the `hearing/results?hearingId=XX` endpoint.
If the Hearing does not exist, creates a new record, or else updates it.