### PR TITLE
Add simplecov gem to monitor test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 /config/master.key
 
 spec/examples.txt
+
+# Ignore simplecov coverage stats
+/coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,5 @@ end
 group :test do
   gem 'rspec_junit_formatter'
   gem 'shoulda-matchers'
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.4)
     dotenv-rails (2.7.4)
       dotenv (= 2.7.4)
@@ -79,6 +80,7 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -177,6 +179,11 @@ GEM
     ruby_dep (1.5.0)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -216,6 +223,7 @@ DEPENDENCIES
   rubocop (~> 0.76.0)
   rubocop-performance
   shoulda-matchers
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   vcr

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe HearingsController, type: :controller do
       end
     end
 
+    context 'with an invalid hearing' do
+      it 'renders a JSON response with an unprocessable_entity error' do
+        allow(HearingRecorder).to receive(:call).and_return(Hearing.new)
+        post :create, params: valid_attributes
+        expect(response.body).to include("can't be blank")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
     context 'with invalid params' do
       it 'renders a JSON response with errors for the new hearing' do
         post :create, params: invalid_attributes

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,16 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'simplecov'
+
+SimpleCov.minimum_coverage 100
+unless ENV['NOCOVERAGE']
+  SimpleCov.start do
+    add_filter 'spec/'
+  end
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
There is currently no code coverage metrics for unit tests.

This PR:

* Adds `simplecov` to the `gemfile`
* Configures `simplecov` to mandate 100% code coverage and not include
specs in the coverage calculation
* Updates `.gitignore` to prevent code coverage details being committed
* Adds an extra test to `hearings_controller_spec` to ensure 100% coverage