### PR TITLE
Defendant as relationship

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -6,7 +6,7 @@ module Api
       class ProsecutionCasesController < ApplicationController
         def index
           @prosecution_cases = Api::SearchProsecutionCase.call(transformed_params)
-          render json: ProsecutionCaseSerializer.new(@prosecution_cases)
+          render json: ProsecutionCaseSerializer.new(@prosecution_cases, serialization_options)
         end
 
         private
@@ -19,6 +19,12 @@ module Api
 
         def transformed_params
           filtered_params.to_hash.transform_keys(&:to_sym)
+        end
+
+        def serialization_options
+          return { include: [params[:include]] } if params[:include].present?
+
+          {}
         end
       end
     end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Defendant
+  include ActiveModel::Model
+
+  attr_accessor :body
+
+  def id
+    body['defendantId']
+  end
+
+  def first_name
+    body['name']['firstName']
+  end
+
+  def last_name
+    body['name']['lastName']
+  end
+
+  def date_of_birth
+    body['dateOfBirth']
+  end
+
+  def national_insurance_number
+    body['nationalInsuranceNumber']
+  end
+end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -3,29 +3,15 @@
 class ProsecutionCase < ApplicationRecord
   validates :body, presence: true
 
-  def defendant_first_name
-    defendant['name']['firstName']
+  def defendants
+    body['defendants'].map { |defendant| Defendant.new(body: defendant) }
   end
 
-  def defendant_last_name
-    defendant['name']['lastName']
+  def defendant_ids
+    defendants.map(&:id)
   end
 
   def prosecution_case_reference
     body['prosecutionCaseReference']
-  end
-
-  def date_of_birth
-    defendant['dateOfBirth']
-  end
-
-  def national_insurance_number
-    defendant['nationalInsuranceNumber']
-  end
-
-  private
-
-  def defendant
-    body['defendants'].first
   end
 end

--- a/app/serializers/defendant_serializer.rb
+++ b/app/serializers/defendant_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DefendantSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :defendants
+
+  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number
+end

--- a/app/serializers/prosecution_case_serializer.rb
+++ b/app/serializers/prosecution_case_serializer.rb
@@ -4,8 +4,7 @@ class ProsecutionCaseSerializer
   include FastJsonapi::ObjectSerializer
   set_type :prosecution_cases
 
-  attributes :prosecution_case_reference, :date_of_birth, :national_insurance_number
+  attributes :prosecution_case_reference
 
-  attribute :first_name, &:defendant_first_name
-  attribute :last_name, &:defendant_last_name
+  has_many :defendants, record_type: :defendants
 end

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4,6 +4,153 @@
     "object"
   ],
   "definitions": {
+    "defendant": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Defendants",
+      "description": "Defendants",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of defendant",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The defendants type",
+          "enum": [
+            "defendants"
+          ],
+          "example": "defendants",
+          "type": [
+            "string"
+          ]
+        },
+        "first_name": {
+          "readOnly": true,
+          "example": "Elaf",
+          "description": "The fore name when the defendant is a person",
+          "type": [
+            "string"
+          ]
+        },
+        "last_name": {
+          "readOnly": true,
+          "example": "Alvi",
+          "description": "The last name when the defendant is a person",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/defendant/definitions/id"
+        },
+        "date_of_birth": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "The person date of birth when the defendant is a person",
+              "example": "1954-02-23",
+              "type": [
+                "string"
+              ],
+              "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+            }
+          ]
+        },
+        "nino": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "National Insurance Number for a person",
+              "example": "SJ336043A",
+              "type": [
+                "string"
+              ],
+              "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
+            }
+          ]
+        },
+        "resource": {
+          "description": "object representing a single defendant",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/defendant/definitions/type"
+            },
+            "id": {
+              "$ref": "#/definitions/defendant/definitions/id"
+            },
+            "attributes": {
+              "$ref": "#/definitions/defendant/definitions/attributes"
+            }
+          }
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "first_name": {
+              "$ref": "#/definitions/defendant/definitions/first_name"
+            },
+            "last_name": {
+              "$ref": "#/definitions/defendant/definitions/last_name"
+            },
+            "date_of_birth": {
+              "$ref": "#/definitions/defendant/definitions/date_of_birth"
+            },
+            "national_insurance_number": {
+              "$ref": "#/definitions/defendant/definitions/nino"
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing defendant.",
+          "href": "/defendants/{(%23%2Fdefinitions%2Fdefendant%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "$ref": "#/definitions/defendant/definitions/resource"
+          }
+        }
+      ],
+      "properties": {
+        "first_name": {
+          "$ref": "#/definitions/defendant/definitions/first_name"
+        },
+        "last_name": {
+          "$ref": "#/definitions/defendant/definitions/last_name"
+        },
+        "date_of_birth": {
+          "$ref": "#/definitions/defendant/definitions/date_of_birth"
+        },
+        "national_insurance_number": {
+          "$ref": "#/definitions/defendant/definitions/nino"
+        }
+      }
+    },
     "oauth": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "OAuth endpoints",
