### PR TITLE
Add POST endpoint to receive hearings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  ERROR_MAPPINGS = {
+    ActionController::ParameterMissing => :bad_request
+  }.freeze
+
+  ERROR_MAPPINGS.each do |klass, status|
+    rescue_from klass do |error|
+      render json: { error: error }, status: status
+    end
+  end
 end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -4,8 +4,8 @@ class HearingsController < ApplicationController
   def create
     @hearing = HearingRecorder.call(params[:hearing][:id], hearing_params)
 
-    if @hearing
-      render json: @hearing, status: :created
+    if @hearing.valid?
+      head :created
     else
       render json: @hearing.errors, status: :unprocessable_entity
     end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class HearingsController < ApplicationController
+  def create
+    @hearing = HearingRecorder.call(params[:hearing][:id], hearing_params)
+
+    if @hearing
+      render json: @hearing, status: :created
+    else
+      render json: @hearing.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # Only allow a trusted parameter "white list" through.
+  def hearing_params
+    params.require(%i[sharedTime hearing])
+    params.permit(:sharedTime, hearing: {})
+  end
+end

--- a/app/services/api/get_hearing_results.rb
+++ b/app/services/api/get_hearing_results.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  class GetHearingResults < ApplicationService
+    def initialize(hearing_id)
+      @hearing_id = hearing_id
+      @response = HearingFetcher.call(hearing_id)
+    end
+
+    def call
+      HearingRecorder.call(hearing_id, response.body) if successful_response?
+    end
+
+    private
+
+    def successful_response?
+      response.status == 200
+    end
+
+    attr_reader :hearing_id, :response
+  end
+end

--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class HearingRecorder < ApplicationService
-  def initialize(hearing_id)
+  def initialize(hearing_id, body = nil)
     @hearing = Hearing.find_or_initialize_by(id: hearing_id)
+    @body = body.presence || HearingFetcher.call(hearing.id).body
   end
 
   def call
-    response = HearingFetcher.call(hearing.id)
-    hearing.body = response.body
-    hearing.save
+    hearing.update(body: body)
+    hearing
   end
 
   private
 
-  attr_reader :hearing
+  attr_reader :hearing, :body
 end

--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class HearingRecorder < ApplicationService
-  def initialize(hearing_id, body = nil)
+  def initialize(hearing_id, body)
     @hearing = Hearing.find_or_initialize_by(id: hearing_id)
-    @body = body.presence || HearingFetcher.call(hearing.id).body
+    @body = body
   end
 
   def call

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :status, only: [:index]
+  resources :hearings, only: [:create]
 end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe HearingsController, type: :controller do
         }.to change(Hearing, :count).by(1)
       end
 
-      it 'renders a JSON response with the new hearing' do
+      it 'renders a JSON response with an empty response' do
         post :create, params: valid_attributes
         expect(response).to have_http_status(:created)
+        expect(response.body).to be_empty
       end
     end
 

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingsController, type: :controller do
+  let(:valid_attributes) { JSON.parse(file_fixture('valid_hearing.json').read) }
+  let(:invalid_attributes) { JSON.parse(file_fixture('invalid_hearing.json').read) }
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new Hearing' do
+        expect {
+          post :create, params: valid_attributes
+        }.to change(Hearing, :count).by(1)
+      end
+
+      it 'renders a JSON response with the new hearing' do
+        post :create, params: valid_attributes
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'renders a JSON response with errors for the new hearing' do
+        post :create, params: invalid_attributes
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/invalid_hearing.json
+++ b/spec/fixtures/files/invalid_hearing.json
@@ -1,0 +1,19 @@
+{
+  "hearing": {
+      "id": "04180ff1-99b0-40b7-9929-ca05bdc767d8",
+      "jurisdictionType": "MAGISTRATES",
+      "courtCentre": {
+          "id": "dd9bf969-f55e-43f1-a08a-7b475a9aa914"
+      },
+      "type": {
+          "id": "141c74ad-b87e-4756-8908-1642b1771ab5",
+          "description": "First hearing",
+          "code": "FHG"
+      },
+      "hearingDays": [{
+          "sittingDay": "2018-10-24 10:00:00",
+          "listingSequence": 1,
+          "listedDurationMinutes": 120
+      }]
+  }
+}

