### PR TITLE
Add schema for oauth access token request

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4,6 +4,109 @@
     "object"
   ],
   "definitions": {
+    "oauth": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "OAuth endpoints",
+      "description": "Endpoints for authentication via OAuth",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "auth_success_response": {
+          "description": "Successful Response",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "access_token": {
+              "example": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+              "description": "Token that can be used to make authenticated requests",
+              "type": [
+                "string"
+              ]
+            },
+            "token_type": {
+              "example": "Bearer",
+              "enum": [
+                "Bearer"
+              ],
+              "description": "Type of token",
+              "type": [
+                "string"
+              ]
+            },
+            "expires_in": {
+              "example": 7200,
+              "description": "Duration of the token validity",
+              "type": [
+                "integer"
+              ]
+            },
+            "created_at": {
+              "description": "when the token was created",
+              "format": "date-time",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Request a new access token.",
+          "href": "/oauth/token",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "description": "Params to request a new access token",
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "grant_type": {
+                "description": "Grant type for the oauth token request.",
+                "enum": [
+                  "client_credentials"
+                ],
+                "example": "client_credentials",
+                "type": [
+                  "string"
+                ]
+              },
+              "client_id": {
+                "example": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+                "description": "Client id for authentication",
+                "type": [
+                  "string"
+                ]
+              },
+              "client_secret": {
+                "example": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU",
+                "description": "Client secret for authentication",
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "required": [
+              "grant_type",
+              "client_id",
+              "client_secret"
+            ]
+          },
+          "http_header": {
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth/definitions/auth_success_response"
+          },
+          "title": "authentication"
+        }
+      ]
+    },
     "prosecution_case": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "title": "Prosecution case search results",
@@ -267,6 +370,9 @@
     }
   },
   "properties": {
+    "oauth": {
+      "$ref": "#/definitions/oauth"
+    },
     "prosecution_case": {
       "$ref": "#/definitions/prosecution_case"
     }

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -1,4 +1,57 @@
 
+## <a name="resource-oauth">OAuth endpoints</a>
+
+Stability: `prototype`
+
+Endpoints for authentication via OAuth
+
+### <a name="link-POST-oauth-/oauth/token">OAuth endpoints authentication</a>
+
+Request a new access token.
+
+```
+POST /oauth/token
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **client_id** | *string* | Client id for authentication | `"b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY"` |
+| **client_secret** | *string* | Client secret for authentication | `"ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU"` |
+| **grant_type** | *string* | Grant type for the oauth token request.<br/> **one of:**`"client_credentials"` | `"client_credentials"` |
+
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/oauth/token \
+  -d '{
+  "grant_type": "client_credentials",
+  "client_id": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+  "client_secret": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU"
+}' \
+  -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8"
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "access_token": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+  "token_type": "Bearer",
+  "expires_in": 7200,
+  "created_at": "2015-01-01T12:00:00Z"
+}
+```
+
+
 ## <a name="resource-prosecution_case">Prosecution case search results</a>
 
 Stability: `prototype`

--- a/schema/schemata/oauth.json
+++ b/schema/schemata/oauth.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "title": "OAuth endpoints",
+  "description": "Endpoints for authentication via OAuth",
+  "id": "schemata/oauth",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "auth_success_response": {
+      "description": "Successful Response",
+      "type": "object",
+      "properties": {
+        "access_token": {
+          "example": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+          "description": "Token that can be used to make authenticated requests",
+          "type": "string"
+        },
+        "token_type": {
+          "example": "Bearer",
+          "enum": [
+            "Bearer"
+          ],
+          "description": "Type of token",
+          "type": "string"
+        },
+        "expires_in": {
+          "example": 7200,
+          "description": "Duration of the token validity",
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "when the token was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Request a new access token.",
+      "href": "/oauth/token",
+      "method": "POST",
+      "rel": "create",
+      "schema": {
+        "description": "Params to request a new access token",
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "description": "Grant type for the oauth token request.",
+            "enum": [
+              "client_credentials"
+            ],
+            "example": "client_credentials",
+            "type": "string"
+          },
+          "client_id": {
+            "example": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+            "description": "Client id for authentication",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU",
+            "description": "Client secret for authentication",
+            "type": "string"
+          }
+        },
+        "required": [
+          "grant_type",
+          "client_id",
+          "client_secret"
+        ]
+      },
+      "http_header": {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
+      },
+      "targetSchema": {
+        "$ref": "/schemata/oauth#/definitions/auth_success_response"
+      },
+      "title": "authentication"
+    }
+  ]
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-167)
Based on https://github.com/doorkeeper-gem/doorkeeper/wiki/Client-Credentials-flow,
I have added schema defintions for client_credentials type oauth token generation.
Actual Implementation to follow using doorkeeper.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