@@ -131,6 +278,47 @@
             },
             "attributes": {
               "$ref": "#/definitions/prosecution_case/definitions/attributes"
+            },
+            "relationships": {
+              "$ref": "#/definitions/prosecution_case/definitions/relationships"
+            }
+          }
+        },
+        "relationships": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "defendants": {
+              "$ref": "#/definitions/prosecution_case/definitions/defendant_relationship"
+            }
+          }
+        },
+        "defendant_relationship": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "data": {
+              "items": {
+                "$ref": "#/definitions/prosecution_case/definitions/defendant"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          }
+        },
+        "defendant": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/defendant/definitions/id"
+            },
+            "type": {
+              "$ref": "#/definitions/defendant/definitions/type"
             }
           }
         },
@@ -146,28 +334,27 @@
               "type": [
                 "array"
               ]
+            },
+            "included": {
+              "items": {
+                "$ref": "#/definitions/defendant/definitions/resource"
+              },
+              "type": [
+                "array"
+              ]
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         "attributes": {
           "type": [
             "object"
           ],
           "properties": {
-            "first_name": {
-              "$ref": "#/definitions/prosecution_case/definitions/first_name"
-            },
-            "last_name": {
-              "$ref": "#/definitions/prosecution_case/definitions/last_name"
-            },
             "prosecution_case_reference": {
               "$ref": "#/definitions/prosecution_case/definitions/prosecution_case_reference"
-            },
-            "date_of_birth": {
-              "$ref": "#/definitions/prosecution_case/definitions/date_of_birth"
-            },
-            "national_insurance_number": {
-              "$ref": "#/definitions/prosecution_case/definitions/nino"
             }
           }
         },
@@ -197,42 +384,8 @@
             "string"
           ]
         },
