### PR TITLE
Add offences and other defendant data

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -24,4 +24,40 @@ class Defendant
   def national_insurance_number
     body['nationalInsuranceNumber']
   end
+
+  def gender
+    body['gender']
+  end
+
+  def address_1
+    body['address_1']
+  end
+
+  def address_2
+    body['address_2']
+  end
+
+  def address_3
+    body['address_3']
+  end
+
+  def address_4
+    body['address_4']
+  end
+
+  def address_5
+    body['address_5']
+  end
+
+  def postcode
+    body['postcode']
+  end
+
+  def offences
+    body['offences'].map { |offence| Offence.new(body: offence) }
+  end
+
+  def offence_ids
+    offences.map(&:id)
+  end
 end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class Offence
+  include ActiveModel::Model
+
+  attr_accessor :body
+
+  def id
+    body['offenceId']
+  end
+
+  def offence_code_order_index
+    body['offenceCodeorderIndex']
+  end
+
+  def order_index
+    body['orderIndex']
+  end
+
+  def offence_title
+    body['offenceTitle']
+  end
+
+  def offence_legislation
+    body['offenceLegislation']
+  end
+
+  def wording
+    body['wording']
+  end
+
+  def arrest_date
+    body['arrestDate']
+  end
+
+  def charge_date
+    body['chargeDate']
+  end
+
+  def date_of_information
+    body['dateOfInformation']
+  end
+
+  def mode_of_trial
+    body['modeOfTrial']
+  end
+
+  def start_date
+    body['startDate']
+  end
+
+  def end_date
+    body['endDate']
+  end
+
+  def proceeding_concluded
+    body['proceedingConcluded']
+  end
+
+  def application_reference
+    body['laaApplnReference']['applicationReference']
+  end
+
+  def status_id
+    body['laaApplnReference']['statusId']
+  end
+
+  def status_code
+    body['laaApplnReference']['statusCode']
+  end
+
+  def status_description
+    body['laaApplnReference']['statusDescription']
+  end
+
+  def status_date
+    body['laaApplnReference']['statusDate']
+  end
+
+  def effective_start_date
+    body['laaApplnReference']['effectiveStartDate']
+  end
+
+  def effective_end_date
+    body['laaApplnReference']['effectiveEndDate']
+  end
+end

--- a/app/serializers/defendant_serializer.rb
+++ b/app/serializers/defendant_serializer.rb
@@ -4,5 +4,7 @@ class DefendantSerializer
   include FastJsonapi::ObjectSerializer
   set_type :defendants
 
-  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number
+  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number, :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
+
+  has_many :offences, record_type: :offences
 end

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OffenceSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :offences
+
+  attributes :offence_code_order_index, :order_index, :offence_title, :offence_legislation, :wording, :arrest_date,
+             :charge_date, :date_of_information, :mode_of_trial, :start_date, :end_date, :proceeding_concluded, :application_reference,
+             :status_id, :status_code, :status_description, :status_date, :effective_start_date, :effective_end_date
+end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe Defendant, type: :model do
         'lastName' => 'Parker'
       },
       'dateOfBirth' => '1971-05-12',
-      'nationalInsuranceNumber' => 'BN102966C'
+      'nationalInsuranceNumber' => 'BN102966C',
+      'gender' => 'female',
+      'address_1' => '102 Petty France',
+      'address_2' => 'London',
+      'postcode' => 'SW1H 9AJ'
     }
   end
 
@@ -20,4 +24,8 @@ RSpec.describe Defendant, type: :model do
   it { expect(defendant.last_name).to eq('Parker') }
   it { expect(defendant.date_of_birth).to eq('1971-05-12') }
   it { expect(defendant.national_insurance_number).to eq('BN102966C') }
