### PR TITLE
Expose offence info to serializer

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -20,7 +20,7 @@ module Api
         end
 
         def serialization_options
-          return { include: [params[:include]] } if params[:include].present?
+          return { include: params[:include].split(',') } if params[:include].present?
 
           {}
         end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -9,79 +9,19 @@ class Offence
     body['offenceId']
   end
 
-  def offence_code_order_index
-    body['offenceCodeorderIndex']
+  def code
+    body['offenceCode']
   end
 
   def order_index
     body['orderIndex']
   end
 
-  def offence_title
+  def title
     body['offenceTitle']
-  end
-
-  def offence_legislation
-    body['offenceLegislation']
-  end
-
-  def wording
-    body['wording']
-  end
-
-  def arrest_date
-    body['arrestDate']
-  end
-
-  def charge_date
-    body['chargeDate']
-  end
-
-  def date_of_information
-    body['dateOfInformation']
   end
 
   def mode_of_trial
     body['modeOfTrial']
-  end
-
-  def start_date
-    body['startDate']
-  end
-
-  def end_date
-    body['endDate']
-  end
-
-  def proceeding_concluded
-    body['proceedingConcluded']
-  end
-
-  def application_reference
-    body['laaApplnReference']['applicationReference']
-  end
-
-  def status_id
-    body['laaApplnReference']['statusId']
-  end
-
-  def status_code
-    body['laaApplnReference']['statusCode']
-  end
-
-  def status_description
-    body['laaApplnReference']['statusDescription']
-  end
-
-  def status_date
-    body['laaApplnReference']['statusDate']
-  end
-
-  def effective_start_date
-    body['laaApplnReference']['effectiveStartDate']
-  end
-
-  def effective_end_date
-    body['laaApplnReference']['effectiveEndDate']
   end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -11,14 +11,6 @@ class ProsecutionCase < ApplicationRecord
     defendants.map(&:id)
   end
 
-  def hearing_summaries
-    body['hearings'].map { |hearing_summary| HearingSummary.new(body: hearing_summary) }
-  end
-
-  def hearing_summary_ids
-    hearing_summaries.map(&:id) if body['hearings'].present?
-  end
-
   def prosecution_case_reference
     body['prosecutionCaseReference']
   end

--- a/app/serializers/defendant_serializer.rb
+++ b/app/serializers/defendant_serializer.rb
@@ -4,7 +4,7 @@ class DefendantSerializer
   include FastJsonapi::ObjectSerializer
   set_type :defendants
 
-  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number
+  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number, :arrest_summons_number
 
   has_many :offences, record_type: :offences
 end

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -4,7 +4,5 @@ class OffenceSerializer
   include FastJsonapi::ObjectSerializer
   set_type :offences
 
-  attributes :offence_code_order_index, :order_index, :offence_title, :offence_legislation, :wording, :arrest_date,
-             :charge_date, :date_of_information, :mode_of_trial, :start_date, :end_date, :proceeding_concluded, :application_reference,
-             :status_id, :status_code, :status_description, :status_date, :effective_start_date, :effective_end_date
+  attributes :code, :order_index, :title, :mode_of_trial
 end

--- a/app/serializers/prosecution_case_serializer.rb
+++ b/app/serializers/prosecution_case_serializer.rb
@@ -7,5 +7,4 @@ class ProsecutionCaseSerializer
   attributes :prosecution_case_reference
 
   has_many :defendants, record_type: :defendants
-  has_many :hearing_summaries, record_type: :hearing_summaries
 end

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -127,6 +127,44 @@
           }
         }
       },
+      "relationships": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "offences": {
+            "$ref": "#/definitions/defendant/definitions/offence_relationship"
+          }
+        }
+      },
+      "offence_relationship": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/definitions/defendant/definitions/offence"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      },
+      "offence": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/definitions/offence/definitions/id"
+          },
+          "type": {
+            "$ref": "#/definitions/offence/definitions/type"
+          }
+        }
+      },
       "links": [
         {
           "description": "Info for existing defendant.",
@@ -298,11 +336,12 @@
         },
         "order_index": {
           "readOnly": true,
-          "example": "Alvi",
-          "description": "The last name when the offence is a person",
+          "example": 0,
+          "description": "The offence sequence provided by the police",
           "type": [
-            "string"
-          ]
+            "integer"
+          ],
+          "minimum": 0
         },
         "identity": {
           "$ref": "#/definitions/offence/definitions/id"
@@ -479,7 +518,14 @@
             },
             "included": {
               "items": {
-                "$ref": "#/definitions/defendant/definitions/resource"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/defendant/definitions/resource"
+                  },
+                  {
+                    "$ref": "#/definitions/offence/definitions/resource"
+                  }
+                ]
               },
               "type": [
                 "array"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -260,6 +260,142 @@
         }
       ]
     },
