### PR TITLE
Search result adaptations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ spec/examples.txt
 
 # dotenv files
 .env.*.local
+.env

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class Defendant
-  include ActiveModel::Model
+class Defendant < ApplicationRecord
+  validates :body, presence: true
 
-  attr_accessor :body, :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
+  attr_accessor :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
 
   def id
     body['defendantId']
@@ -31,5 +31,32 @@ class Defendant
 
   def offence_ids
     offences.map(&:id)
+  end
+
+  # TODO: this is pseudocode only at the moment to demonstrate logic
+  def add_hearing_data
+    offence_ids.each do |offence_id|
+      offence = Offence.find(offence_id)
+      next unless offence.application_reference.present?
+
+      hearing_summaries = HearingSummary.where(defendants: [id])
+      hearing_summaries.each do |hearing_summary|
+        hearing_result = Api::GetHearingResults.new(hearing_summary.id)
+        self.gender = hearing_result.gender
+        update_defendant_address(hearing_result.address)
+        hearing_summary.hearing_date = hearing_result.hearing_date
+      end
+    end
+  end
+
+  private
+
+  def update_defendant_address(address)
+    self.address_1 = address.address1
+    self.address_2 = address.address2
+    self.address_3 = address.address3
+    self.address_4 = address.address4
+    self.address_5 = address.address5
+    self.postcode = address.postcode
   end
 end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -3,7 +3,7 @@
 class Defendant
   include ActiveModel::Model
 
-  attr_accessor :body
+  attr_accessor :body, :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
 
   def id
     body['defendantId']
@@ -23,34 +23,6 @@ class Defendant
 
   def national_insurance_number
     body['nationalInsuranceNumber']
-  end
-
-  def gender
-    body['gender']
-  end
-
-  def address_1
-    body['address_1']
-  end
-
-  def address_2
-    body['address_2']
-  end
-
-  def address_3
-    body['address_3']
-  end
-
-  def address_4
-    body['address_4']
-  end
-
-  def address_5
-    body['address_5']
-  end
-
-  def postcode
-    body['postcode']
   end
 
   def offences

--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class HearingSummary
+  include ActiveModel::Model
+
+  attr_accessor :body, :hearing_date
+
+  def id
+    body['hearingId']
+  end
+
+  def jurisdiction_type
+    body['jurisdictionType']
+  end
+
+  def court_centre_id
+    court_centre['id']
+  end
+
+  def court_centre_name
+    body['courtCenter']['name']
+  end
+
+  def court_centre_welsh_name
+    body['courtCenter']['welshName']
+  end
+
+  def court_centre_room_id
+    body['courtCenter']['roomId']
+  end
+
+  def court_centre_room_name
+    body['courtCenter']['roomName']
+  end
+
+  def court_centre_welsh_room_name
+    body['courtCenter']['welshRoomName']
+  end
+
+  def court_centre_address_1
+    court_centre_address['address 1']
+  end
+
+  def court_centre_address_2
+    court_centre_address['address 2']
+  end
+
+  def court_centre_address_3
+    court_centre_address['address 3']
+  end
+
+  def court_centre_address_4
+    court_centre_address['address 4']
+  end
+
+  def court_centre_address_5
+    court_centre_address['address 5']
+  end
+
+  def court_centre_postcode
+    court_centre_address['postcode']
+  end
+
+  def hearing_type_id
+    body['hearingType']['id']
+  end
+
+  def hearing_type_description
+    body['hearingType']['description']
+  end
+
+  def hearing_type_code
+    body['hearingType']['code']
+  end
+
+  def court_centre
+    body['courtCenter']
+  end
+
+  def court_centre_address
+    court_centre['address']
+  end
+
+  def defendants
+    body['defendants']
+  end
+end

--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class HearingSummary
-  include ActiveModel::Model
+class HearingSummary < ApplicationRecord
+  validates :body, presence: true
 
