### PR TITLE
Move 'require rails_helper' to .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--require rails_helper

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ApplicationController, type: :controller do
   controller do
     def index

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingsController, type: :controller do
   include AuthorisedRequestHelper
 

--- a/spec/controllers/prosecution_cases_controller_spec.rb
+++ b/spec/controllers/prosecution_cases_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCasesController, type: :controller do
   include AuthorisedRequestHelper
 

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe StatusController, type: :controller do
   describe 'GET #index' do
     it 'returns http success' do

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Hearing, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:body) }

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCase, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:body) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe User, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'Hearings', type: :request do
   include AuthorisedRequestHelper
 

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'ProsecutionCases', type: :request do
   include AuthorisedRequestHelper
 

--- a/spec/routing/hearings_routing_spec.rb
+++ b/spec/routing/hearings_routing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingsController, type: :routing do
   describe 'routing' do
     it 'routes to #create' do

--- a/spec/routing/prosecution_cases_routing_spec.rb
+++ b/spec/routing/prosecution_cases_routing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCasesController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Api::GetHearingResults do
   subject { described_class.call(hearing_id) }
 

--- a/spec/services/api/record_laa_reference_spec.rb
+++ b/spec/services/api/record_laa_reference_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Api::RecordLaaReference do
   subject { described_class.call(params) }
 

--- a/spec/services/api/record_representation_order_spec.rb
+++ b/spec/services/api/record_representation_order_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Api::RecordRepresentationOrder do
   subject { described_class.call(params) }
 

--- a/spec/services/api/search_prosecution_case_spec.rb
+++ b/spec/services/api/search_prosecution_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Api::SearchProsecutionCase do
   let(:params) { { howdy: 'hello' } }
   let(:response_status) { 200 }

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ApplicationService do
   subject { described_class.call('some', 'arguments') }
 

--- a/spec/services/common_platform_connection_spec.rb
+++ b/spec/services/common_platform_connection_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CommonPlatformConnection do
   let(:host) { 'https://example.com' }
 

--- a/spec/services/hearing_fetcher_spec.rb
+++ b/spec/services/hearing_fetcher_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingFetcher do
   subject { described_class.call(hearing_id: hearing_id) }
 

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingRecorder do
   let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
   let(:body) { { response: 'text' }.to_json }

--- a/spec/services/normaliser/mlra_prosecution_case_search_spec.rb
+++ b/spec/services/normaliser/mlra_prosecution_case_search_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Normaliser::MlraProsecutionCaseSearch do
   let(:incoming_params) do
     ActionController::Parameters.new(

--- a/spec/services/prosecution_case_recorder_spec.rb
+++ b/spec/services/prosecution_case_recorder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCaseRecorder do
   let(:prosecution_case_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
   let(:body) { { response: 'text' }.to_json }

--- a/spec/services/prosecution_case_searcher_spec.rb
+++ b/spec/services/prosecution_case_searcher_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCaseSearcher do
   let(:prosecution_case_reference) { 'TFL12345' }
 

--- a/spec/support/unauthorised_request.rb
+++ b/spec/support/unauthorised_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.shared_examples 'an unauthorised request' do
   it 'responds with a 401 status code' do
     get :index


### PR DESCRIPTION
This commit adds 'require rails_helper' to the .rspec file and removes
it from each individual spec.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/-CACP-165)

This PR adds `require rails_helper` to the `.rspec` file and removes it from each individual spec file.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