--- a/spec/fixtures/files/valid_hearing.json
+++ b/spec/fixtures/files/valid_hearing.json
@@ -1,0 +1,20 @@
+{
+  "hearing": {
+      "id": "04180ff1-99b0-40b7-9929-ca05bdc767d8",
+      "jurisdictionType": "MAGISTRATES",
+      "courtCentre": {
+          "id": "dd9bf969-f55e-43f1-a08a-7b475a9aa914"
+      },
+      "type": {
+          "id": "141c74ad-b87e-4756-8908-1642b1771ab5",
+          "description": "First hearing",
+          "code": "FHG"
+      },
+      "hearingDays": [{
+          "sittingDay": "2018-10-24 10:00:00",
+          "listingSequence": 1,
+          "listedDurationMinutes": 120
+      }]
+  },
+  "sharedTime": "2018-10-25 11:30:00"
+}

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Hearings', type: :request do
+  describe 'POST /hearings' do
+    let(:params) { JSON.parse(file_fixture('valid_hearing.json').read) }
+
+    it 'renders a 201 status' do
+      post '/hearings', params: params
+      expect(response).to have_http_status(201)
+    end
+  end
+end

--- a/spec/routing/hearings_routing_spec.rb
+++ b/spec/routing/hearings_routing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #create' do
+      expect(post: '/hearings').to route_to('hearings#create')
+    end
+  end
+end

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::GetHearingResults do
+  subject { described_class.call(hearing_id) }
+
+  let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }
+
+  let(:response) { double(body: { amazing_body: true }.to_json, status: 200) }
+
+  before do
+    allow(HearingFetcher).to receive(:call).with(hearing_id).and_return(response)
+  end
+
+  it 'calls the HearingRecorder service' do
+    expect(HearingRecorder).to receive(:call).with(hearing_id, response.body)
+    subject
+  end
+
+  context 'when the status is a 404' do
+    let(:response) { double(body: {}.to_json, status: 404) }
+
+    it 'does not record the result' do
+      expect(HearingRecorder).not_to receive(:call)
+      subject
+    end
+  end
+end

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe HearingRecorder do
     }.to change(Hearing, :count).by(1)
   end
 
+  it 'returns the created Hearing' do
+    expect(subject).to be_a(Hearing)
+  end
+
   context 'when the Hearing exists' do
     let!(:hearing) { Hearing.create!(id: hearing_id, body: { amazing_body: true }) }
 
@@ -31,6 +35,20 @@ RSpec.describe HearingRecorder do
     it 'updates Hearing with new response' do
       subject
       expect(hearing.reload.body).to eq(response.body)
+    end
+  end
+  context 'when the body exists' do
+    let(:body) { { response: 'text' }.to_json }
+
+    subject { described_class.call(hearing_id, body) }
+
+    it 'does not fetch the hearing again' do
+      expect(HearingFetcher).not_to receive(:call)
+      subject
+    end
+
+    it 'updates the hearing with the body' do
+      expect(subject.body).to eq(body)
     end
   end
 end

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -3,15 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe HearingRecorder do
-  subject { described_class.call(hearing_id) }
-
   let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
+  let(:body) { { response: 'text' }.to_json }
 
-  let(:response) { double(body: { hearing: { id: hearing_id } }.to_json) }
-
-  before do
-    allow(HearingFetcher).to receive(:call).and_return(response)
-  end
+  subject { described_class.call(hearing_id, body) }
 
   it 'creates a Hearing' do
     expect {
@@ -21,6 +16,10 @@ RSpec.describe HearingRecorder do
 
   it 'returns the created Hearing' do
     expect(subject).to be_a(Hearing)
+  end
+
+  it 'saves the body on the Hearing' do
+    expect(subject.body).to eq(body)
   end
 
   context 'when the Hearing exists' do
@@ -34,21 +33,7 @@ RSpec.describe HearingRecorder do
 
     it 'updates Hearing with new response' do
       subject
-      expect(hearing.reload.body).to eq(response.body)
-    end
-  end
-  context 'when the body exists' do
-    let(:body) { { response: 'text' }.to_json }
-
-    subject { described_class.call(hearing_id, body) }
-
-    it 'does not fetch the hearing again' do
-      expect(HearingFetcher).not_to receive(:call)
-      subject
-    end
-
-    it 'updates the hearing with the body' do
-      expect(subject.body).to eq(body)
+      expect(hearing.reload.body).to eq(body)
     end
   end
 end


### PR DESCRIPTION
Endpoint for Publish Hearing-Resulted API.

Added a service which can be triggered via a background job/rake task depending on the use case as below:
```ruby
Api::GetHearingResults.call(hearing_id)
```
This will call the mock endpoint and record the body of the response against the `Hearing`.