+    "offence": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Offences",
+      "description": "Offences",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of offence",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The offences type",
+          "enum": [
+            "offences"
+          ],
+          "example": "offences",
+          "type": [
+            "string"
+          ]
+        },
+        "code": {
+          "readOnly": true,
+          "example": "AA06001",
+          "description": "The offence code",
+          "type": [
+            "string"
+          ]
+        },
+        "order_index": {
+          "readOnly": true,
+          "example": "Alvi",
+          "description": "The last name when the offence is a person",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/offence/definitions/id"
+        },
+        "title": {
+          "readOnly": true,
+          "example": "Fail to wear protective clothing",
+          "description": "The offence title",
+          "type": [
+            "string"
+          ]
+        },
+        "mode_of_trial": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "Indicates if the offence is either way, indictable only or summary only",
+              "example": "Indictable-Only Offence",
+              "type": [
+                "string"
+              ]
+            }
+          ]
+        },
+        "resource": {
+          "description": "object representing a single offence",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/offence/definitions/type"
+            },
+            "id": {
+              "$ref": "#/definitions/offence/definitions/id"
+            },
+            "attributes": {
+              "$ref": "#/definitions/offence/definitions/attributes"
+            }
+          }
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "code": {
+              "$ref": "#/definitions/offence/definitions/code"
+            },
+            "order_index": {
+              "$ref": "#/definitions/offence/definitions/order_index"
+            },
+            "mode_of_trial": {
+              "$ref": "#/definitions/offence/definitions/mode_of_trial"
+            },
+            "title": {
+              "$ref": "#/definitions/offence/definitions/title"
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing offence.",
+          "href": "/offences/{(%23%2Fdefinitions%2Foffence%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "$ref": "#/definitions/offence/definitions/resource"
+          }
+        }
+      ],
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/offence/definitions/code"
+        },
+        "order_index": {
+          "$ref": "#/definitions/offence/definitions/order_index"
+        },
+        "mode_of_trial": {
+          "$ref": "#/definitions/offence/definitions/mode_of_trial"
+        },
+        "title": {
+          "$ref": "#/definitions/offence/definitions/title"
+        }
+      }
+    },
     "prosecution_case": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "title": "Prosecution case search results",
@@ -517,6 +653,9 @@
     },
     "oauth": {
       "$ref": "#/definitions/oauth"
+    },
+    "offence": {
+      "$ref": "#/definitions/offence"
     },
     "prosecution_case": {
       "$ref": "#/definitions/prosecution_case"

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -105,6 +105,57 @@ HTTP/1.1 201 Created
 ```
 
 
+## <a name="resource-offence">Offences</a>
+
+Stability: `prototype`
+
+Offences
+
+### Attributes
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **code** | *string* | The offence code | `"AA06001"` |
+| **mode_of_trial** | *string* | Indicates if the offence is either way, indictable only or summary only | `"Indictable-Only Offence"` |
+| **order_index** | *string* | The last name when the offence is a person | `"Alvi"` |
+| **title** | *string* | The offence title | `"Fail to wear protective clothing"` |
+
+### <a name="link-GET-offence-/offences/{(%23%2Fdefinitions%2Foffence%2Fdefinitions%2Fidentity)}">Offences Info</a>
+
+Info for existing offence.
+
+```
+GET /offences/{offence_id}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/offences/$OFFENCE_ID
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "type": "offences",
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "attributes": {
+    "code": "AA06001",
+    "order_index": "Alvi",
+    "mode_of_trial": null,
+    "title": "Fail to wear protective clothing"
+  }
+}
+```
+
+
 ## <a name="resource-prosecution_case">Prosecution case search results</a>
 
 Stability: `prototype`

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -117,7 +117,7 @@ Offences
 | ------- | ------- | ------- | ------- |
 | **code** | *string* | The offence code | `"AA06001"` |
 | **mode_of_trial** | *string* | Indicates if the offence is either way, indictable only or summary only | `"Indictable-Only Offence"` |
-| **order_index** | *string* | The last name when the offence is a person | `"Alvi"` |
+| **order_index** | *integer* | The offence sequence provided by the police<br/> **Range:** `0 <= value` | `0` |
 | **title** | *string* | The offence title | `"Fail to wear protective clothing"` |
 
 ### <a name="link-GET-offence-/offences/{(%23%2Fdefinitions%2Foffence%2Fdefinitions%2Fidentity)}">Offences Info</a>
@@ -148,7 +148,7 @@ HTTP/1.1 200 OK
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "attributes": {
     "code": "AA06001",
-    "order_index": "Alvi",
+    "order_index": 0,
     "mode_of_trial": null,
     "title": "Fail to wear protective clothing"
   }
@@ -225,17 +225,7 @@ HTTP/1.1 200 OK
     }
   ],
   "included": [
-    {
-      "type": "defendants",
-      "id": "01234567-89ab-cdef-0123-456789abcdef",
-      "attributes": {
-        "first_name": "Elaf",
-        "last_name": "Alvi",
-        "date_of_birth": null,
-        "national_insurance_number": null,
-        "arrest_summons_number": "MG25A11223344"
-      }
-    }
+    null
   ]
 }
 ```