-  attr_accessor :body, :hearing_date
+  attr_accessor :hearing_date
 
   def id
     body['hearingId']

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-class Offence
-  include ActiveModel::Model
-
-  attr_accessor :body
+class Offence < ApplicationRecord
+  validates :body, presence: true
 
   def id
     body['offenceId']

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -4,11 +4,11 @@ class ProsecutionCase < ApplicationRecord
   validates :body, presence: true
 
   def defendants
-    body['defendants'].map { |defendant| Defendant.new(body: defendant) }
+    body['defendants']&.map { |defendant| Defendant.new(body: defendant) }
   end
 
   def defendant_ids
-    defendants.map(&:id)
+    defendants&.map(&:id)
   end
 
   def hearing_summaries
@@ -21,5 +21,10 @@ class ProsecutionCase < ApplicationRecord
 
   def prosecution_case_reference
     body['prosecutionCaseReference']
+  end
+
+  def supplement_with_hearing_data
+    # defendants
+    defendant_ids&.each { |defendant_id| Defendant.find_by(id: defendant_id)&.add_hearing_data }
   end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -11,6 +11,14 @@ class ProsecutionCase < ApplicationRecord
     defendants.map(&:id)
   end
 
+  def hearing_summaries
+    body['hearings'].map { |hearing_summary| HearingSummary.new(body: hearing_summary) }
+  end
+
+  def hearing_summary_ids
+    hearing_summaries.map(&:id) if body['hearings'].present?
+  end
+
   def prosecution_case_reference
     body['prosecutionCaseReference']
   end

--- a/app/serializers/hearing_summary_serializer.rb
+++ b/app/serializers/hearing_summary_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HearingSummarySerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :hearing_summaries
+
+  attributes :jurisdiction_type, :court_centre_id, :court_centre_name, :court_centre_welsh_name, :court_centre_room_id, :court_centre_room_name, :court_centre_welsh_room_name,
+             :court_centre_address_1, :court_centre_address_2, :court_centre_address_3, :court_centre_address_4, :court_centre_address_5, :court_centre_postcode, :hearing_type_id,
+             :hearing_type_description, :hearing_type_code, :hearing_date, :defendants
+end

--- a/app/serializers/prosecution_case_serializer.rb
+++ b/app/serializers/prosecution_case_serializer.rb
@@ -7,4 +7,5 @@ class ProsecutionCaseSerializer
   attributes :prosecution_case_reference
 
   has_many :defendants, record_type: :defendants
+  has_many :hearing_summaries, record_type: :hearing_summaries
 end

--- a/app/services/prosecution_case_recorder.rb
+++ b/app/services/prosecution_case_recorder.rb
@@ -9,6 +9,9 @@ class ProsecutionCaseRecorder < ApplicationService
 
   def call
     prosecution_case.update(body: body)
+
+    prosecution_case.supplement_with_hearing_data
+
     prosecution_case
   end
 

--- a/db/migrate/20200219113951_create_defendants.rb
+++ b/db/migrate/20200219113951_create_defendants.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDefendants < ActiveRecord::Migration[6.0]
+  def change
+    create_table :defendants, id: :uuid do |t|
+      t.jsonb :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200219153802_create_offences.rb
+++ b/db/migrate/20200219153802_create_offences.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateOffences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :offences, id: :uuid do |t|
+      t.jsonb :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200219153811_create_hearing_summaries.rb
+++ b/db/migrate/20200219153811_create_hearing_summaries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateHearingSummaries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hearing_summaries, id: :uuid do |t|
+      t.jsonb :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_053550) do
+ActiveRecord::Schema.define(version: 2020_02_19_153811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "defendants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "hearing_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "body", null: false
@@ -62,6 +74,12 @@ ActiveRecord::Schema.define(version: 2020_02_10_053550) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "offences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "prosecution_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
@@ -31,29 +31,26 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"ef5bb46f8db2184938d9914a2f5f649f"
+      - W/"c69b7756ad13bd5a37b72fbbb3298c23"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 33aca713-ece3-4984-9d72-cde91774373b
+      - e61feb3d-0872-401d-9c1f-5c63d51f6937
       x-runtime:
-      - '0.052434'
+      - '0.028273'
       connection:
       - close
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '[{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
+      string: '[{"prosecutionCaseId":"7a0c947e-97b4-4c5a-ae6a-26320afc914d","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"8cd0ba7e-df89-45a3-8c61-4008a2186d64","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"cacbd4d4-9102-4687-98b4-d529be3d5710","offenceCode":"Random
         string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
         string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]}]'
