### PR TITLE
CACP-231 Record prosecution_case/defendant/offence IDs

### DIFF
--- a/app/models/prosecution_case_defendant_offence.rb
+++ b/app/models/prosecution_case_defendant_offence.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ProsecutionCaseDefendantOffence < ApplicationRecord
+  validates :prosecution_case_id, presence: true
+  validates :defendant_id, presence: true
+  validates :offence_id, presence: true
+end

--- a/app/services/prosecution_case_recorder.rb
+++ b/app/services/prosecution_case_recorder.rb
@@ -9,6 +9,13 @@ class ProsecutionCaseRecorder < ApplicationService
 
   def call
     prosecution_case.update(body: body)
+
+    prosecution_case.defendants.each do |defendant|
+      defendant.offences.each do |offence|
+        ProsecutionCaseDefendantOffence.find_or_create_by!(prosecution_case_id: prosecution_case.id, defendant_id: defendant.id, offence_id: offence.id)
+      end
+    end
+
     prosecution_case
   end
 

--- a/db/migrate/20200304144205_create_prosecution_case_defendant_offences.rb
+++ b/db/migrate/20200304144205_create_prosecution_case_defendant_offences.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateProsecutionCaseDefendantOffences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :prosecution_case_defendant_offences, id: :uuid do |t|
+      t.uuid :prosecution_case_id,    null: false
+      t.uuid :defendant_id,           null: false
+      t.uuid :offence_id,             null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_053550) do
+ActiveRecord::Schema.define(version: 2020_03_04_144205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,6 +62,14 @@ ActiveRecord::Schema.define(version: 2020_02_10_053550) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "prosecution_case_defendant_offences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "prosecution_case_id", null: false
+    t.uuid "defendant_id", null: false
+    t.uuid "offence_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "prosecution_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/fixtures/files/prosecution_case_search_result.json
+++ b/spec/fixtures/files/prosecution_case_search_result.json
@@ -1,0 +1,59 @@
+{
+    "prosecutionCaseId": "7a0c947e-97b4-4c5a-ae6a-26320afc914d",
+    "prosecutionCaseReference": "TFL12345",
+    "caseStatus": "INACTIVE",
+    "defendants": [
+        {
+            "defendantId": "8cd0ba7e-df89-45a3-8c61-4008a2186d64",
+            "nationalInsuranceNumber": "BN102966C",
+            "arrestSummonsNumber": "arrest123",
+            "name": {
+                "firstName": "Alfredine",
+                "middleName": "Treutel",
+                "lastName": "Parker"
+            },
+            "dateOfBirth": "1971-05-12",
+            "dateOfNextHearing": "2012-12-12",
+            "proceedingsConcluded": false,
+            "offences": [
+                {
+                    "offenceId": "cacbd4d4-9102-4687-98b4-d529be3d5710",
+                    "offenceCode": "Random string",
+                    "orderIndex": 1,
+                    "offenceTitle": "Random string",
+                    "offenceLegislation": "Random string",
+                    "wording": "Random string",
+                    "arrestDate": "2019-10-17",
+                    "chargeDate": "2019-10-17",
+                    "dateOfInformation": "2019-10-17",
+                    "modeOfTrial": "Random string",
+                    "startDate": "2019-10-17",
+                    "endDate": "2019-10-17",
+                    "proceedingsConcluded": false
+                }
+            ]
+        }
+    ],
+    "hearings": [
+        {
+            "hearingId": "8f23cfd3-d4ff-4e90-b018-03385b7a96d3",
+            "jurisdictionType": "CROWN",
+            "courtCentre": {
+                "id": "f30b31b7-41f3-4b30-a482-1b3c89f8c4b7",
+                "name": "Random string",
+                "welshName": "Llinyn ar hap",
+                "roomId": "c2181e2b-be46-4d82-9ac6-1c02e4cc7dbb",
+                "roomName": "Grand Hall",
+                "welshRoomName": "Neuadd y Grand"
+            },
+            "type": {
+                "id": "c4278f10-8f17-446d-8e3b-85236687a1f4",
+                "description": "This is a description",
+                "code": "12D10JAS"
+            },
+            "defendants": [
+                "ecca893f-0928-4fc6-ae50-6a8794b78c5c"
+            ]
+        }
+    ]
+}

--- a/spec/models/prosecution_case_defendant_spec.rb
+++ b/spec/models/prosecution_case_defendant_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
+  let(:prosecution_case_id) { SecureRandom.uuid }
+  let(:defendant_id) { SecureRandom.uuid }
+  let(:offence_id) { SecureRandom.uuid }
+  let(:prosecution_case_defendant_offence) do
+    described_class.new(
+      prosecution_case_id: prosecution_case_id,
+      defendant_id: defendant_id,
+      offence_id: offence_id
+    )
+  end
+
+  it { expect(prosecution_case_defendant_offence.prosecution_case_id).to eq prosecution_case_id }
+  it { expect(prosecution_case_defendant_offence.defendant_id).to eq defendant_id }
+  it { expect(prosecution_case_defendant_offence.offence_id).to eq offence_id }
+end

--- a/spec/services/api/search_prosecution_case_spec.rb
+++ b/spec/services/api/search_prosecution_case_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::SearchProsecutionCase do
   let(:params) { { howdy: 'hello' } }
   let(:response_status) { 200 }
   let(:search_results) { double('Response', status: response_status, body: response_body) }
-  let(:response_body) { [{ 'prosecutionCaseId' => 12_345 }] }
+  let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
+  let(:response_body) { [JSON.parse(file_fixture('prosecution_case_search_result.json').read)] }
 
   before do
     allow(ProsecutionCaseSearcher).to receive(:call).and_return(search_results)
@@ -14,7 +15,7 @@ RSpec.describe Api::SearchProsecutionCase do
 
   it 'records ProsecutionCase' do
     expect(ProsecutionCaseRecorder).to receive(:call)
-      .with(12_345, 'prosecutionCaseId' => 12_345)
+      .with(prosecution_case_id, response_body[0])
     subject
   end
 

--- a/spec/services/prosecution_case_recorder_spec.rb
+++ b/spec/services/prosecution_case_recorder_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe ProsecutionCaseRecorder do
-  let(:prosecution_case_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
-  let(:body) { { response: 'text' }.to_json }
+  let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
+  let(:defendant_id) { '8cd0ba7e-df89-45a3-8c61-4008a2186d64' }
+  let(:offence_id) { 'cacbd4d4-9102-4687-98b4-d529be3d5710' }
+  let(:body) { JSON.parse(file_fixture('prosecution_case_search_result.json').read) }
 
   subject(:record) { described_class.call(prosecution_case_id, body) }
 
@@ -10,6 +12,12 @@ RSpec.describe ProsecutionCaseRecorder do
     expect {
       record
     }.to change(ProsecutionCase, :count).by(1)
+  end
+
+  it 'creates a ProsecutionCaseDefendantOffence record' do
+    expect {
+      record
+    }.to change(ProsecutionCaseDefendantOffence, :count).by(1)
   end
 
   it 'returns the created Prosecution Case' do
@@ -24,7 +32,15 @@ RSpec.describe ProsecutionCaseRecorder do
     let!(:prosecution_case) do
       ProsecutionCase.create!(
         id: prosecution_case_id,
-        body: { amazing_body: true }
+        body: JSON.parse(file_fixture('prosecution_case_search_result.json').read)
+      )
+    end
+
+    let!(:prosecution_case_defendant_offence) do
+      ProsecutionCaseDefendantOffence.create!(
+        prosecution_case_id: prosecution_case_id,
+        defendant_id: defendant_id,
+        offence_id: offence_id
       )
     end
 
@@ -32,6 +48,12 @@ RSpec.describe ProsecutionCaseRecorder do
       expect {
         record
       }.not_to change(ProsecutionCase, :count)
+    end
+
+    it 'does not create a new ProsecutionCaseDefendantOffence record' do
+      expect {
+        record
+      }.not_to change(ProsecutionCaseDefendantOffence, :count)
     end
 
     it 'updates Prosecution Case with new response' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-231)

First part of CACP-231. The overall goal of this story is to map a single link request from View Court Data into multiple calls to Common Platform. As a first step this PR creates a model and database table to map `prosecution_case_ids` to `defendant_ids` to `offence_ids`, and adds a call to the `ProsecutionCaseRecorder` to create records. This will enable us to identify which offences need to be included in the link calls to Common Platform.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