--- a/schema/schemata/defendant.json
+++ b/schema/schemata/defendant.json
@@ -102,6 +102,36 @@
       }
     }
   },
+  "relationships": {
+    "type": "object",
+    "properties": {
+      "offences": {
+        "$ref": "/schemata/defendant#/definitions/offence_relationship"
+      }
+    }
+  },
+  "offence_relationship": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "items": {
+          "$ref": "/schemata/defendant#/definitions/offence"
+        },
+        "type": "array"
+      }
+    }
+  },
+  "offence": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "/schemata/offence#/definitions/id"
+      },
+      "type": {
+        "$ref": "/schemata/offence#/definitions/type"
+      }
+    }
+  },
   "links": [
     {
       "description": "Info for existing defendant.",

--- a/schema/schemata/offence.json
+++ b/schema/schemata/offence.json
@@ -31,9 +31,10 @@
     },
     "order_index": {
       "readOnly": true,
-      "example": "Alvi",
-      "description": "The last name when the offence is a person",
-      "type": "string"
+      "example": 0,
+      "description": "The offence sequence provided by the police",
+      "type": "integer",
+      "minimum": 0
     },
     "identity": {
       "$ref": "/schemata/offence#/definitions/id"

--- a/schema/schemata/offence.json
+++ b/schema/schemata/offence.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Offences",
+  "description": "Offences",
+  "id": "schemata/offence",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of offence",
+      "readOnly": true,
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The offences type",
+      "enum": [
+        "offences"
+      ],
+      "example": "offences",
+      "type": "string"
+    },
+    "code": {
+      "readOnly": true,
+      "example": "AA06001",
+      "description": "The offence code",
+      "type": "string"
+    },
+    "order_index": {
+      "readOnly": true,
+      "example": "Alvi",
+      "description": "The last name when the offence is a person",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "/schemata/offence#/definitions/id"
+    },
+    "title": {
+      "readOnly": true,
+      "example": "Fail to wear protective clothing",
+      "description": "The offence title",
+      "type": "string"
+    },
+    "mode_of_trial": {
+      "readOnly": true,
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "Indicates if the offence is either way, indictable only or summary only",
+          "example": "Indictable-Only Offence",
+          "type": "string"
+        }
+      ]
+    },
+    "resource": {
+      "description": "object representing a single offence",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "/schemata/offence#/definitions/type"
+        },
+        "id": {
+          "$ref": "/schemata/offence#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "/schemata/offence#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "$ref": "/schemata/offence#/definitions/code"
+        },
+        "order_index": {
+          "$ref": "/schemata/offence#/definitions/order_index"
+        },
+        "mode_of_trial": {
+          "$ref": "/schemata/offence#/definitions/mode_of_trial"
+        },
+        "title": {
+          "$ref": "/schemata/offence#/definitions/title"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing offence.",
+      "href": "/offences/{(%2Fschemata%2Foffence%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "/schemata/offence#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "code": {
+      "$ref": "/schemata/offence#/definitions/code"
+    },
+    "order_index": {
+      "$ref": "/schemata/offence#/definitions/order_index"
+    },
+    "mode_of_trial": {
+      "$ref": "/schemata/offence#/definitions/mode_of_trial"
+    },
+    "title": {
+      "$ref": "/schemata/offence#/definitions/title"
+    }
+  }
+}

