### PR TITLE
Remove '-sit' from urls

### DIFF
--- a/app/services/api/record_laa_reference.rb
+++ b/app/services/api/record_laa_reference.rb
@@ -22,7 +22,7 @@ module Api
               "/defendants/#{defendant_id}"\
               "/offences/#{offence_id}"
 
-      @headers = { 'LAAReference-Subscription-Key' => shared_key }
+      @headers = { 'Ocp-Apim-Subscription-Key' => shared_key }
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/app/services/api/record_laa_reference.rb
+++ b/app/services/api/record_laa_reference.rb
@@ -16,7 +16,7 @@ module Api
       @application_reference = application_reference
       @status_date = status_date
       @connection = connection
-      @url = '/record/laareference-sit/progression-command-api'\
+      @url = '/record/laareference/progression-command-api'\
               '/command/api/rest/progression/laaReference'\
               "/cases/#{prosecution_case_id}"\
               "/defendants/#{defendant_id}"\

--- a/app/services/api/record_representation_order.rb
+++ b/app/services/api/record_representation_order.rb
@@ -19,7 +19,7 @@ module Api
       @status_date = status_date
       @effective_start_date = effective_start_date
       @defence_organisation = defence_organisation
-      @url = '/receive/representation-sit/progression-command-api'\
+      @url = '/receive/representation/progression-command-api'\
               '/command/api/rest/progression/representationOrder' \
               "/cases/#{prosecution_case_id}" \
               "/defendants/#{defendant_id}" \

--- a/app/services/api/record_representation_order.rb
+++ b/app/services/api/record_representation_order.rb
@@ -26,7 +26,7 @@ module Api
               "/offences/#{offence_id}"
 
       @connection = connection
-      @headers = { 'LAARepresent-Subscription-Key' => shared_key }
+      @headers = { 'Ocp-Apim-Subscription-Key' => shared_key }
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/app/services/hearing_fetcher.rb
+++ b/app/services/hearing_fetcher.rb
@@ -4,7 +4,7 @@ class HearingFetcher < ApplicationService
   def initialize(hearing_id:, shared_key: ENV['SHARED_SECRET_KEY_HEARING'], connection: CommonPlatformConnection.call)
     @url = 'hearing/result/LAAGetHearingHttpTrigger'
     @params = { hearingId: hearing_id }
-    @headers = { 'LAHearing-Subscription-Key' => shared_key }
+    @headers = { 'Ocp-Apim-Subscription-Key' => shared_key }
     @connection = connection
   end
 

--- a/app/services/hearing_fetcher.rb
+++ b/app/services/hearing_fetcher.rb
@@ -2,7 +2,7 @@
 
 class HearingFetcher < ApplicationService
   def initialize(hearing_id:, shared_key: ENV['SHARED_SECRET_KEY_HEARING'], connection: CommonPlatformConnection.call)
-    @url = 'hearing/result-sit/LAAGetHearingHttpTrigger'
+    @url = 'hearing/result/LAAGetHearingHttpTrigger'
     @params = { hearingId: hearing_id }
     @headers = { 'LAHearing-Subscription-Key' => shared_key }
     @connection = connection

--- a/app/services/prosecution_case_searcher.rb
+++ b/app/services/prosecution_case_searcher.rb
@@ -11,7 +11,7 @@ class ProsecutionCaseSearcher < ApplicationService
                  date_of_next_hearing: nil,
                  shared_key: ENV['SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE'],
                  connection: CommonPlatformConnection.call)
-    @url = '/search/case-sit/prosecutionCases'
+    @url = '/search/case/prosecutionCases'
     @headers = { 'LAASearchCase-Subscription-Key' => shared_key }
     @connection = connection
     @prosecution_case_reference = prosecution_case_reference

--- a/app/services/prosecution_case_searcher.rb
+++ b/app/services/prosecution_case_searcher.rb
@@ -12,7 +12,7 @@ class ProsecutionCaseSearcher < ApplicationService
                  shared_key: ENV['SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE'],
                  connection: CommonPlatformConnection.call)
     @url = '/search/case/prosecutionCases'