-        "first_name": {
-          "readOnly": true,
-          "example": "Elaf",
-          "description": "The fore name when the defendant is a person",
-          "type": [
-            "string"
-          ]
-        },
-        "last_name": {
-          "readOnly": true,
-          "example": "Alvi",
-          "description": "The last name when the defendant is a person",
-          "type": [
-            "string"
-          ]
-        },
         "identity": {
           "$ref": "#/definitions/prosecution_case/definitions/id"
-        },
-        "nino": {
-          "readOnly": true,
-          "anyOf": [
-            {
-              "type": [
-                "null"
-              ]
-            },
-            {
-              "description": "National Insurance Number for a person",
-              "example": "SJ336043A",
-              "type": [
-                "string"
-              ],
-              "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
-            }
-          ]
         },
         "date_of_next_hearing": {
           "description": "The date of the next hearing for the defendant",
@@ -244,24 +397,6 @@
               ]
             },
             {
-              "example": "1954-02-23",
-              "type": [
-                "string"
-              ],
-              "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
-            }
-          ]
-        },
-        "date_of_birth": {
-          "readOnly": true,
-          "anyOf": [
-            {
-              "type": [
-                "null"
-              ]
-            },
-            {
-              "description": "The person date of birth when the defendant is a person",
               "example": "1954-02-23",
               "type": [
                 "string"
@@ -294,7 +429,7 @@
             {
               "properties": {
                 "national_insurance_number": {
-                  "$ref": "#/definitions/prosecution_case/definitions/nino"
+                  "$ref": "#/definitions/defendant/definitions/nino"
                 }
               }
             },
@@ -308,23 +443,23 @@
             {
               "properties": {
                 "first_name": {
-                  "$ref": "#/definitions/prosecution_case/definitions/first_name"
+                  "$ref": "#/definitions/defendant/definitions/first_name"
                 },
                 "last_name": {
-                  "$ref": "#/definitions/prosecution_case/definitions/last_name"
+                  "$ref": "#/definitions/defendant/definitions/last_name"
                 },
                 "date_of_birth": {
-                  "$ref": "#/definitions/prosecution_case/definitions/date_of_birth"
+                  "$ref": "#/definitions/defendant/definitions/date_of_birth"
                 }
               }
             },
             {
               "properties": {
                 "first_name": {
-                  "$ref": "#/definitions/prosecution_case/definitions/first_name"
+                  "$ref": "#/definitions/defendant/definitions/first_name"
                 },
                 "last_name": {
-                  "$ref": "#/definitions/prosecution_case/definitions/last_name"
+                  "$ref": "#/definitions/defendant/definitions/last_name"
                 },
                 "date_of_next_hearing": {
                   "$ref": "#/definitions/prosecution_case/definitions/date_of_next_hearing"
@@ -370,6 +505,9 @@
     }
   },
   "properties": {
+    "defendant": {
+      "$ref": "#/definitions/defendant"
+    },
     "oauth": {
       "$ref": "#/definitions/oauth"
     },

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -1,4 +1,55 @@
 
+## <a name="resource-defendant">Defendants</a>
+
+Stability: `prototype`
+
+Defendants
+
+### Attributes
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **date_of_birth** | *string* | The person date of birth when the defendant is a person | `"1954-02-23"` |
+| **first_name** | *string* | The fore name when the defendant is a person | `"Elaf"` |
+| **last_name** | *string* | The last name when the defendant is a person | `"Alvi"` |
+| **national_insurance_number** | *string* | National Insurance Number for a person | `"SJ336043A"` |
+
+### <a name="link-GET-defendant-/defendants/{(%23%2Fdefinitions%2Fdefendant%2Fdefinitions%2Fidentity)}">Defendants Info</a>
+
+Info for existing defendant.
+
+```
+GET /defendants/{defendant_id}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/defendants/$DEFENDANT_ID
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "type": "defendants",
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "attributes": {
+    "first_name": "Elaf",
+    "last_name": "Alvi",
+    "date_of_birth": null,
+    "national_insurance_number": null
+  }
+}
+```
+
+
 ## <a name="resource-oauth">OAuth endpoints</a>
 
 Stability: `prototype`
@@ -62,12 +113,9 @@ Prosecution case search results
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **data:attributes:date_of_birth** | *string* | The person date of birth when the defendant is a person | `"1954-02-23"` |
-| **data:attributes:first_name** | *string* | The fore name when the defendant is a person | `"Elaf"` |
-| **data:attributes:last_name** | *string* | The last name when the defendant is a person | `"Alvi"` |
-| **data:attributes:national_insurance_number** | *string* | National Insurance Number for a person | `"SJ336043A"` |
 | **data:attributes:prosecution_case_reference** | *string* | The prosecuting authorities reference for their prosecution case that is layed before court.  For example PTI-URN from police/cps cases | `"05PP1000915"` |
 | **data:id** | *uuid* | Unique identifier of prosecution case provided by HMCTS (prosecutionCaseId) | `"01234567-89ab-cdef-0123-456789abcdef"` |
+| **data:relationships:defendants:data** | *array* |  | `[{"id":"01234567-89ab-cdef-0123-456789abcdef","type":"defendants"}]` |
 | **data:type** | *string* | The prosecution cases type<br/> **one of:**`"prosecution_cases"` | `"prosecution_cases"` |
 
 ### <a name="link-GET-prosecution_case-/api/internal/v1/prosecution_cases">Prosecution case search results List</a>
@@ -108,9 +156,27 @@ HTTP/1.1 200 OK
       "type": "prosecution_cases",
       "id": "01234567-89ab-cdef-0123-456789abcdef",
       "attributes": {
+        "prosecution_case_reference": "05PP1000915"
+      },
+      "relationships": {
+        "defendants": {
+          "data": [
+            {
+              "id": "01234567-89ab-cdef-0123-456789abcdef",
+              "type": "defendants"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "defendants",
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "attributes": {
         "first_name": "Elaf",
         "last_name": "Alvi",
-        "prosecution_case_reference": "05PP1000915",
         "date_of_birth": null,
         "national_insurance_number": null
       }

--- a/schema/schemata/defendant.json
+++ b/schema/schemata/defendant.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defendants",
+  "description": "Defendants",
+  "id": "schemata/defendant",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defendant",
+      "readOnly": true,
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The defendants type",
+      "enum": [
+        "defendants"
+      ],
+      "example": "defendants",
+      "type": "string"
+    },
+    "first_name": {
+      "readOnly": true,
+      "example": "Elaf",
+      "description": "The fore name when the defendant is a person",
+      "type": "string"
+    },
+    "last_name": {
+      "readOnly": true,
+      "example": "Alvi",
+      "description": "The last name when the defendant is a person",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "/schemata/defendant#/definitions/id"
+    },
+    "date_of_birth": {
+      "readOnly": true,
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "The person date of birth when the defendant is a person",
+          "example": "1954-02-23",
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      ]
+    },
+    "nino": {
+      "readOnly": true,
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "National Insurance Number for a person",
+          "example": "SJ336043A",
+          "type": "string",
+          "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
+        }
+      ]
+    },
+    "resource": {
+      "description": "object representing a single defendant",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "/schemata/defendant#/definitions/type"
+        },
+        "id": {
+          "$ref": "/schemata/defendant#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "/schemata/defendant#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "first_name": {
+          "$ref": "/schemata/defendant#/definitions/first_name"
+        },
+        "last_name": {
+          "$ref": "/schemata/defendant#/definitions/last_name"
+        },
+        "date_of_birth": {
+          "$ref": "/schemata/defendant#/definitions/date_of_birth"
+        },
+        "national_insurance_number": {
+          "$ref": "/schemata/defendant#/definitions/nino"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing defendant.",
+      "href": "/defendants/{(%2Fschemata%2Fdefendant%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "/schemata/defendant#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "first_name": {
+      "$ref": "/schemata/defendant#/definitions/first_name"
+    },
+    "last_name": {
+      "$ref": "/schemata/defendant#/definitions/last_name"
+    },
+    "date_of_birth": {
+      "$ref": "/schemata/defendant#/definitions/date_of_birth"
+    },
+    "national_insurance_number": {
+      "$ref": "/schemata/defendant#/definitions/nino"
+    }
+  },
+  "id": "schemata/defendant"
+}

--- a/schema/schemata/defendant.json
+++ b/schema/schemata/defendant.json
@@ -124,6 +124,5 @@
     "national_insurance_number": {
       "$ref": "/schemata/defendant#/definitions/nino"
     }
-  },
-  "id": "schemata/defendant"
+  }
 }

--- a/schema/schemata/prosecution_case.json
+++ b/schema/schemata/prosecution_case.json
@@ -19,6 +19,39 @@
         },
         "attributes": {
           "$ref": "/schemata/prosecution_case#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "/schemata/prosecution_case#/definitions/relationships"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defendants": {
+          "$ref": "/schemata/prosecution_case#/definitions/defendant_relationship"
+        }
+      }
+    },
+    "defendant_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "/schemata/prosecution_case#/definitions/defendant"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defendant": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "/schemata/defendant#/definitions/id"
+        },
+        "type": {
+          "$ref": "/schemata/defendant#/definitions/type"
         }
       }
     },