--- a/schema/schemata/prosecution_case.json
+++ b/schema/schemata/prosecution_case.json
@@ -66,7 +66,14 @@
         },
         "included": {
           "items": {
-            "$ref": "/schemata/defendant#/definitions/resource"
+            "anyOf":[
+              {
+                "$ref": "/schemata/defendant#/definitions/resource"
+              },
+              {
+                "$ref": "/schemata/offence#/definitions/resource"
+              }
+            ]
           },
           "type": "array"
         }

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe HearingSummary, type: :model do
   let(:hearing_summary_hash) do
     {
+      'hearingId' => 'UUID',
       'jurisdictionType' => 'Magistrate',
       'courtCenter' => {
         'id' => '1',
@@ -33,6 +34,7 @@ RSpec.describe HearingSummary, type: :model do
 
   before { hearing_summary.hearing_date = '2020-02-01' }
 
+  it { expect(hearing_summary.id).to eq('UUID') }
   it { expect(hearing_summary.jurisdiction_type).to eq('Magistrate') }
   it { expect(hearing_summary.court_centre_id).to eq('1') }
   it { expect(hearing_summary.court_centre_name).to eq('Westminster') }

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -5,49 +5,26 @@ require 'rails_helper'
 RSpec.describe Offence, type: :model do
   let(:offence_hash) do
     {
-      'offenceCodeorderIndex' => 'AA06001',
-      'orderIndex' => '0',
+      'offenceId' => 'db1cc378-a0e9-4943-bc36-7b34e47ae943',
+      'offenceCode' => 'AA06001',
+      'orderIndex' => 1,
       'offenceTitle' => 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
       'offenceLegislation' => 'N/A',
-      'wording' => 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
+      'wording' => 'Random string',
       'arrestDate' => '2020-02-01',
       'chargeDate' => '2020-02-01',
       'dateOfInformation' => '2020-02-01',
       'modeOfTrial' => 'Indictable-Only Offence',
       'startDate' => '2020-02-01',
-      'endDate' => nil,
-      'proceedingConcluded' => 'N',
-      'laaApplnReference' => {
-        'applicationReference' => '1234567',
-        'statusId' => '0',
-        'statusCode' => 'AP',
-        'statusDescription' => 'Application Pending',
-        'statusDate' => '2020-02-01',
-        'effectiveStartDate' => '2020-02-01',
-        'effectiveEndDate' => nil
-      }
+      'endDate' => '2020-02-01',
+      'proceedingsConcluded' => false
     }
   end
 
   subject(:offence) { described_class.new(body: offence_hash) }
 
-  it { expect(offence.offence_code_order_index).to eq('AA06001') }
-  it { expect(offence.order_index).to eq('0') }
-  it { expect(offence.offence_title).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
-  it { expect(offence.offence_legislation).to eq('N/A') }
-  it { expect(offence.wording).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
-  it { expect(offence.arrest_date).to eq('2020-02-01') }
-  it { expect(offence.charge_date).to eq('2020-02-01') }
-  it { expect(offence.date_of_information).to eq('2020-02-01') }
+  it { expect(offence.code).to eq('AA06001') }
+  it { expect(offence.order_index).to eq(1) }
+  it { expect(offence.title).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
   it { expect(offence.mode_of_trial).to eq('Indictable-Only Offence') }
-  it { expect(offence.start_date).to eq('2020-02-01') }
-  it { expect(offence.end_date).to be_nil }
-  it { expect(offence.proceeding_concluded).to eq('N') }
-  it { expect(offence.application_reference).to eq('1234567') }
-  it { expect(offence.status_id).to eq('0') }
-  it { expect(offence.status_code).to eq('AP') }
-  it { expect(offence.status_description).to eq('Application Pending') }
-  it { expect(offence.status_date).to eq('2020-02-01') }
-  it { expect(offence.effective_start_date).to eq('2020-02-01') }
-  it { expect(offence.effective_end_date).to be_nil }
 end

--- a/spec/requests/api/internal/v1/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/prosecution_cases_spec.rb
@@ -29,5 +29,14 @@ RSpec.describe 'Api::Internal::V1::ProsecutionCases', type: :request do
         expect(response).to have_http_status(200)
       end
     end
+
+    context 'including defendants and offences' do
+      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants,defendants.offences') }
+      it 'matches the given schema' do
+        get api_internal_v1_prosecution_cases_path, params: query_with_defendants, headers: valid_auth_header
+        expect(response.body).to be_valid_against_schema(schema: schema)
+        expect(response).to have_http_status(200)
+      end
+    end
   end
 end

--- a/spec/serializer/defendant_serializer_spec.rb
+++ b/spec/serializer/defendant_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DefendantSerializer do
                     last_name: 'Doe',
                     date_of_birth: '2012-12-12',
                     national_insurance_number: 'XW858621B',
+                    arrest_summons_number: 'MG25A11223344',
                     offence_ids: ['55555'])
   end
 
@@ -22,5 +23,12 @@ RSpec.describe DefendantSerializer do
     it { expect(attribute_hash[:last_name]).to eq('Doe') }
     it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
     it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
+    it { expect(attribute_hash[:arrest_summons_number]).to eq('MG25A11223344') }
+  end
+
+  context 'relationships' do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:offences][:data]).to eq([id: '55555', type: :offences]) }
   end
 end

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -6,25 +6,10 @@ RSpec.describe OffenceSerializer do
   let(:offence) do
     instance_double('Offence',
                     id: 'UUID',
-                    offence_code_order_index: 'AA06001',
+                    code: 'AA06001',
                     order_index: '0',
-                    offence_title: 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
-                    offence_legislation: 'N/A',
-                    wording: 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
-                    arrest_date: '2020-02-01',
-                    charge_date: '2020-02-01',
-                    date_of_information: '2020-02-01',
-                    mode_of_trial: 'Indictable-Only Offence',
-                    start_date: '2020-02-01',
-                    end_date: nil,
-                    proceeding_concluded: 'N',
-                    application_reference: '1234567',
-                    status_id: '0',
-                    status_code: 'AP',
-                    status_description: 'Application Pending',
-                    status_date: '2020-02-01',
-                    effective_start_date: '2020-02-01',
-                    effective_end_date: nil)
+                    title: 'Fail to wear protective clothing',
+                    mode_of_trial: 'Indictable-Only Offence')
   end
 
   subject { described_class.new(offence).serializable_hash }
