### PR TITLE
Ensure prmd loading in production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,10 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 gem 'faraday_middleware'
+gem 'prmd'
 
 group :development, :test do
   gem 'dotenv-rails'
-  gem 'prmd'
   gem 'pry-rails', '~> 0.3.9'
   gem 'rspec-rails', '~> 4.0.0.beta4'
   gem 'rubocop', '~> 0.79.0', require: false

--- a/lib/tasks/prmd.rake
+++ b/lib/tasks/prmd.rake
@@ -18,6 +18,9 @@ namespace :schema do
   Prmd::RakeTasks::Doc.new do |t|
     t.files = { 'schema/schema.json' => 'schema/schema.md' }
   end
+
+  desc 'Combine, verify and generate schema docs using prmd'
+  task generate: %i[combine verify doc]
 end
 
-task default: ['schema:combine', 'schema:verify', 'schema:doc']
+task default: ['schema:generate']


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-79)

Follow up to https://github.com/ministryofjustice/laa-court-data-adaptor/pull/51, we need to have `prmd` available in all environments as opposed to only development/test, since that is included as part of the default rake task calls.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