@@ -30,26 +63,21 @@
             "$ref": "/schemata/prosecution_case#/definitions/resource"
           },
           "type": "array"
+        },
+        "included": {
+          "items": {
+            "$ref": "/schemata/defendant#/definitions/resource"
+          },
+          "type": "array"
         }
-      }
+      },
+      "required": ["data"]
     },
     "attributes": {
       "type": "object",
       "properties": {
-        "first_name": {
-          "$ref": "/schemata/prosecution_case#/definitions/first_name"
-        },
-        "last_name": {
-          "$ref": "/schemata/prosecution_case#/definitions/last_name"
-        },
         "prosecution_case_reference": {
           "$ref": "/schemata/prosecution_case#/definitions/prosecution_case_reference"
-        },
-        "date_of_birth": {
-          "$ref": "/schemata/prosecution_case#/definitions/date_of_birth"
-        },
-        "national_insurance_number": {
-          "$ref": "/schemata/prosecution_case#/definitions/nino"
         }
       }
     },
@@ -73,34 +101,8 @@
       "description": "The police arrest summons number when the defendant is a person",
       "type": "string"
     },
-    "first_name": {
-      "readOnly": true,
-      "example": "Elaf",
-      "description": "The fore name when the defendant is a person",
-      "type": "string"
-    },
-    "last_name": {
-      "readOnly": true,
-      "example": "Alvi",
-      "description": "The last name when the defendant is a person",
-      "type": "string"
-    },
     "identity": {
       "$ref": "/schemata/prosecution_case#/definitions/id"
-    },
-    "nino": {
-      "readOnly": true,
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "description": "National Insurance Number for a person",
-          "example": "SJ336043A",
-          "type": "string",
-          "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
-        }
-      ]
     },
     "date_of_next_hearing": {
       "description": "The date of the next hearing for the defendant",
@@ -110,20 +112,6 @@
           "type": "null"
         },
         {
-          "example": "1954-02-23",
-          "type": "string",
-          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
-        }
-      ]
-    },
-    "date_of_birth": {
-      "readOnly": true,
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "description": "The person date of birth when the defendant is a person",
           "example": "1954-02-23",
           "type": "string",
           "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
@@ -150,7 +138,7 @@
         {
           "properties": {
             "national_insurance_number": {
-              "$ref": "/schemata/prosecution_case#/definitions/nino"
+              "$ref": "/schemata/defendant#/definitions/nino"
             }
           }
         },
@@ -164,23 +152,23 @@
         {
           "properties": {
             "first_name": {
-              "$ref": "/schemata/prosecution_case#/definitions/first_name"
+              "$ref": "/schemata/defendant#/definitions/first_name"
             },
             "last_name": {
-              "$ref": "/schemata/prosecution_case#/definitions/last_name"
+              "$ref": "/schemata/defendant#/definitions/last_name"
             },
             "date_of_birth": {
-              "$ref": "/schemata/prosecution_case#/definitions/date_of_birth"
+              "$ref": "/schemata/defendant#/definitions/date_of_birth"
             }
           }
         },
         {
           "properties": {
             "first_name": {
-              "$ref": "/schemata/prosecution_case#/definitions/first_name"
+              "$ref": "/schemata/defendant#/definitions/first_name"
             },
             "last_name": {
-              "$ref": "/schemata/prosecution_case#/definitions/last_name"
+              "$ref": "/schemata/defendant#/definitions/last_name"
             },
             "date_of_next_hearing": {
               "$ref": "/schemata/prosecution_case#/definitions/date_of_next_hearing"

--- a/schema/schemata/prosecution_case.json
+++ b/schema/schemata/prosecution_case.json
@@ -71,7 +71,9 @@
           "type": "array"
         }
       },
-      "required": ["data"]
+      "required": [
+        "data"
+      ]
     },
     "attributes": {
       "type": "object",

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Defendant, type: :model do
+  let(:defendant_hash) do
+    {
+      'name' => {
+        'firstName' => 'Alfredine',
+        'lastName' => 'Parker'
+      },
+      'dateOfBirth' => '1971-05-12',
+      'nationalInsuranceNumber' => 'BN102966C'
+    }
+  end
+
+  subject(:defendant) { described_class.new(body: defendant_hash) }
+
+  it { expect(defendant.first_name).to eq('Alfredine') }
+  it { expect(defendant.last_name).to eq('Parker') }
+  it { expect(defendant.date_of_birth).to eq('1971-05-12') }
+  it { expect(defendant.national_insurance_number).to eq('BN102966C') }
+end

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe ProsecutionCase, type: :model do
       end
     end
 
-    it { expect(prosecution_case.defendant_first_name).to eq('Alfredine') }
-    it { expect(prosecution_case.defendant_last_name).to eq('Parker') }
     it { expect(prosecution_case.prosecution_case_reference).to eq('TFL12345') }
-    it { expect(prosecution_case.date_of_birth).to eq('1971-05-12') }
-    it { expect(prosecution_case.national_insurance_number).to eq('BN102966C') }
   end
 end

--- a/spec/requests/api/internal/v1/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/prosecution_cases_spec.rb
@@ -16,5 +16,14 @@ RSpec.describe 'Api::Internal::V1::ProsecutionCases', type: :request do
       expect(response.body).to be_valid_against_schema(schema: schema)
       expect(response).to have_http_status(200)
     end
+
+    context 'including defendants' do
+      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants') }
+      it 'matches the given schema' do
+        get api_internal_v1_prosecution_cases_path, params: query_with_defendants
+        expect(response.body).to be_valid_against_schema(schema: schema)
+        expect(response).to have_http_status(200)
+      end
+    end
   end
 end

--- a/spec/serializer/defendant_serializer_spec.rb
+++ b/spec/serializer/defendant_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DefendantSerializer do
+  let(:defendant) do
+    instance_double('Defendant',
+                    id: 'UUID',
+                    first_name: 'John',
+                    last_name: 'Doe',
+                    date_of_birth: '2012-12-12',
+                    national_insurance_number: 'XW858621B')
+  end
+
+  subject { described_class.new(defendant).serializable_hash }
+
+  context 'attributes' do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:first_name]).to eq('John') }
+    it { expect(attribute_hash[:last_name]).to eq('Doe') }
+    it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
+    it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
+  end
+end

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe ProsecutionCaseSerializer do
   let(:prosecution_case) do
     instance_double('ProsecutionCase',
                     id: 'UUID',
-                    defendant_first_name: 'John',
-                    defendant_last_name: 'Doe',
                     prosecution_case_reference: 'AAA',
-                    date_of_birth: '2012-12-12',
-                    national_insurance_number: 'XW858621B')
+                    defendant_ids: ['UUID'])
   end
 
   subject { described_class.new(prosecution_case).serializable_hash }