-    http_version:
-  recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
-recorded_with: VCR 5.0.0
+        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}],"hearings":[{"hearingId":"8f23cfd3-d4ff-4e90-b018-03385b7a96d3","jurisdictionType":"CROWN","courtCentre":{"id":"f30b31b7-41f3-4b30-a482-1b3c89f8c4b7","name":"Random
+        string","welshName":"Llinyn ar hap","roomId":"c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb","roomName":"Grand
+        Hall","welshRoomName":"Neuadd y Grand"},"type":{"id":"c4278f10-8f17-446d-8e3b-85236687a1f4","description":"This
+        is a description","code":"12D10JAS"},"defendants":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"]}]}]'
+    http_version: null
+  recorded_at: Wed, 19 Feb 2020 11:17:18 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
@@ -31,48 +31,26 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"533043f794f069786e5f6596ff29c040"
+      - W/"c69b7756ad13bd5a37b72fbbb3298c23"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 69d5cc22-ea98-474e-819a-8d51c5c0fd6a
+      - df12a28b-4515-4f71-89b0-7be0e20b9fb0
       x-runtime:
-      - '0.097029'
+      - '0.031199'
       connection:
       - close
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '[{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
+      string: '[{"prosecutionCaseId":"7a0c947e-97b4-4c5a-ae6a-26320afc914d","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"8cd0ba7e-df89-45a3-8c61-4008a2186d64","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"cacbd4d4-9102-4687-98b4-d529be3d5710","offenceCode":"Random
         string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
         string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]},{"prosecutionCaseId":"d139123d-e518-4519-9eda-c36ab2224e25","prosecutionCaseReference":"3658e889-e050-4608-8f21-8bdaa529f8d0","caseStatus":"INACTIVE","defendants":[{"defendantId":"7f3b25d0-daa8-4cf5-b8e7-5db7304bbcf2","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"676bc24c-2186-4b55-b3d3-cbcfa43305fb","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}]},{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]},{"prosecutionCaseId":"b9950946-fe3b-4eaa-9f0a-35e497e34528","prosecutionCaseReference":"3658e889-e050-4608-8f21-8bdaa529f8d0","caseStatus":"INACTIVE","defendants":[{"defendantId":"23d7f10a-067a-476e-bba6-bb855674e23b","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"147fed98-ba8a-46cb-b2b4-7c41cf4734bf","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"785b253a-7d5a-493b-a7fa-b03153cad5b9","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15"}}]}]}]'
-    http_version:
-  recorded_at: Wed, 05 Feb 2020 13:40:11 GMT
-recorded_with: VCR 5.0.0
+        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}],"hearings":[{"hearingId":"8f23cfd3-d4ff-4e90-b018-03385b7a96d3","jurisdictionType":"CROWN","courtCentre":{"id":"f30b31b7-41f3-4b30-a482-1b3c89f8c4b7","name":"Random
+        string","welshName":"Llinyn ar hap","roomId":"c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb","roomName":"Grand
+        Hall","welshRoomName":"Neuadd y Grand"},"type":{"id":"c4278f10-8f17-446d-8e3b-85236687a1f4","description":"This
+        is a description","code":"12D10JAS"},"defendants":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"]}]}]'
+    http_version: null
+  recorded_at: Wed, 19 Feb 2020 11:17:18 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
@@ -31,48 +31,26 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"533043f794f069786e5f6596ff29c040"
+      - W/"c69b7756ad13bd5a37b72fbbb3298c23"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 44485af4-99a3-4147-b714-dc257503cc51
+      - dfaa1bb5-2d28-4cfb-a1ef-5e936f6e4563
       x-runtime:
