### PR TITLE
Add user authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'puma', '~> 4.1'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
     ast (2.4.0)
+    bcrypt (3.1.13)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -203,6 +204,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   dotenv-rails
   faraday_middleware

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class StatusController < ApplicationController
+  skip_before_action :authenticate, only: [:index]
   def index
     render head: :ok
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  has_secure_password :auth_token
+
+  validates :name, presence: true
+end

--- a/db/migrate/20191211135014_create_users.rb
+++ b/db/migrate/20191211135014_create_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.string :name
+      t.string :auth_token_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_174858) do
+ActiveRecord::Schema.define(version: 2019_12_11_135014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -24,6 +24,13 @@ ActiveRecord::Schema.define(version: 2019_11_13_174858) do
 
   create_table "prosecution_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "auth_token_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      head :ok
+    end
+  end
+
+  let(:valid_token) { 'TOKENTOKEN' }
+  let(:user) { User.create(name: 'HMCTS USER', auth_token: valid_token) }
+  let(:user_id) { user.id }
+
+  it_behaves_like 'an unauthorised request'
+
+  describe 'Token Authorisation' do
+    let(:token) { 'FAKETOKEN' }
+
+    before do
+      request.headers.merge!('Authorization': "Bearer #{token}, user_id=#{user_id}")
+    end
+
+    describe 'invalid token' do
+      it_behaves_like 'an unauthorised request'
+    end
+
+    describe 'invalid user id' do
+      let(:user_id) { 'INVALID-USER-ID' }
+
+      it_behaves_like 'an unauthorised request'
+    end
+
+    describe 'valid user id and token' do
+      let(:token) { valid_token }
+
+      it 'returns an ok status' do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe HearingsController, type: :controller do
+  include AuthorisedRequestHelper
+
+  before { authorise_requests! }
+
   let(:valid_attributes) { JSON.parse(file_fixture('valid_hearing.json').read) }
   let(:invalid_attributes) { JSON.parse(file_fixture('invalid_hearing.json').read) }
 

--- a/spec/controllers/prosecution_cases_controller_spec.rb
+++ b/spec/controllers/prosecution_cases_controller_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe ProsecutionCasesController, type: :controller do
+  include AuthorisedRequestHelper
+
+  before { authorise_requests! }
+
   describe 'GET #index' do
     let(:params) { JSON.parse(file_fixture('valid_prosecution_case_search.json').read) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+  end
+end

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -3,11 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Hearings', type: :request do
+  include AuthorisedRequestHelper
+
   describe 'POST /hearings' do
     let(:params) { JSON.parse(file_fixture('valid_hearing.json').read) }
+    let(:user) { User.create!(name: 'LAA User', auth_token: 'TOKEN') }
+    let(:headers) { valid_auth_header(user) }
 
     it 'renders a 201 status' do
-      post '/hearings', params: params
+      post '/hearings', params: params, headers: headers
       expect(response).to have_http_status(201)
     end
   end

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'ProsecutionCases', type: :request do
+  include AuthorisedRequestHelper
+
   describe 'GET /prosecution_cases' do
     let(:params) { JSON.parse(file_fixture('valid_prosecution_case_search.json').read) }
+    let(:user) { User.create!(name: 'LAA User', auth_token: 'TOKEN') }
+    let(:headers) { valid_auth_header(user) }
 
     it 'renders a 200 status' do
       VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
-        get '/prosecution_cases', params: params
+        get '/prosecution_cases', params: params, headers: headers
         expect(response).to have_http_status(200)
       end
     end

--- a/spec/support/authorised_request_helper.rb
+++ b/spec/support/authorised_request_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AuthorisedRequestHelper
+  def authorise_requests!
+    allow(controller).to receive(:authenticate).and_return(true)
+  end
+
+  def valid_auth_header(user)
+    { 'Authorization': "Bearer #{user.auth_token}, user_id=#{user.id}" }
+  end
+end

--- a/spec/support/unauthorised_request.rb
+++ b/spec/support/unauthorised_request.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'an unauthorised request' do
+  it 'responds with a 401 status code' do
+    get :index
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
Adds a User model 
Add Authorisation via HTTP Token auth to the controller.

The expected format for this is as follows:
```
  Authorization: Bearer SECRETTOKEN, user_id=USER-UUID
```
This allows us to fetch the user by the id and then verify by the token
and avoids the need for storing the `SECRETTOKEN`
in plaintext or encrypted, since it is stored as a BCrypt digest
using the standard rails `has_secure_password` method.