@@ -32,24 +17,9 @@ RSpec.describe OffenceSerializer do
   context 'attributes' do
     let(:attribute_hash) { subject[:data][:attributes] }
 
-    it { expect(attribute_hash[:offence_code_order_index]).to eq('AA06001') }
+    it { expect(attribute_hash[:code]).to eq('AA06001') }
     it { expect(attribute_hash[:order_index]).to eq('0') }
-    it { expect(attribute_hash[:offence_title]).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
-    it { expect(attribute_hash[:offence_legislation]).to eq('N/A') }
-    it { expect(attribute_hash[:wording]).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
-    it { expect(attribute_hash[:arrest_date]).to eq('2020-02-01') }
-    it { expect(attribute_hash[:charge_date]).to eq('2020-02-01') }
-    it { expect(attribute_hash[:date_of_information]).to eq('2020-02-01') }
+    it { expect(attribute_hash[:title]).to eq('Fail to wear protective clothing') }
     it { expect(attribute_hash[:mode_of_trial]).to eq('Indictable-Only Offence') }
-    it { expect(attribute_hash[:start_date]).to eq('2020-02-01') }
-    it { expect(attribute_hash[:end_date]).to be_nil }
-    it { expect(attribute_hash[:proceeding_concluded]).to eq('N') }
-    it { expect(attribute_hash[:application_reference]).to eq('1234567') }
-    it { expect(attribute_hash[:status_id]).to eq('0') }
-    it { expect(attribute_hash[:status_code]).to eq('AP') }
-    it { expect(attribute_hash[:status_description]).to eq('Application Pending') }
-    it { expect(attribute_hash[:status_date]).to eq('2020-02-01') }
-    it { expect(attribute_hash[:effective_start_date]).to eq('2020-02-01') }
-    it { expect(attribute_hash[:effective_end_date]).to be_nil }
   end
 end

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe ProsecutionCaseSerializer do
     instance_double('ProsecutionCase',
                     id: 'UUID',
                     prosecution_case_reference: 'AAA',
-                    defendant_ids: ['UUID'],
-                    hearing_summary_ids: ['UUID'])
+                    defendant_ids: ['DEFENDANT-UUID'])
   end
 
   subject { described_class.new(prosecution_case).serializable_hash }
@@ -17,5 +16,11 @@ RSpec.describe ProsecutionCaseSerializer do
     let(:attribute_hash) { subject[:data][:attributes] }
 
     it { expect(attribute_hash[:prosecution_case_reference]).to eq('AAA') }
+  end
+
+  context 'relationships' do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:defendants][:data]).to eq([id: 'DEFENDANT-UUID', type: :defendants]) }
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-88)

Added these attributes from offence:
`orderIndex`, `offenceCode`, `offenceTitle`, `modeOfTrial`

Pending: (These are available probably from the GET hearings call, so, perhaps we could spike and add them once we have figured out the absolute required data set)
`.plea.pleaDate`, `.plea.pleaValue`, `.count`

 Allow exposing offences as a relationship on defendants, hence we can make queries of the form:

`include=defendants,defendants.offences` to be able to output both defendant and defendant offences

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