-      - '0.100542'
+      - '0.031499'
       connection:
       - close
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '[{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
+      string: '[{"prosecutionCaseId":"7a0c947e-97b4-4c5a-ae6a-26320afc914d","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"8cd0ba7e-df89-45a3-8c61-4008a2186d64","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"cacbd4d4-9102-4687-98b4-d529be3d5710","offenceCode":"Random
         string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
         string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]},{"prosecutionCaseId":"d139123d-e518-4519-9eda-c36ab2224e25","prosecutionCaseReference":"3658e889-e050-4608-8f21-8bdaa529f8d0","caseStatus":"INACTIVE","defendants":[{"defendantId":"7f3b25d0-daa8-4cf5-b8e7-5db7304bbcf2","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"676bc24c-2186-4b55-b3d3-cbcfa43305fb","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}]},{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]},{"prosecutionCaseId":"b9950946-fe3b-4eaa-9f0a-35e497e34528","prosecutionCaseReference":"3658e889-e050-4608-8f21-8bdaa529f8d0","caseStatus":"INACTIVE","defendants":[{"defendantId":"23d7f10a-067a-476e-bba6-bb855674e23b","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"147fed98-ba8a-46cb-b2b4-7c41cf4734bf","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"785b253a-7d5a-493b-a7fa-b03153cad5b9","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15"}}]}]}]'
-    http_version:
-  recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
-recorded_with: VCR 5.0.0
+        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}],"hearings":[{"hearingId":"8f23cfd3-d4ff-4e90-b018-03385b7a96d3","jurisdictionType":"CROWN","courtCentre":{"id":"f30b31b7-41f3-4b30-a482-1b3c89f8c4b7","name":"Random
+        string","welshName":"Llinyn ar hap","roomId":"c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb","roomName":"Grand
+        Hall","welshRoomName":"Neuadd y Grand"},"type":{"id":"c4278f10-8f17-446d-8e3b-85236687a1f4","description":"This
+        is a description","code":"12D10JAS"},"defendants":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"]}]}]'
+    http_version: null
+  recorded_at: Wed, 19 Feb 2020 11:17:18 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -31,29 +31,26 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"ef5bb46f8db2184938d9914a2f5f649f"
+      - W/"c69b7756ad13bd5a37b72fbbb3298c23"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 18ac4c89-c5c6-4573-9a83-7dee7d12152e
+      - fb4a12e8-5b34-403e-8a12-0b0ce1d6f6f8
       x-runtime:
-      - '0.050269'
+      - '0.028971'
       connection:
       - close
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '[{"prosecutionCaseId":"9ed80b34-e228-431f-a12b-062ba6c027b2","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"426ee6b6-a7dd-488b-a42a-29ef125ed431","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"adbebec8-3023-48f5-a6ea-d67a0121f991","offenceCode":"Random
+      string: '[{"prosecutionCaseId":"7a0c947e-97b4-4c5a-ae6a-26320afc914d","prosecutionCaseReference":"TFL12345","caseStatus":"INACTIVE","defendants":[{"defendantId":"8cd0ba7e-df89-45a3-8c61-4008a2186d64","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"arrest123","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"cacbd4d4-9102-4687-98b4-d529be3d5710","offenceCode":"Random
         string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
         string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]},{"defendantId":"679c116b-6cd5-48fa-99a9-85310eb37537","nationalInsuranceNumber":"BN102966C","arrestSummonsNumber":"Random
-        string","name":{"firstName":"Alfredine","middleName":"Treutel","lastName":"Parker"},"dateOfBirth":"1971-05-12","dateOfNextHearing":"2012-12-12","proceedingsConcluded":false,"offences":[{"offenceId":"58d7a2b8-a52b-4342-9872-2a4d02a0ed09","offenceCode":"Random
-        string","orderIndex":1,"offenceTitle":"Random string","offenceLegislation":"Random
-        string","wording":"Random string","arrestDate":"2019-10-17","chargeDate":"2019-10-17","dateOfInformation":"2019-10-17","modeOfTrial":"Random
-        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false,"laaApplnReference":{"applicationReference":"SOME
-        SORT OF MAAT ID","statusId":"bc9bad50-c263-47d5-8f3e-8251aba75f09","statusCode":"ABCDEF","statusDescription":"FAKE
-        NEWS","statusDate":"2020-01-24","effectiveStartDate":"2020-01-25"}}]}]}]'
-    http_version:
-  recorded_at: Wed, 05 Feb 2020 13:40:10 GMT
-recorded_with: VCR 5.0.0
+        string","startDate":"2019-10-17","endDate":"2019-10-17","proceedingsConcluded":false}]}],"hearings":[{"hearingId":"8f23cfd3-d4ff-4e90-b018-03385b7a96d3","jurisdictionType":"CROWN","courtCentre":{"id":"f30b31b7-41f3-4b30-a482-1b3c89f8c4b7","name":"Random
+        string","welshName":"Llinyn ar hap","roomId":"c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb","roomName":"Grand
+        Hall","welshRoomName":"Neuadd y Grand"},"type":{"id":"c4278f10-8f17-446d-8e3b-85236687a1f4","description":"This
+        is a description","code":"12D10JAS"},"defendants":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"]}]}]'
+    http_version: null
+  recorded_at: Wed, 19 Feb 2020 11:17:18 GMT
+recorded_with: VCR 5.1.0

