### PR TITLE
Add pre-commit git hook to run rubocop

### DIFF
--- a/scripts/install-hooks.bash
+++ b/scripts/install-hooks.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+GIT_DIR=$(git rev-parse --git-dir)
+
+echo "Installing hooks..."
+# this command creates symlink to our pre-commit script
+ln -s ../../scripts/pre-commit.bash $GIT_DIR/hooks/pre-commit
+echo "Done!"

--- a/scripts/pre-commit.bash
+++ b/scripts/pre-commit.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Running pre-commit hook"
+./scripts/run-rubocop.bash
+
+# $? stores exit value of the last command
+if [ $? -ne 0 ]; then
+ echo "Code must be clean before commiting"
+ exit 1
+fi

--- a/scripts/run-rubocop.bash
+++ b/scripts/run-rubocop.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "${0%/*}/.."
+
+echo "Running rubocop"
+bundle exec rubocop -a


### PR DESCRIPTION
Sets a script to run `rubocop -a`, and symlinks it to the pre-commit file in `.git/hooks` so that it runs before a commit

To install the script to run `rubocop -a` run `./scripts/install-hooks.bash` in the application root. This will create a non-sample `pre-commit` file in `.git/hooks`. 

If changes to this script are made - delete `.git/hooks/pre-commit` and re-run the installer.

You also may have to run `chmod +x scripts/*.bash` if new scripts are added to make them executable.

For reference I follow this [tutorial](https://medium.com/better-programming/git-hooks-for-your-rails-app-to-run-rubocop-brakeman-and-rspec-on-push-or-commit-ab51cd65e713)