+  it { expect(defendant.gender).to eq('female') }
+  it { expect(defendant.address_1).to eq('102 Petty France') }
+  it { expect(defendant.address_2).to eq('London') }
+  it { expect(defendant.postcode).to eq('SW1H 9AJ') }
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Offence, type: :model do
+  let(:offence_hash) do
+    {
+      'offenceCodeorderIndex' => 'AA06001',
+      'orderIndex' => '0',
+      'offenceTitle' => 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
+      'offenceLegislation' => 'N/A',
+      'wording' => 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
+      'arrestDate' => '2020-02-01',
+      'chargeDate' => '2020-02-01',
+      'dateOfInformation' => '2020-02-01',
+      'modeOfTrial' => 'Indictable-Only Offence',
+      'startDate' => '2020-02-01',
+      'endDate' => nil,
+      'proceedingConcluded' => 'N',
+      'laaApplnReference' => {
+        'applicationReference' => '1234567',
+        'statusId' => '0',
+        'statusCode' => 'AP',
+        'statusDescription' => 'Application Pending',
+        'statusDate' => '2020-02-01',
+        'effectiveStartDate' => '2020-02-01',
+        'effectiveEndDate' => nil
+      }
+    }
+  end
+
+  subject(:offence) { described_class.new(body: offence_hash) }
+
+  it { expect(offence.offence_code_order_index).to eq('AA06001') }
+  it { expect(offence.order_index).to eq('0') }
+  it { expect(offence.offence_title).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
+  it { expect(offence.offence_legislation).to eq('N/A') }
+  it { expect(offence.wording).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
+  it { expect(offence.arrest_date).to eq('2020-02-01') }
+  it { expect(offence.charge_date).to eq('2020-02-01') }
+  it { expect(offence.date_of_information).to eq('2020-02-01') }
+  it { expect(offence.mode_of_trial).to eq('Indictable-Only Offence') }
+  it { expect(offence.start_date).to eq('2020-02-01') }
+  it { expect(offence.end_date).to be_nil }
+  it { expect(offence.proceeding_concluded).to eq('N') }
+  it { expect(offence.application_reference).to eq('1234567') }
+  it { expect(offence.status_id).to eq('0') }
+  it { expect(offence.status_code).to eq('AP') }
+  it { expect(offence.status_description).to eq('Application Pending') }
+  it { expect(offence.status_date).to eq('2020-02-01') }
+  it { expect(offence.effective_start_date).to eq('2020-02-01') }
+  it { expect(offence.effective_end_date).to be_nil }
+end

--- a/spec/serializer/defendant_serializer_spec.rb
+++ b/spec/serializer/defendant_serializer_spec.rb
@@ -9,7 +9,15 @@ RSpec.describe DefendantSerializer do
                     first_name: 'John',
                     last_name: 'Doe',
                     date_of_birth: '2012-12-12',
-                    national_insurance_number: 'XW858621B')
+                    national_insurance_number: 'XW858621B',
+                    gender: 'male',
+                    address_1: '1 Main Street',
+                    address_2: 'My Town',
+                    address_3: 'My City',
+                    address_4: 'My County',
+                    address_5: 'United Kingdom',
+                    postcode: 'AA1 1AA',
+                    offence_ids: ['55555'])
   end
 
   subject { described_class.new(defendant).serializable_hash }
@@ -21,5 +29,12 @@ RSpec.describe DefendantSerializer do
     it { expect(attribute_hash[:last_name]).to eq('Doe') }
     it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
     it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
+    it { expect(attribute_hash[:gender]).to eq('male') }
+    it { expect(attribute_hash[:address_1]).to eq('1 Main Street') }
+    it { expect(attribute_hash[:address_2]).to eq('My Town') }
+    it { expect(attribute_hash[:address_3]).to eq('My City') }
+    it { expect(attribute_hash[:address_4]).to eq('My County') }
+    it { expect(attribute_hash[:address_5]).to eq('United Kingdom') }
+    it { expect(attribute_hash[:postcode]).to eq('AA1 1AA') }
   end
 end

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OffenceSerializer do
+  let(:offence) do
+    instance_double('Offence',
+                    id: 'UUID',
+                    offence_code_order_index: 'AA06001',
+                    order_index: '0',
+                    offence_title: 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
+                    offence_legislation: 'N/A',
+                    wording: 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
+                    arrest_date: '2020-02-01',
+                    charge_date: '2020-02-01',
+                    date_of_information: '2020-02-01',
+                    mode_of_trial: 'Indictable-Only Offence',
+                    start_date: '2020-02-01',
+                    end_date: nil,
+                    proceeding_concluded: 'N',
+                    application_reference: '1234567',
+                    status_id: '0',
+                    status_code: 'AP',
+                    status_description: 'Application Pending',
+                    status_date: '2020-02-01',
+                    effective_start_date: '2020-02-01',
+                    effective_end_date: nil)
+  end
+
+  subject { described_class.new(offence).serializable_hash }
+
+  context 'attributes' do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:offence_code_order_index]).to eq('AA06001') }
+    it { expect(attribute_hash[:order_index]).to eq('0') }
+    it { expect(attribute_hash[:offence_title]).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
+    it { expect(attribute_hash[:offence_legislation]).to eq('N/A') }
+    it { expect(attribute_hash[:wording]).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
+    it { expect(attribute_hash[:arrest_date]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:charge_date]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:date_of_information]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:mode_of_trial]).to eq('Indictable-Only Offence') }
+    it { expect(attribute_hash[:start_date]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:end_date]).to be_nil }
+    it { expect(attribute_hash[:proceeding_concluded]).to eq('N') }
+    it { expect(attribute_hash[:application_reference]).to eq('1234567') }
+    it { expect(attribute_hash[:status_id]).to eq('0') }
+    it { expect(attribute_hash[:status_code]).to eq('AP') }
+    it { expect(attribute_hash[:status_description]).to eq('Application Pending') }
+    it { expect(attribute_hash[:status_date]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:effective_start_date]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:effective_end_date]).to be_nil }
+  end
+end


### PR DESCRIPTION
## What

As the first step in implementing https://dsdmoj.atlassian.net/browse/CACP-88, amend the `defendant` model to hold additional data, including `gender`, `address` fields, and a list of `offences`.

This requires creation of an `offence` model and serializer, and amendments to various other classes.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