@@ -18,10 +15,6 @@ RSpec.describe ProsecutionCaseSerializer do
   context 'attributes' do
     let(:attribute_hash) { subject[:data][:attributes] }
 
-    it { expect(attribute_hash[:first_name]).to eq('John') }
-    it { expect(attribute_hash[:last_name]).to eq('Doe') }
     it { expect(attribute_hash[:prosecution_case_reference]).to eq('AAA') }
-    it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
-    it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
   end
 end

--- a/spec/support/matchers/be_valid_against_schema.rb
+++ b/spec/support/matchers/be_valid_against_schema.rb
@@ -15,7 +15,6 @@ RSpec::Matchers.define :be_valid_against_schema do |options = {}|
       options[:schema],
       data,
       fragment: options[:fragment],
-      strict: true,
       validate_schema: true
     )
     schema_errors = errors


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-173)
Changed the schema to render  `defendants` as a `has_many` relationship of `prosecution_case`.

This can be triggered by means of adding a query param: `include=defendants` on the query, based on the [jsonapi spec](https://jsonapi.org/format/#fetching-includes)

So:
```
curl -n URL/api/internal/v1/prosecution_cases?include=defendants \
 -G \
  -d filter[prosecution_case_reference]=05PP1000915 \
  -H "Content-Type: application/vnd.api+json"
```

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
