### PR TITLE
Enable Ingress to allow access from outside k8s

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/values.yaml
+++ b/helm_deploy/laa-court-data-adaptor/values.yaml
@@ -36,13 +36,13 @@ service:
   port: 3000
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
-      paths: []
+    - host: laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+      paths: ["/"]
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
By enabling the ingress we will be able to access the servie from
outside kubernetes network.