-    @headers = { 'LAASearchCase-Subscription-Key' => shared_key }
+    @headers = { 'Ocp-Apim-Subscription-Key' => shared_key }
     @connection = connection
     @prosecution_case_reference = prosecution_case_reference
     @national_insurance_number = national_insurance_number

--- a/spec/cassettes/hearing_result_fetcher/success.yml
+++ b/spec/cassettes/hearing_result_fetcher/success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAHearing-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_HEARING>"
   response:
     status:

--- a/spec/cassettes/hearing_result_fetcher/success.yml
+++ b/spec/cassettes/hearing_result_fetcher/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/hearing/result-sit/LAAGetHearingHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    uri: "<COMMON_PLATFORM_URL>/hearing/result/LAAGetHearingHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
     body:
       encoding: US-ASCII
       string: ''
@@ -48,6 +48,6 @@ http_interactions:
         string","welshName":"Llinyn ar hap","roomId":"5a57d6d5-3fc5-4e2b-993b-0d071fbad6ab","roomName":"Grand
         Hall","welshRoomName":"Neuadd y Grand"},"hearingLanguage":"WELSH","hasSharedResults":false,"type":{"id":"297dda64-5a5d-4fa8-9ce9-d86fdc7c2330","description":"This
         is a description","code":"12D10JAS"},"isEffectiveTrial":false,"isBoxHearing":false,"hearingDays":[{"sittingDay":"2019-10-23T16:19:15.000Z","listingSequence":1,"listedDurationMinutes":1}]}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/hearing_result_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_result_fetcher/unauthorised.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAHearing-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - INCORRECT KEY
   response:
     status:

--- a/spec/cassettes/hearing_result_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_result_fetcher/unauthorised.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/hearing/result-sit/LAAGetHearingHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    uri: "<COMMON_PLATFORM_URL>/hearing/result/LAAGetHearingHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/laa_reference_recorder/update.yml
+++ b/spec/cassettes/laa_reference_recorder/update.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAAReference-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_LAA_REFERENCE>"
       Content-Type:
       - application/json

--- a/spec/cassettes/laa_reference_recorder/update.yml
+++ b/spec/cassettes/laa_reference_recorder/update.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<COMMON_PLATFORM_URL>/record/laareference-sit/progression-command-api/command/api/rest/progression/laaReference/cases/b9950946-fe3b-4eaa-9f0a-35e497e34528/defendants/23d7f10a-067a-476e-bba6-bb855674e23b/offences/147fed98-ba8a-46cb-b2b4-7c41cf4734bf"
+    uri: "<COMMON_PLATFORM_URL>/record/laareference/progression-command-api/command/api/rest/progression/laaReference/cases/b9950946-fe3b-4eaa-9f0a-35e497e34528/defendants/23d7f10a-067a-476e-bba6-bb855674e23b/offences/147fed98-ba8a-46cb-b2b4-7c41cf4734bf"
     body:
       encoding: UTF-8
       string: '{"statusCode":"ABCDEF","applicationReference":"SOME SORT OF MAAT ID","statusDate":"2019-12-12"}'
@@ -41,6 +41,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/representation_order_recorder/update.yml
+++ b/spec/cassettes/representation_order_recorder/update.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<COMMON_PLATFORM_URL>/receive/representation-sit/progression-command-api/command/api/rest/progression/representationOrder/cases/b9950946-fe3b-4eaa-9f0a-35e497e34528/defendants/23d7f10a-067a-476e-bba6-bb855674e23b/offences/147fed98-ba8a-46cb-b2b4-7c41cf4734bf"
+    uri: "<COMMON_PLATFORM_URL>/receive/representation/progression-command-api/command/api/rest/progression/representationOrder/cases/b9950946-fe3b-4eaa-9f0a-35e497e34528/defendants/23d7f10a-067a-476e-bba6-bb855674e23b/offences/147fed98-ba8a-46cb-b2b4-7c41cf4734bf"
     body:
       encoding: UTF-8
       string: '{"statusCode":"ABCDEF","applicationReference":"SOME SORT OF MAAT ID","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15","defenceOrganisation":{"organisation":{"name":"SOME
