### PR TITLE
Require COMMON_PLATFORM_URL to boot the app.

### DIFF
--- a/app/models/concerns/common_platform_connection.rb
+++ b/app/models/concerns/common_platform_connection.rb
@@ -7,7 +7,7 @@ module CommonPlatformConnection
     private
 
     def common_platform_connection
-      @common_platform_connection ||= Faraday.new ENV.fetch('COMMON_PLATFORM_URL') do |connection|
+      @common_platform_connection ||= Faraday.new Rails.configuration.x.common_platform_url do |connection|
         connection.request :json
         connection.response :json, content_type: 'application/json'
         connection.adapter Faraday.default_adapter

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module LaaCourtDataAdaptor
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.x.common_platform_url = ENV.fetch('COMMON_PLATFORM_URL')
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-288)
We need to ensure that the adaptor knows where to find the Common platform or a mock version to query against. This change will cause the app to not boot if the `COMMON_PLATFORM_URL` is not set.

## Checklist
- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
