### PR TITLE
Add arrest summons number to defendant json

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -3,7 +3,7 @@
 class Defendant
   include ActiveModel::Model
 
-  attr_accessor :body, :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
+  attr_accessor :body
 
   def id
     body['defendantId']
@@ -23,6 +23,10 @@ class Defendant
 
   def national_insurance_number
     body['nationalInsuranceNumber']
+  end
+
+  def arrest_summons_number
+    body['arrestSummonsNumber']
   end
 
   def offences

--- a/app/serializers/defendant_serializer.rb
+++ b/app/serializers/defendant_serializer.rb
@@ -4,7 +4,7 @@ class DefendantSerializer
   include FastJsonapi::ObjectSerializer
   set_type :defendants
 
-  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number, :gender, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode
+  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number
 
   has_many :offences, record_type: :offences
 end

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -120,6 +120,9 @@
             },
             "national_insurance_number": {
               "$ref": "#/definitions/defendant/definitions/nino"
+            },
+            "arrest_summons_number": {
+              "$ref": "#/definitions/prosecution_case/definitions/arrest_summons_number"
             }
           }
         }
@@ -148,6 +151,9 @@
         },
         "national_insurance_number": {
           "$ref": "#/definitions/defendant/definitions/nino"
+        },
+        "arrest_summons_number": {
+          "$ref": "#/definitions/prosecution_case/definitions/arrest_summons_number"
         }
       }
     },

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -9,6 +9,7 @@ Defendants
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
+| **[arrest_summons_number](#resource-prosecution_case)** | *string* | The police arrest summons number when the defendant is a person | `"MG25A11223344"` |
 | **date_of_birth** | *string* | The person date of birth when the defendant is a person | `"1954-02-23"` |
 | **first_name** | *string* | The fore name when the defendant is a person | `"Elaf"` |
 | **last_name** | *string* | The last name when the defendant is a person | `"Alvi"` |
@@ -44,7 +45,8 @@ HTTP/1.1 200 OK
     "first_name": "Elaf",
     "last_name": "Alvi",
     "date_of_birth": null,
-    "national_insurance_number": null
+    "national_insurance_number": null,
+    "arrest_summons_number": "MG25A11223344"
   }
 }
 ```
@@ -179,7 +181,8 @@ HTTP/1.1 200 OK
         "first_name": "Elaf",
         "last_name": "Alvi",
         "date_of_birth": null,
-        "national_insurance_number": null
+        "national_insurance_number": null,
+        "arrest_summons_number": "MG25A11223344"
       }
     }
   ]

--- a/schema/schemata/defendant.json
+++ b/schema/schemata/defendant.json
@@ -95,6 +95,9 @@
         },
         "national_insurance_number": {
           "$ref": "/schemata/defendant#/definitions/nino"
+        },
+        "arrest_summons_number": {
+          "$ref": "/schemata/prosecution_case#/definitions/arrest_summons_number"
         }
       }
     }
@@ -123,6 +126,9 @@
     },
     "national_insurance_number": {
       "$ref": "/schemata/defendant#/definitions/nino"
+    },
+    "arrest_summons_number": {
+      "$ref": "/schemata/prosecution_case#/definitions/arrest_summons_number"
     }
   }
 }

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -10,25 +10,16 @@ RSpec.describe Defendant, type: :model do
         'lastName' => 'Parker'
       },
       'dateOfBirth' => '1971-05-12',
-      'nationalInsuranceNumber' => 'BN102966C'
+      'nationalInsuranceNumber' => 'BN102966C',
+      'arrestSummonsNumber' => 'ARREST123'
     }
   end
 
   subject(:defendant) { described_class.new(body: defendant_hash) }
 
-  before do
-    defendant.gender = 'female'
-    defendant.address_1 = '102 Petty France'
-    defendant.address_2 = 'London'
-    defendant.postcode = 'SW1H 9AJ'
-  end
-
   it { expect(defendant.first_name).to eq('Alfredine') }
   it { expect(defendant.last_name).to eq('Parker') }
   it { expect(defendant.date_of_birth).to eq('1971-05-12') }
   it { expect(defendant.national_insurance_number).to eq('BN102966C') }
-  it { expect(defendant.gender).to eq('female') }
-  it { expect(defendant.address_1).to eq('102 Petty France') }
-  it { expect(defendant.address_2).to eq('London') }
-  it { expect(defendant.postcode).to eq('SW1H 9AJ') }
+  it { expect(defendant.arrest_summons_number).to eq('ARREST123') }
 end

--- a/spec/serializer/defendant_serializer_spec.rb
+++ b/spec/serializer/defendant_serializer_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe DefendantSerializer do
                     last_name: 'Doe',
                     date_of_birth: '2012-12-12',
                     national_insurance_number: 'XW858621B',
-                    gender: 'male',
-                    address_1: '1 Main Street',
-                    address_2: 'My Town',
-                    address_3: 'My City',
-                    address_4: 'My County',
-                    address_5: 'United Kingdom',
-                    postcode: 'AA1 1AA',
                     offence_ids: ['55555'])
   end
 
@@ -29,12 +22,5 @@ RSpec.describe DefendantSerializer do
     it { expect(attribute_hash[:last_name]).to eq('Doe') }
     it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
     it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
-    it { expect(attribute_hash[:gender]).to eq('male') }
-    it { expect(attribute_hash[:address_1]).to eq('1 Main Street') }
-    it { expect(attribute_hash[:address_2]).to eq('My Town') }
-    it { expect(attribute_hash[:address_3]).to eq('My City') }
-    it { expect(attribute_hash[:address_4]).to eq('My County') }
-    it { expect(attribute_hash[:address_5]).to eq('United Kingdom') }
-    it { expect(attribute_hash[:postcode]).to eq('AA1 1AA') }
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-88)
According to the latest design changes, the Gender/address fields are removed due to GDPR concerns.
We also have a newly added field of `arrest_summons_number`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