@@ -42,6 +42,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/representation_order_recorder/update.yml
+++ b/spec/cassettes/representation_order_recorder/update.yml
@@ -10,7 +10,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAARepresent-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_REPRESENTATION_ORDER>"
       Content-Type:
       - application/json

--- a/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?arrestSummonsNumber=arrest123"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?arrestSummonsNumber=arrest123"
     body:
       encoding: US-ASCII
       string: ''
@@ -54,6 +54,6 @@ http_interactions:
         string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
         SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
         NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE>"
   response:
     status:

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE>"
   response:
     status:

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?dateOfBirth=1971-05-12&name%5BfirstName%5D=Alfredine&name%5BlastName%5D=Parker"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?dateOfBirth=1971-05-12&name%5BfirstName%5D=Alfredine&name%5BlastName%5D=Parker"
     body:
       encoding: US-ASCII
       string: ''
@@ -73,6 +73,6 @@ http_interactions:
         string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
         SORT OF MAAT ID","statusId":"785b253a-7d5a-493b-a7fa-b03153cad5b9","statusCode":"ABCDEF","statusDescription":"FAKE
         NEWS","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15"}}]}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:11 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE>"
   response:
     status:

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?dateOfNextHearing=2025-05-04&name%5BfirstName%5D=Alfredine&name%5BlastName%5D=Parker"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?dateOfNextHearing=2025-05-04&name%5BfirstName%5D=Alfredine&name%5BlastName%5D=Parker"
     body:
       encoding: US-ASCII
       string: ''
@@ -54,6 +54,6 @@ http_interactions:
         string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
         SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
         NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE>"
   response:
     status:

--- a/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?nationalInsuranceNumber=BN102966C"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?nationalInsuranceNumber=BN102966C"
     body:
       encoding: US-ASCII
       string: ''
@@ -73,6 +73,6 @@ http_interactions:
         string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
         SORT OF MAAT ID","statusId":"785b253a-7d5a-493b-a7fa-b03153cad5b9","statusCode":"ABCDEF","statusDescription":"FAKE
         NEWS","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15"}}]}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - "<SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE>"
   response:
     status:

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?prosecutionCaseReference=TFL12345"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?prosecutionCaseReference=TFL12345"
     body:
       encoding: US-ASCII
       string: ''
@@ -54,6 +54,6 @@ http_interactions:
         string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
         SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
         NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/unauthorised.yml
+++ b/spec/cassettes/search_prosecution_case/unauthorised.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/search/case-sit/prosecutionCases?prosecutionCaseReference=TFL12345"
+    uri: "<COMMON_PLATFORM_URL>/search/case/prosecutionCases?prosecutionCaseReference=TFL12345"
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/search_prosecution_case/unauthorised.yml
+++ b/spec/cassettes/search_prosecution_case/unauthorised.yml
@@ -9,7 +9,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.17.3
-      LAASearchCase-Subscription-Key:
+      Ocp-Apim-Subscription-Key:
       - INCORRECT KEY
   response:
     status:

--- a/spec/services/api/record_laa_reference_spec.rb
+++ b/spec/services/api/record_laa_reference_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::RecordLaaReference do
 
   context 'connection' do
     let(:connection) { double('CommonPlatformConnection') }