--- a/spec/fixtures/files/prosecution_case_with_hearing.json
+++ b/spec/fixtures/files/prosecution_case_with_hearing.json
@@ -1,0 +1,53 @@
+{
+  "prosecutionCaseId": "7a0c947e-97b4-4c5a-ae6a-26320afc914d",
+  "prosecutionCaseReference": "TFL12345",
+  "caseStatus": "INACTIVE",
+  "defendants": [{
+    "defendantId": "8cd0ba7e-df89-45a3-8c61-4008a2186d64",
+    "nationalInsuranceNumber": "BN102966C",
+    "arrestSummonsNumber": "arrest123",
+    "name": {
+      "firstName": "Alfredine",
+      "middleName": "Treutel",
+      "lastName": "Parker"
+    },
+    "dateOfBirth": "1971-05-12",
+    "dateOfNextHearing": "2012-12-12",
+    "proceedingsConcluded": false,
+    "offences": [{
+      "offenceId": "cacbd4d4-9102-4687-98b4-d529be3d5710",
+      "offenceCode": "Random string",
+      "orderIndex": 1,
+      "offenceTitle": "Random string",
+      "offenceLegislation": "Random string",
+      "wording": "Random string",
+      "arrestDate": "2019-10-17",
+      "chargeDate": "2019-10-17",
+      "dateOfInformation": "2019-10-17",
+      "modeOfTrial": "Random string",
+      "startDate": "2019-10-17",
+      "endDate": "2019-10-17",
+      "proceedingsConcluded": false
+    }]
+  }],
+  "hearings": [{
+    "hearingId": "8f23cfd3-d4ff-4e90-b018-03385b7a96d3",
+    "jurisdictionType": "CROWN",
+    "courtCentre": {
+      "id": "f30b31b7-41f3-4b30-a482-1b3c89f8c4b7",
+      "name": "Random string",
+      "welshName": "Llinyn ar hap",
+      "roomId": "c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb",
+      "roomName": "Grand Hall",
+      "welshRoomName": "Neuadd y Grand"
+    },
+    "type": {
+      "id": "c4278f10-8f17-446d-8e3b-85236687a1f4",
+      "description": "This is a description",
+      "code": "12D10JAS"
+    },
+    "defendants": [
+      "ecca893f-0928-4fc6-ae50-6a8794b78c5c"
+    ]
+  }]
+}

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe Defendant, type: :model do
         'lastName' => 'Parker'
       },
       'dateOfBirth' => '1971-05-12',
