### PR TITLE
Update schema to use filter to search prosecution cases

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -31,6 +31,21 @@
             }
           }
         },
+        "resource_collection": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "data": {
+              "items": {
+                "$ref": "#/definitions/prosecution_case/definitions/resource"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          }
+        },
         "attributes": {
           "type": [
             "object"
@@ -225,7 +240,7 @@
           "title": "List",
           "schema": {
             "properties": {
-              "prosecution_case": {
+              "filter": {
                 "$ref": "#/definitions/prosecution_case/definitions/prosecution_case_search"
               }
             },
@@ -237,19 +252,7 @@
             ]
           },
           "targetSchema": {
-            "properties": {
-              "data": {
-                "items": {
-                  "$ref": "#/definitions/prosecution_case/definitions/resource"
-                },
-                "type": [
-                  "array"
-                ]
-              }
-            },
-            "type": [
-              "object"
-            ]
+            "$ref": "#/definitions/prosecution_case/definitions/resource_collection"
           },
           "http_header": {
             "Content-Type": "application/vnd.api+json"

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -25,12 +25,11 @@ Search prosecution cases.
 GET /api/prosecution_cases
 ```
 
-#### Required Parameters
+#### Optional Parameters
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **prosecution_case** | *string* |  |  |
-
+| **filter** | *string* |  |  |
 
 
 #### Curl Example
@@ -38,7 +37,7 @@ GET /api/prosecution_cases
 ```bash
 $ curl -n https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/prosecution_cases \
  -G \
-  -d prosecution_case[prosecution_case_reference]=05PP1000915 \
+  -d filter[prosecution_case_reference]=05PP1000915 \
   -H "Content-Type: application/vnd.api+json"
 ```
 

--- a/schema/schemata/prosecution_case.json
+++ b/schema/schemata/prosecution_case.json
@@ -22,6 +22,17 @@
         }
       }
     },
+    "resource_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "/schemata/prosecution_case#/definitions/resource"
+          },
+          "type": "array"
+        }
+      }
+    },
     "attributes": {
       "type": "object",
       "properties": {
@@ -188,7 +199,7 @@
       "title": "List",
       "schema": {
         "properties": {
-          "prosecution_case": {
+          "filter": {
             "$ref": "/schemata/prosecution_case#/definitions/prosecution_case_search"
           }
         },
@@ -198,15 +209,7 @@
         ]
       },
       "targetSchema": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "/schemata/prosecution_case#/definitions/resource"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
+        "$ref": "/schemata/prosecution_case#/definitions/resource_collection"
       },
       "http_header": {
         "Content-Type": "application/vnd.api+json"


### PR DESCRIPTION
## What
Update schema to use `filter` instead of `prosecution_case` to group query params.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
