### PR TITLE
Extend prosecution_case_defendant_offences table

### DIFF
--- a/app/services/api/record_laa_reference.rb
+++ b/app/services/api/record_laa_reference.rb
@@ -47,6 +47,7 @@ module Api
       offence = ProsecutionCaseDefendantOffence.find_by(offence_id: offence_id)
       offence.maat_reference = application_reference
       offence.dummy_maat_reference = (application_reference.to_s[0] == 'A')
+      offence.rep_order_status = status_code
       offence.response_status = response.status
       offence.response_body = response.body
       offence.save!

--- a/app/services/laa_reference_updater.rb
+++ b/app/services/laa_reference_updater.rb
@@ -6,34 +6,26 @@ class LaaReferenceUpdater < ApplicationService
   end
 
   def call
-    @maat_reference = contract[:maat_reference] || dummy_maat_reference
-
     ProsecutionCaseDefendantOffence.where(defendant_id: contract[:defendant_id]).each do |offence|
-      @response = Api::RecordLaaReference.call(
+      Api::RecordLaaReference.call(
         prosecution_case_id: offence.prosecution_case_id,
         defendant_id: offence.defendant_id,
         offence_id: offence.offence_id,
         status_code: 'AP',
-        application_reference: @maat_reference,
+        application_reference: maat_reference,
         status_date: Date.today.strftime('%Y-%m-%d')
       )
-
-      update_record(offence)
     end
   end
 
   private
 
-  def dummy_maat_reference
-    "A#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
+  def maat_reference
+    @maat_reference ||= contract[:maat_reference].presence || dummy_maat_reference
   end
 
-  def update_record(offence)
-    offence.maat_reference = @maat_reference
-    offence.dummy_maat_reference = (@maat_reference.to_s[0] == 'A')
-    offence.response_status = @response.status
-    offence.response_body = @response.body
-    offence.save!
+  def dummy_maat_reference
+    "A#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
   end
 
   attr_reader :contract

--- a/app/services/laa_reference_updater.rb
+++ b/app/services/laa_reference_updater.rb
@@ -6,17 +6,19 @@ class LaaReferenceUpdater < ApplicationService
   end
 
   def call
-    maat_reference = contract[:maat_reference]
+    @maat_reference = contract[:maat_reference] || dummy_maat_reference
 
     ProsecutionCaseDefendantOffence.where(defendant_id: contract[:defendant_id]).each do |offence|
-      Api::RecordLaaReference.call(
+      @response = Api::RecordLaaReference.call(
         prosecution_case_id: offence.prosecution_case_id,
         defendant_id: offence.defendant_id,
         offence_id: offence.offence_id,
         status_code: 'AP',
-        application_reference: maat_reference || dummy_maat_reference,
+        application_reference: @maat_reference,
         status_date: Date.today.strftime('%Y-%m-%d')
       )
+
+      update_record(offence)
     end
   end
 
@@ -24,6 +26,14 @@ class LaaReferenceUpdater < ApplicationService
 
   def dummy_maat_reference
     "A#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
+  end
+
+  def update_record(offence)
+    offence.maat_reference = @maat_reference
+    offence.dummy_maat_reference = (@maat_reference.to_s[0] == 'A')
+    offence.response_status = @response.status
+    offence.response_body = @response.body
+    offence.save!
   end
 
   attr_reader :contract

--- a/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
+++ b/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddColumnsToProsecutionCaseDefendantOffences < ActiveRecord::Migration[6.0]
+  def change
+    add_column :prosecution_case_defendant_offences, :maat_reference, :string
+    add_column :prosecution_case_defendant_offences, :dummy_maat_reference, :boolean
+    add_column :prosecution_case_defendant_offences, :response_status, :integer
+    add_column :prosecution_case_defendant_offences, :response_body, :json
+    add_column :prosecution_case_defendant_offences, :user_id, :string
+  end
+end

--- a/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
+++ b/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
@@ -4,6 +4,7 @@ class AddColumnsToProsecutionCaseDefendantOffences < ActiveRecord::Migration[6.0
   def change
     add_column :prosecution_case_defendant_offences, :maat_reference, :string
     add_column :prosecution_case_defendant_offences, :dummy_maat_reference, :boolean, default: false, null: false
+    add_column :prosecution_case_defendant_offences, :rep_order_status, :string
     add_column :prosecution_case_defendant_offences, :response_status, :integer
     add_column :prosecution_case_defendant_offences, :response_body, :json
   end

--- a/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
+++ b/db/migrate/20200310222258_add_columns_to_prosecution_case_defendant_offences.rb
@@ -3,9 +3,8 @@
 class AddColumnsToProsecutionCaseDefendantOffences < ActiveRecord::Migration[6.0]
   def change
     add_column :prosecution_case_defendant_offences, :maat_reference, :string
-    add_column :prosecution_case_defendant_offences, :dummy_maat_reference, :boolean
+    add_column :prosecution_case_defendant_offences, :dummy_maat_reference, :boolean, default: false, null: false
     add_column :prosecution_case_defendant_offences, :response_status, :integer
     add_column :prosecution_case_defendant_offences, :response_body, :json
-    add_column :prosecution_case_defendant_offences, :user_id, :string
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -128,6 +128,7 @@ CREATE TABLE public.prosecution_case_defendant_offences (
     updated_at timestamp(6) without time zone NOT NULL,
     maat_reference character varying,
     dummy_maat_reference boolean DEFAULT false NOT NULL,
+    rep_order_status character varying,
     response_status integer,
     response_body json
 );

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,10 +127,9 @@ CREATE TABLE public.prosecution_case_defendant_offences (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     maat_reference character varying,
-    dummy_maat_reference boolean,
+    dummy_maat_reference boolean DEFAULT false NOT NULL,
     response_status integer,
-    response_body json,
-    user_id character varying
+    response_body json
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -125,7 +125,12 @@ CREATE TABLE public.prosecution_case_defendant_offences (
     defendant_id uuid NOT NULL,
     offence_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    maat_reference character varying,
+    dummy_maat_reference boolean,
+    response_status integer,
+    response_body json,
+    user_id character varying
 );
 
 
@@ -320,6 +325,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191211135014'),
 ('20200210053550'),
 ('20200304144205'),
-('20200310210135');
+('20200310210135'),
+('20200310222258');
 
 

--- a/spec/models/prosecution_case_defendant_spec.rb
+++ b/spec/models/prosecution_case_defendant_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   let(:offence_id) { SecureRandom.uuid }
   let(:maat_reference) { 'A00000001' }
   let(:dummy_maat_reference) { true }
+  let(:rep_order_status) { 'AP' }
   let(:response_status) { 200 }
   let(:response_body) { { response: 'response' }.to_json }
 
@@ -16,6 +17,7 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
       offence_id: offence_id,
       maat_reference: maat_reference,
       dummy_maat_reference: dummy_maat_reference,
+      rep_order_status: rep_order_status,
       response_status: response_status,
       response_body: response_body
     )
@@ -26,6 +28,7 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   it { expect(prosecution_case_defendant_offence.offence_id).to eq offence_id }
   it { expect(prosecution_case_defendant_offence.maat_reference).to eq maat_reference }
   it { expect(prosecution_case_defendant_offence.dummy_maat_reference).to eq dummy_maat_reference }
+  it { expect(prosecution_case_defendant_offence.rep_order_status).to eq rep_order_status }
   it { expect(prosecution_case_defendant_offence.response_status).to eq response_status }
   it { expect(prosecution_case_defendant_offence.response_body).to eq response_body }
 end

--- a/spec/models/prosecution_case_defendant_spec.rb
+++ b/spec/models/prosecution_case_defendant_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   let(:dummy_maat_reference) { true }
   let(:response_status) { 200 }
   let(:response_body) { { response: 'response' }.to_json }
-  let(:user_id) { 'user-id' }
 
   let(:prosecution_case_defendant_offence) do
     described_class.new(
@@ -18,8 +17,7 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
       maat_reference: maat_reference,
       dummy_maat_reference: dummy_maat_reference,
       response_status: response_status,
-      response_body: response_body,
-      user_id: user_id
+      response_body: response_body
     )
   end
 
@@ -30,5 +28,4 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   it { expect(prosecution_case_defendant_offence.dummy_maat_reference).to eq dummy_maat_reference }
   it { expect(prosecution_case_defendant_offence.response_status).to eq response_status }
   it { expect(prosecution_case_defendant_offence.response_body).to eq response_body }
-  it { expect(prosecution_case_defendant_offence.user_id).to eq user_id }
 end

--- a/spec/models/prosecution_case_defendant_spec.rb
+++ b/spec/models/prosecution_case_defendant_spec.rb
@@ -4,15 +4,31 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   let(:prosecution_case_id) { SecureRandom.uuid }
   let(:defendant_id) { SecureRandom.uuid }
   let(:offence_id) { SecureRandom.uuid }
+  let(:maat_reference) { 'A00000001' }
+  let(:dummy_maat_reference) { true }
+  let(:response_status) { 200 }
+  let(:response_body) { { response: 'response' }.to_json }
+  let(:user_id) { 'user-id' }
+
   let(:prosecution_case_defendant_offence) do
     described_class.new(
       prosecution_case_id: prosecution_case_id,
       defendant_id: defendant_id,
-      offence_id: offence_id
+      offence_id: offence_id,
+      maat_reference: maat_reference,
+      dummy_maat_reference: dummy_maat_reference,
+      response_status: response_status,
+      response_body: response_body,
+      user_id: user_id
     )
   end
 
   it { expect(prosecution_case_defendant_offence.prosecution_case_id).to eq prosecution_case_id }
   it { expect(prosecution_case_defendant_offence.defendant_id).to eq defendant_id }
   it { expect(prosecution_case_defendant_offence.offence_id).to eq offence_id }
+  it { expect(prosecution_case_defendant_offence.maat_reference).to eq maat_reference }
+  it { expect(prosecution_case_defendant_offence.dummy_maat_reference).to eq dummy_maat_reference }
+  it { expect(prosecution_case_defendant_offence.response_status).to eq response_status }
+  it { expect(prosecution_case_defendant_offence.response_body).to eq response_body }
+  it { expect(prosecution_case_defendant_offence.user_id).to eq user_id }
 end

--- a/spec/services/api/record_laa_reference_spec.rb
+++ b/spec/services/api/record_laa_reference_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe Api::RecordLaaReference do
     it 'updates the database record for the offence' do
       subject
       offence_record = ProsecutionCaseDefendantOffence.find_by(defendant_id: defendant_id)
-      expect(offence_record.maat_reference).to eq('SOME SORT OF MAAT ID')
+      expect(offence_record.maat_reference).to eq 'SOME SORT OF MAAT ID'
       expect(offence_record.dummy_maat_reference).to be false
+      expect(offence_record.rep_order_status).to eq 'ABCDEF'
       expect(offence_record.response_status).to eq(200)
       expect(offence_record.response_body).to eq({ 'test' => 'test' })
     end

--- a/spec/services/laa_reference_updater_spec.rb
+++ b/spec/services/laa_reference_updater_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LaaReferenceUpdater do
 
   before do
     allow(Api::RecordLaaReference).to receive(:new).and_return(mock_record_laa_reference_service)
-    allow(mock_record_laa_reference_service).to receive(:call).and_return(Faraday::Response.new(status: 200, body: { 'test' => 'test' }))
+    allow(mock_record_laa_reference_service).to receive(:call)
   end
 
   before do
@@ -24,13 +24,6 @@ RSpec.describe LaaReferenceUpdater do
     update
   end
 
-  it 'updates the ProsecutionCaseDefendantOffence record' do
-    update
-    offence_record = ProsecutionCaseDefendantOffence.find_by(defendant_id: defendant_id)
-    expect(offence_record.maat_reference).to eq(maat_reference.to_s)
-    expect(offence_record.dummy_maat_reference).to be false
-  end
-
   context 'with multiple offences' do
     before do
       ProsecutionCaseDefendantOffence.create!(prosecution_case_id: SecureRandom.uuid,
@@ -41,17 +34,6 @@ RSpec.describe LaaReferenceUpdater do
     it 'creates and calls the Api::RecordLaaReference service multiple times' do
       expect(mock_record_laa_reference_service).to receive(:call).twice
       update
-    end
-
-    it 'updates all the ProsecutionCaseDefendantOffence records' do
-      update
-      ProsecutionCaseDefendantOffence.where(defendant_id: defendant_id).each do |record|
-        expect(record.maat_reference).to eq(maat_reference.to_s)
-        expect(record.dummy_maat_reference).to be false
-        expect(record.response_status).to eq(200)
-        expect(record.response_body).to eq({ 'test' => 'test' })
-        expect(record.user_id).to be_nil
-      end
     end
   end
 
@@ -65,13 +47,6 @@ RSpec.describe LaaReferenceUpdater do
     it 'creates a dummy maat_reference' do
       expect(Api::RecordLaaReference).to receive(:new).with(hash_including(application_reference: 'A10000000'))
       update
-    end
-
-    it 'updates the ProsecutionCaseDefendantOffence record' do
-      update
-      offence_record = ProsecutionCaseDefendantOffence.find_by(defendant_id: defendant_id)
-      expect(offence_record.maat_reference).to eq('A10000000')
-      expect(offence_record.dummy_maat_reference).to be true
     end
   end
 end


### PR DESCRIPTION
## What

See comments on [CACP-89](https://dsdmoj.atlassian.net/browse/CACP-89) and [CACP-184](https://dsdmoj.atlassian.net/browse/CACP-184)

We want to capture additional data in the `prosecution_case_defendant_offences` table to provide more of an audit trail. 

Based on Richard's comments on the above ticket I've added the following fields to the table:
 - `maat_reference`: the maat id
 - `dummy_maat_reference`: boolean to indicate if a dummy maat id is used
 - `rep_order_status`: the legal aid status for the offence
 - `response_status`: HTTP status from the common platform response
 - `response_body`: json representation of the common platform response body

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
