### PR TITLE
Rename HearingResult* services to Hearing*

### DIFF
--- a/app/services/hearing_fetcher.rb
+++ b/app/services/hearing_fetcher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HearingResultFetcher < ApplicationService
+class HearingFetcher < ApplicationService
   def initialize(hearing_id)
     @hearing_id = hearing_id
   end

--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-class HearingResultRecorder < ApplicationService
+class HearingRecorder < ApplicationService
   def initialize(hearing_id)
     @hearing = Hearing.find_or_initialize_by(id: hearing_id)
   end
 
   def call
-    response = HearingResultFetcher.call(hearing.id)
+    response = HearingFetcher.call(hearing.id)
     hearing.body = response.body
     hearing.save
   end

--- a/spec/services/hearing_fetcher_spec.rb
+++ b/spec/services/hearing_fetcher_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe HearingResultFetcher do
+RSpec.describe HearingFetcher do
   subject { described_class.call(hearing_id) }
 
   let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe HearingResultRecorder do
+RSpec.describe HearingRecorder do
   subject { described_class.call(hearing_id) }
 
   let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
@@ -10,7 +10,7 @@ RSpec.describe HearingResultRecorder do
   let(:response) { double(body: { hearing: { id: hearing_id } }.to_json) }
 
   before do
-    allow(HearingResultFetcher).to receive(:call).and_return(response)
+    allow(HearingFetcher).to receive(:call).and_return(response)
   end
 
   it 'creates a Hearing' do


### PR DESCRIPTION
From [this discussion](https://github.com/ministryofjustice/laa-court-data-adaptor/pull/2#discussion_r345805688), rename `HearingResultRecorder` and `HearingResultFetcher` to `HearingRecorder` and `HearingFetcher` respectively.