-      'nationalInsuranceNumber' => 'BN102966C',
-      'gender' => 'female',
-      'address_1' => '102 Petty France',
-      'address_2' => 'London',
-      'postcode' => 'SW1H 9AJ'
+      'nationalInsuranceNumber' => 'BN102966C'
     }
   end
 
   subject(:defendant) { described_class.new(body: defendant_hash) }
+
+  before do
+    defendant.gender = 'female'
+    defendant.address_1 = '102 Petty France'
+    defendant.address_2 = 'London'
+    defendant.postcode = 'SW1H 9AJ'
+  end
 
   it { expect(defendant.first_name).to eq('Alfredine') }
   it { expect(defendant.last_name).to eq('Parker') }

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe HearingSummary, type: :model do
+  let(:hearing_summary_hash) do
+    {
+      'jurisdictionType' => 'Magistrate',
+      'courtCenter' => {
+        'id' => '1',
+        'name' => 'Westminster',
+        'welshName' => 'Westminster',
+        'roomId' => '1',
+        'roomName' => 'Court 1',
+        'welshRoomName' => 'Court 1',
+        'address' => {
+          'address 1' => 'Westminster Magistrates Court',
+          'address 2' => '181 Marylebone Road',
+          'address 3' => 'Westminster',
+          'address 4' => 'London',
+          'address 5' => 'United Kingdom',
+          'postcode' => 'NW1 5BR'
+        }
+      },
+      'hearingType' => {
+        'id' => '1',
+        'description' => 'Committal for Sentencing',
+        'code' => 'AA1'
+      },
+      'defendants' => ['UUID']
+    }
+  end
+
+  subject(:hearing_summary) { described_class.new(body: hearing_summary_hash) }
+
+  before { hearing_summary.hearing_date = '2020-02-01' }
+
+  it { expect(hearing_summary.jurisdiction_type).to eq('Magistrate') }
+  it { expect(hearing_summary.court_centre_id).to eq('1') }
+  it { expect(hearing_summary.court_centre_name).to eq('Westminster') }
+  it { expect(hearing_summary.court_centre_welsh_name).to eq('Westminster') }
+  it { expect(hearing_summary.court_centre_room_id).to eq('1') }
+  it { expect(hearing_summary.court_centre_room_name).to eq('Court 1') }
+  it { expect(hearing_summary.court_centre_welsh_room_name).to eq('Court 1') }
+  it { expect(hearing_summary.court_centre_address_1).to eq('Westminster Magistrates Court') }
+  it { expect(hearing_summary.court_centre_address_2).to eq('181 Marylebone Road') }
+  it { expect(hearing_summary.court_centre_address_3).to eq('Westminster') }
+  it { expect(hearing_summary.court_centre_address_4).to eq('London') }
+  it { expect(hearing_summary.court_centre_address_5).to eq('United Kingdom') }
+  it { expect(hearing_summary.court_centre_postcode).to eq('NW1 5BR') }
+  it { expect(hearing_summary.hearing_type_id).to eq('1') }
+  it { expect(hearing_summary.hearing_type_description).to eq('Committal for Sentencing') }
+  it { expect(hearing_summary.hearing_type_code).to eq('AA1') }
+  it { expect(hearing_summary.defendants).to eq(['UUID']) }
+  it { expect(hearing_summary.hearing_date).to eq('2020-02-01') }
+end

