### PR TITLE
Make CP Link calls on request from View Court Data

### DIFF
--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -37,14 +37,14 @@ module Api
           offence_ids = offences.pluck(:offence_id)
 
           offence_ids.each do |offence_id|
-            Api::RecordLaaReference.new(
+            LaaReferenceUpdaterJob.perform_later(
               prosecution_case_id: prosecution_case_id,
               defendant_id: defendant_id,
               offence_id: offence_id,
               status_code: 'AP',
               application_reference: maat_reference,
               status_date: Date.today.strftime('%Y-%m-%d')
-            ).call
+            )
           end
         end
       end

--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -9,6 +9,8 @@ module Api
           if contract.errors.present?
             render json: contract.errors.to_hash, status: :bad_request
           else
+            make_common_platform_calls(contract)
+
             render status: :accepted
           end
         end
@@ -25,6 +27,25 @@ module Api
 
         def transformed_params
           create_params.slice(*allowed_params).to_hash.transform_keys(&:to_sym)
+        end
+
+        def make_common_platform_calls(contract)
+          maat_reference = contract[:maat_reference]
+          defendant_id = contract[:defendant_id]
+          offences = ProsecutionCaseDefendantOffence.where(defendant_id: defendant_id)
+          prosecution_case_id = offences.pluck(:prosecution_case_id).first
+          offence_ids = offences.pluck(:offence_id)
+
+          offence_ids.each do |offence_id|
+            Api::RecordLaaReference.new(
+              prosecution_case_id: prosecution_case_id,
+              defendant_id: defendant_id,
+              offence_id: offence_id,
+              status_code: 'AP',
+              application_reference: maat_reference,
+              status_date: Date.today.strftime('%Y-%m-%d')
+            ).call
+          end
         end
       end
     end

--- a/app/jobs/laa_reference_updater_job.rb
+++ b/app/jobs/laa_reference_updater_job.rb
@@ -3,7 +3,7 @@
 class LaaReferenceUpdaterJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    Api::RecordLaaReference.new(*args).call
+  def perform(contract)
+    LaaReferenceUpdater.call(contract)
   end
 end

--- a/app/jobs/laa_reference_updater_job.rb
+++ b/app/jobs/laa_reference_updater_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LaaReferenceUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Api::RecordLaaReference.new(*args).call
+  end
+end

--- a/app/services/laa_reference_updater.rb
+++ b/app/services/laa_reference_updater.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class LaaReferenceUpdater < ApplicationService
+  def initialize(contract)
+    @contract = contract
+  end
+
+  def call
+    maat_reference = contract[:maat_reference]
+
+    ProsecutionCaseDefendantOffence.where(defendant_id: contract[:defendant_id]).each do |offence|
+      Api::RecordLaaReference.call(
+        prosecution_case_id: offence.prosecution_case_id,
+        defendant_id: offence.defendant_id,
+        offence_id: offence.offence_id,
+        status_code: 'AP',
+        application_reference: maat_reference,
+        status_date: Date.today.strftime('%Y-%m-%d')
+      )
+    end
+  end
+
+  private
+
+  attr_reader :contract
+end

--- a/spec/jobs/laa_reference_updater_job_spec.rb
+++ b/spec/jobs/laa_reference_updater_job_spec.rb
@@ -3,19 +3,12 @@
 RSpec.describe LaaReferenceUpdaterJob, type: :job do
   include ActiveJob::TestHelper
   describe '#perform_later' do
-    let(:mock_laa_reference_recorder) { double Api::RecordLaaReference }
+    let(:mock_laa_reference_updater) { double LaaReferenceUpdater }
 
-    before { allow(Api::RecordLaaReference).to receive(:new).and_return(mock_laa_reference_recorder) }
+    before { allow(LaaReferenceUpdater).to receive(:new).and_return(mock_laa_reference_updater) }
 
     subject(:job) do
-      described_class.perform_later(
-        prosecution_case_id: SecureRandom.uuid,
-        defendant_id: SecureRandom.uuid,
-        offence_id: SecureRandom.uuid,
-        status_code: 'AP',
-        application_reference: '123456789',
-        status_date: Date.today.strftime('%Y-%m-%d')
-      )
+      described_class.perform_later(contact: 'contract')
     end
 
     it 'queues a call to update the laa reference' do
@@ -25,8 +18,8 @@ RSpec.describe LaaReferenceUpdaterJob, type: :job do
       }.to have_enqueued_job
     end
 
-    it 'creates a RecordLaaReference and calls it' do
-      expect(mock_laa_reference_recorder).to receive(:call).once
+    it 'creates a LaaReferenceUpdater and calls it' do
+      expect(mock_laa_reference_updater).to receive(:call).once
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/jobs/laa_reference_updater_job_spec.rb
+++ b/spec/jobs/laa_reference_updater_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe LaaReferenceUpdaterJob, type: :job do
+  include ActiveJob::TestHelper
+  describe '#perform_later' do
+    let(:mock_laa_reference_recorder) { double Api::RecordLaaReference }
+
+    before { allow(Api::RecordLaaReference).to receive(:new).and_return(mock_laa_reference_recorder) }
+
+    subject(:job) do
+      described_class.perform_later(
+        prosecution_case_id: SecureRandom.uuid,
+        defendant_id: SecureRandom.uuid,
+        offence_id: SecureRandom.uuid,
+        status_code: 'AP',
+        application_reference: '123456789',
+        status_date: Date.today.strftime('%Y-%m-%d')
+      )
+    end
+
+    it 'queues a call to update the laa reference' do
+      ActiveJob::Base.queue_adapter = :test
+      expect {
+        job
+      }.to have_enqueued_job
+    end
+
+    it 'creates a RecordLaaReference and calls it' do
+      expect(mock_laa_reference_recorder).to receive(:call).once
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/services/laa_reference_updater_spec.rb
+++ b/spec/services/laa_reference_updater_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe LaaReferenceUpdater do
+  let(:maat_reference) { 12_345_678 }
+  let(:defendant_id) { SecureRandom.uuid }
+  let(:contract) { NewLaaReferenceContract.new.call({ maat_reference: maat_reference, defendant_id: defendant_id }) }
+  let(:mock_record_laa_reference_service) { double Api::RecordLaaReference }
+
+  before { allow(Api::RecordLaaReference).to receive(:new).and_return(mock_record_laa_reference_service) }
+
+  before do
+    ProsecutionCaseDefendantOffence.create!(prosecution_case_id: SecureRandom.uuid,
+                                            defendant_id: defendant_id,
+                                            offence_id: SecureRandom.uuid)
+  end
+
+  subject(:record) { described_class.call(contract) }
+
+  it 'creates and calls the Api::RecordLaaReference service once' do
+    expect(mock_record_laa_reference_service).to receive(:call).once
+    record
+  end
+
+  context 'with multiple offences' do
+    before do
+      ProsecutionCaseDefendantOffence.create!(prosecution_case_id: SecureRandom.uuid,
+                                              defendant_id: defendant_id,
+                                              offence_id: SecureRandom.uuid)
+    end
+
+    it 'creates and calls the Api::RecordLaaReference service multiple times' do
+      expect(mock_record_laa_reference_service).to receive(:call).twice
+      record
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-231)

View Court Data provides a `maat_reference` and `defendant_id` in its link requests. CDA needs to translate that `defendant_id` into the (potentially) multiple `offence_id`s that belong to that defendant and make a call to common platform for each one.

This PR amends the `laa_references_controller` so that when a link request is received from View Court Data, the correct `offence_id`s for that defendant are identified and a call is made to Common Platform to register the `maat_reference` against each one.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