-    let(:headers) { { 'LAAReference-Subscription-Key' => 'SECRET KEY' } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key' => 'SECRET KEY' } }
     let(:request_params) do
       {
         statusCode: 'ABCDEF',

--- a/spec/services/api/record_laa_reference_spec.rb
+++ b/spec/services/api/record_laa_reference_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::RecordLaaReference do
       status_date: '2019-12-12'
     }
   end
-  let(:url) { "/record/laareference-sit/progression-command-api/command/api/rest/progression/laaReference/cases/#{prosecution_case_id}/defendants/#{defendant_id}/offences/#{offence_id}" }
+  let(:url) { "/record/laareference/progression-command-api/command/api/rest/progression/laaReference/cases/#{prosecution_case_id}/defendants/#{defendant_id}/offences/#{offence_id}" }
 
   it 'returns a no content status' do
     VCR.use_cassette('laa_reference_recorder/update') do

--- a/spec/services/api/record_representation_order_spec.rb
+++ b/spec/services/api/record_representation_order_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::RecordRepresentationOrder do
   end
 
   # rubocop:disable Layout/LineLength
-  let(:url) { "/receive/representation-sit/progression-command-api/command/api/rest/progression/representationOrder/cases/#{prosecution_case_id}/defendants/#{defendant_id}/offences/#{offence_id}" }
+  let(:url) { "/receive/representation/progression-command-api/command/api/rest/progression/representationOrder/cases/#{prosecution_case_id}/defendants/#{defendant_id}/offences/#{offence_id}" }
   # rubocop:enable Layout/LineLength
 
   it 'returns a no content status' do

--- a/spec/services/api/record_representation_order_spec.rb
+++ b/spec/services/api/record_representation_order_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::RecordRepresentationOrder do
 
   context 'connection' do
     let(:connection) { double('CommonPlatformConnection') }
-    let(:headers) { { 'LAARepresent-Subscription-Key' => 'SECRET KEY' } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key' => 'SECRET KEY' } }
     let(:request_params) do
       {
         statusCode: 'ABCDEF',

--- a/spec/services/hearing_fetcher_spec.rb
+++ b/spec/services/hearing_fetcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe HearingFetcher do
     let(:connection) { double('CommonPlatformConnection') }
     let(:url) { 'hearing/result/LAAGetHearingHttpTrigger' }
     let(:params) { { hearingId: hearing_id } }
-    let(:headers) { { 'LAHearing-Subscription-Key' => 'SECRET KEY' } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key' => 'SECRET KEY' } }
 
     it 'makes a get request' do
       expect(connection).to receive(:get).with(url, params, headers)

--- a/spec/services/hearing_fetcher_spec.rb
+++ b/spec/services/hearing_fetcher_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe HearingFetcher do
     subject { described_class.call(hearing_id: hearing_id, shared_key: 'SECRET KEY', connection: connection) }
 
     let(:connection) { double('CommonPlatformConnection') }
-    let(:url) { 'hearing/result-sit/LAAGetHearingHttpTrigger' }
+    let(:url) { 'hearing/result/LAAGetHearingHttpTrigger' }
     let(:params) { { hearingId: hearing_id } }
     let(:headers) { { 'LAHearing-Subscription-Key' => 'SECRET KEY' } }
 

--- a/spec/services/prosecution_case_searcher_spec.rb
+++ b/spec/services/prosecution_case_searcher_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ProsecutionCaseSearcher do
     let(:connection) { double('CommonPlatformConnection') }
     let(:url) { '/search/case/prosecutionCases' }
     let(:params) { { prosecutionCaseReference: prosecution_case_reference } }
-    let(:headers) { { 'LAASearchCase-Subscription-Key' => 'SECRET KEY' } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key' => 'SECRET KEY' } }
 
     it 'makes a get request' do
       expect(connection).to receive(:get).with(url, params, headers)

--- a/spec/services/prosecution_case_searcher_spec.rb
+++ b/spec/services/prosecution_case_searcher_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ProsecutionCaseSearcher do
     subject { described_class.call(prosecution_case_reference: prosecution_case_reference, shared_key: 'SECRET KEY', connection: connection) }
 
     let(:connection) { double('CommonPlatformConnection') }
-    let(:url) { '/search/case-sit/prosecutionCases' }
+    let(:url) { '/search/case/prosecutionCases' }
     let(:params) { { prosecutionCaseReference: prosecution_case_reference } }
     let(:headers) { { 'LAASearchCase-Subscription-Key' => 'SECRET KEY' } }
 


### PR DESCRIPTION
## What

Several API paths include the string `-sit`. HMCTS have informed us that their APIs do not include this, so it needs to be removed from our code.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