--- a/spec/serializer/hearing_summary_serializer_spec.rb
+++ b/spec/serializer/hearing_summary_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingSummarySerializer do
+  let(:hearing_summary) do
+    instance_double('HearingSummary',
+                    id: 'UUID',
+                    jurisdiction_type: 'Magistrate',
+                    court_centre_id: '1',
+                    court_centre_name: 'Westminster',
+                    court_centre_welsh_name: 'Westminster',
+                    court_centre_room_id: '1',
+                    court_centre_room_name: 'Court 1',
+                    court_centre_welsh_room_name: 'Court 1',
+                    court_centre_address_1: 'Westminster Magistrates Court',
+                    court_centre_address_2: '181 Marylebone Road',
+                    court_centre_address_3: 'Westminster',
+                    court_centre_address_4: 'London',
+                    court_centre_address_5: 'United Kingdom',
+                    court_centre_postcode: 'NW1 5BR',
+                    hearing_type_id: '1',
+                    hearing_type_description: 'Committal for Sentencing',
+                    hearing_type_code: 'AA1',
+                    defendants: ['UUID'],
+                    hearing_date: '2020-02-01')
+  end
+
+  subject { described_class.new(hearing_summary).serializable_hash }
+
+  context 'attributes' do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:jurisdiction_type]).to eq('Magistrate') }
+    it { expect(attribute_hash[:court_centre_id]).to eq('1') }
+    it { expect(attribute_hash[:court_centre_name]).to eq('Westminster') }
+    it { expect(attribute_hash[:court_centre_welsh_name]).to eq('Westminster') }
+    it { expect(attribute_hash[:court_centre_room_id]).to eq('1') }
+    it { expect(attribute_hash[:court_centre_room_name]).to eq('Court 1') }
+    it { expect(attribute_hash[:court_centre_welsh_room_name]).to eq('Court 1') }
+    it { expect(attribute_hash[:court_centre_address_1]).to eq('Westminster Magistrates Court') }
+    it { expect(attribute_hash[:court_centre_address_2]).to eq('181 Marylebone Road') }
+    it { expect(attribute_hash[:court_centre_address_3]).to eq('Westminster') }
+    it { expect(attribute_hash[:court_centre_address_4]).to eq('London') }
+    it { expect(attribute_hash[:court_centre_address_5]).to eq('United Kingdom') }
+    it { expect(attribute_hash[:court_centre_postcode]).to eq('NW1 5BR') }
+    it { expect(attribute_hash[:hearing_type_id]).to eq('1') }
+    it { expect(attribute_hash[:hearing_type_description]).to eq('Committal for Sentencing') }
+    it { expect(attribute_hash[:hearing_type_code]).to eq('AA1') }
+    it { expect(attribute_hash[:defendants]).to eq(['UUID']) }
+    it { expect(attribute_hash[:hearing_date]).to eq('2020-02-01') }
+  end
+end

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe ProsecutionCaseSerializer do
     instance_double('ProsecutionCase',
                     id: 'UUID',
                     prosecution_case_reference: 'AAA',
-                    defendant_ids: ['UUID'])
+                    defendant_ids: ['UUID'],
+                    hearing_summary_ids: ['UUID'])
   end
 
   subject { described_class.new(prosecution_case).serializable_hash }

--- a/spec/services/prosecution_case_recorder_spec.rb
+++ b/spec/services/prosecution_case_recorder_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ProsecutionCaseRecorder do
   let(:prosecution_case_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
-  let(:body) { { response: 'text' }.to_json }
+  let(:body) { JSON.parse(file_fixture('prosecution_case_with_hearing.json').read) }
 
   subject(:record) { described_class.call(prosecution_case_id, body) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-88)

Draft pull request to cover the 'adaptions' part of CACP-88:

```On response from CP - If LAA reference exists on Offence then
1. Iterate through hearing IDs and call GET HEARING to fetch detailed hearing data.
2. Supplement defendant data on response with
- gender
- address1
- address2
- address3
- address4
- address5
- postcode
3. Supplement each hearing summary on response with 
- hearing date
4. Return response to CPUI 
```

This adds a `supplement_with_hearing_data` method to the `ProsecutionCase` model which is called on each case by the `ProsecutionCaseRecorder`.

`supplement_with_hearing_data` iterates over the defendants on the case and calls the `add_hearing_data` method on each.

`add_hearing_data` does most of the work. It iterates over each offence and if an `application_reference` exists, gets all the hearing summaries for that defendant and calls Common Platform to get the full hearing data for each. It then extracts the gender and address data from updates the defendant/hearing_summary records.

This is all mostly pseudocode at the moment. It won't run and has no tests. I'm only opening this to get an opinion on it as a solution.