### PR TITLE
Add swagger and document prosecution_cases endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails', '~> 0.3.9'
   gem 'rspec-rails', '~> 4.0.0.rc1'
+  gem 'rswag'
   gem 'rubocop', '~> 0.80.1', require: false
   gem 'rubocop-performance'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,19 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rswag (2.2.0)
+      rswag-api (= 2.2.0)
+      rswag-specs (= 2.2.0)
+      rswag-ui (= 2.2.0)
+    rswag-api (2.2.0)
+      railties (>= 3.1, < 6.1)
+    rswag-specs (2.2.0)
+      activesupport (>= 3.1, < 6.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 6.1)
+    rswag-ui (2.2.0)
+      actionpack (>= 3.1, < 6.1)
+      railties (>= 3.1, < 6.1)
     rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -291,6 +304,7 @@ DEPENDENCIES
   rails (~> 6.0.2)
   rspec-rails (~> 4.0.0.rc1)
   rspec_junit_formatter
+  rswag
   rubocop (~> 0.80.1)
   rubocop-performance
   shoulda-matchers

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   use_doorkeeper
   namespace :api do
     namespace :internal do

--- a/spec/requests/api/internal/v1/non_swagger_prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/non_swagger_prosecution_cases_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Api::Internal::V1::ProsecutionCases', type: :request do
+  include AuthorisedRequestHelper
+
+  describe 'GET /api/internal/v1/prosecution_cases' do
+    let(:headers) { valid_auth_header }
+
+    around do |example|
+      VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
+        example.run
+      end
+    end
+
+    let(:valid_query_params) { { filter: { prosecution_case_reference: 'TFL12345' } } }
+    let(:schema) { File.read('schema/schema.json') }
+
+    it 'matches the given schema' do
+      get api_internal_v1_prosecution_cases_path, params: valid_query_params, headers: valid_auth_header
+      expect(response.body).to be_valid_against_schema(schema: schema)
+      expect(response).to have_http_status(200)
+    end
+
+    context 'including defendants' do
+      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants') }
+      it 'matches the given schema' do
+        get api_internal_v1_prosecution_cases_path, params: query_with_defendants, headers: valid_auth_header
+        expect(response.body).to be_valid_against_schema(schema: schema)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'including defendants and offences' do
+      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants,defendants.offences') }
+      it 'matches the given schema' do
+        get api_internal_v1_prosecution_cases_path, params: query_with_defendants, headers: valid_auth_header
+        expect(response.body).to be_valid_against_schema(schema: schema)
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v1/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/prosecution_cases_spec.rb
@@ -1,41 +1,168 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Api::Internal::V1::ProsecutionCases', type: :request do
+require 'swagger_helper'
+
+RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc: 'v1/swagger.yaml' do
   include AuthorisedRequestHelper
 
-  describe 'GET /api/internal/v1/prosecution_cases' do
-    let(:headers) { valid_auth_header }
+  let(:token) { access_token }
+  let(:schema) { File.read('schema/schema.json') }
 
-    around do |example|
-      VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
-        example.run
+  path '/api/internal/v1/prosecution_cases' do
+    get('list prosecution_cases') do
+      description 'Search prosecution cases'
+      consumes 'application/json'
+      security [oauth: ['read']]
+
+      context 'search by prosecution_case_reference' do
+        response(200, 'Success') do
+          around do |example|
+            VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
+              example.run
+            end
+          end
+
+          parameter name: 'filter[prosecution_case_reference]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'prosecution_case.json#/definitions/prosecution_case_reference'
+                    },
+                    description: 'Searches prosecution cases by prosecution case reference'
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[prosecution_case_reference]') { 'TFL12345' }
+
+          run_test! do |response|
+            expect(response.body).to be_valid_against_schema(schema: schema)
+          end
+        end
       end
-    end
 
-    let(:valid_query_params) { { filter: { prosecution_case_reference: 'TFL12345' } } }
-    let(:schema) { File.read('schema/schema.json') }
+      context 'search by arrest_summons_number' do
+        response(200, 'Success') do
+          around do |example|
+            VCR.use_cassette('search_prosecution_case/by_arrest_summons_number_success') do
+              example.run
+            end
+          end
 
-    it 'matches the given schema' do
-      get api_internal_v1_prosecution_cases_path, params: valid_query_params, headers: valid_auth_header
-      expect(response.body).to be_valid_against_schema(schema: schema)
-      expect(response).to have_http_status(200)
-    end
+          parameter name: 'filter[arrest_summons_number]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'prosecution_case.json#/definitions/arrest_summons_number'
+                    },
+                    description: 'Searches prosecution cases by arrest summons number'
 
-    context 'including defendants' do
-      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants') }
-      it 'matches the given schema' do
-        get api_internal_v1_prosecution_cases_path, params: query_with_defendants, headers: valid_auth_header
-        expect(response.body).to be_valid_against_schema(schema: schema)
-        expect(response).to have_http_status(200)
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[arrest_summons_number]') { 'arrest123' }
+
+          run_test! do |response|
+            expect(response.body).to be_valid_against_schema(schema: schema)
+          end
+        end
       end
-    end
 
-    context 'including defendants and offences' do
-      let(:query_with_defendants) { valid_query_params.merge(include: 'defendants,defendants.offences') }
-      it 'matches the given schema' do
-        get api_internal_v1_prosecution_cases_path, params: query_with_defendants, headers: valid_auth_header
-        expect(response.body).to be_valid_against_schema(schema: schema)
-        expect(response).to have_http_status(200)
+      context 'search by national_insurance_number' do
+        response(200, 'Success') do
+          around do |example|
+            VCR.use_cassette('search_prosecution_case/by_national_insurance_number_success') do
+              example.run
+            end
+          end
+
+          parameter name: 'filter[national_insurance_number]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/nino'
+                    },
+                    description: 'Searches prosecution cases by national_insurance_number'
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[national_insurance_number]') { 'BN102966C' }
+
+          run_test! do |response|
+            expect(response.body).to be_valid_against_schema(schema: schema)
+          end
+        end
+      end
+
+      context 'search by name and date of birth' do
+        response(200, 'Success') do
+          around do |example|
+            VCR.use_cassette('search_prosecution_case/by_name_and_date_of_birth_success') do
+              example.run
+            end
+          end
+
+          parameter name: 'filter[first_name]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/first_name'
+                    },
+                    description: 'Searches prosecution cases by first_name'
+
+          parameter name: 'filter[last_name]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/last_name'
+                    },
+                    description: 'Searches prosecution cases by last_name'
+
+          parameter name: 'filter[date_of_birth]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/date_of_birth'
+                    },
+                    description: 'Searches prosecution cases by date_of_birth'
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[first_name]') { 'Alfredine' }
+          let(:'filter[last_name]') { 'Parker' }
+          let(:'filter[date_of_birth]') { '1971-05-12' }
+
+          run_test! do |response|
+            expect(response.body).to be_valid_against_schema(schema: schema)
+          end
+        end
+      end
+
+      context 'search by name and date of next hearing' do
+        response(200, 'Success') do
+          around do |example|
+            VCR.use_cassette('search_prosecution_case/by_name_and_date_of_next_hearing_success') do
+              example.run
+            end
+          end
+
+          parameter name: 'filter[first_name]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/first_name'
+                    },
+                    description: 'Searches prosecution cases by first_name'
+
+          parameter name: 'filter[last_name]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'defendant.json#/definitions/last_name'
+                    },
+                    description: 'Searches prosecution cases by last_name'
+
+          parameter name: 'filter[date_of_next_hearing]', in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': 'prosecution_case.json#/definitions/date_of_next_hearing'
+                    },
+                    description: 'Searches prosecution cases by date_of_next_hearing'
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[first_name]') { 'Alfredine' }
+          let(:'filter[last_name]') { 'Parker' }
+          let(:'filter[date_of_next_hearing]') { '2025-05-04' }
+
+          run_test! do |response|
+            expect(response.body).to be_valid_against_schema(schema: schema)
+          end
+        end
+      end
+
+      context 'unauthorized request' do
+        response('401', 'Unauthorized') do
+          let(:Authorization) { nil }
+
+          run_test!
+        end
       end
     end
   end

--- a/spec/support/authorised_request_helper.rb
+++ b/spec/support/authorised_request_helper.rb
@@ -9,4 +9,8 @@ module AuthorisedRequestHelper
     access_token = Doorkeeper::Application.create(name: 'test').access_tokens.create!
     { 'Authorization': "Bearer #{access_token.token}" }
   end
+
+  def access_token
+    Doorkeeper::Application.create(name: 'test').access_tokens.create!
+  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+
+      securityDefinitions: {
+        oauth: {
+          in: :header,
+          type: :oauth2,
+          require: true,
+          description: 'OAuth2 client credentials flow',
+          flow: 'clientCredentials',
+          scopes: %w[read write],
+          tokenUrl: 'https://localhost:3000/oauth/token'
+        }
+      }
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/swagger/v1/defendant.json
+++ b/swagger/v1/defendant.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defendants",
+  "description": "Defendants",
+  "id": "schemata/defendant",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defendant",
+      "readOnly": true,
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The defendants type",
+      "enum": [
+        "defendants"
+      ],
+      "example": "defendants",
+      "type": "string"
+    },
+    "first_name": {
+      "readOnly": true,
+      "example": "Alfredine",
+      "description": "The fore name when the defendant is a person",
+      "type": "string"
+    },
+    "last_name": {
+      "readOnly": true,
+      "example": "Parker",
+      "description": "The last name when the defendant is a person",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "/schemata/defendant#/definitions/id"
+    },
+    "date_of_birth": {
+      "readOnly": true,
+      "example": "1971-05-12",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "The person date of birth when the defendant is a person",
+          "example": "1954-02-23",
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      ]
+    },
+    "nino": {
+      "readOnly": true,
+      "example": "BN102966C",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "National Insurance Number for a person",
+          "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
+        }
+      ]
+    },
+    "resource": {
+      "description": "object representing a single defendant",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "/schemata/defendant#/definitions/type"
+        },
+        "id": {
+          "$ref": "/schemata/defendant#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "/schemata/defendant#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "first_name": {
+          "$ref": "/schemata/defendant#/definitions/first_name"
+        },
+        "last_name": {
+          "$ref": "/schemata/defendant#/definitions/last_name"
+        },
+        "date_of_birth": {
+          "$ref": "/schemata/defendant#/definitions/date_of_birth"
+        },
+        "national_insurance_number": {
+          "$ref": "/schemata/defendant#/definitions/nino"
+        },
+        "arrest_summons_number": {
+          "$ref": "/schemata/prosecution_case#/definitions/arrest_summons_number"
+        }
+      }
+    }
+  },
+  "relationships": {
+    "type": "object",
+    "properties": {
+      "offences": {
+        "$ref": "/schemata/defendant#/definitions/offence_relationship"
+      }
+    }
+  },
+  "offence_relationship": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "items": {
+          "$ref": "/schemata/defendant#/definitions/offence"
+        },
+        "type": "array"
+      }
+    }
+  },
+  "offence": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "/schemata/offence#/definitions/id"
+      },
+      "type": {
+        "$ref": "/schemata/offence#/definitions/type"
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing defendant.",
+      "href": "/defendants/{(%2Fschemata%2Fdefendant%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "/schemata/defendant#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "first_name": {
+      "$ref": "/schemata/defendant#/definitions/first_name"
+    },
+    "last_name": {
+      "$ref": "/schemata/defendant#/definitions/last_name"
+    },
+    "date_of_birth": {
+      "$ref": "/schemata/defendant#/definitions/date_of_birth"
+    },
+    "national_insurance_number": {
+      "$ref": "/schemata/defendant#/definitions/nino"
+    },
+    "arrest_summons_number": {
+      "$ref": "/schemata/prosecution_case#/definitions/arrest_summons_number"
+    }
+  }
+}

--- a/swagger/v1/oauth.json
+++ b/swagger/v1/oauth.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "title": "OAuth endpoints",
+  "description": "Endpoints for authentication via OAuth",
+  "id": "schemata/oauth",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "auth_success_response": {
+      "description": "Successful Response",
+      "type": "object",
+      "properties": {
+        "access_token": {
+          "example": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+          "description": "Token that can be used to make authenticated requests",
+          "type": "string"
+        },
+        "token_type": {
+          "example": "Bearer",
+          "enum": [
+            "Bearer"
+          ],
+          "description": "Type of token",
+          "type": "string"
+        },
+        "expires_in": {
+          "example": 7200,
+          "description": "Duration of the token validity",
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "when the token was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Request a new access token.",
+      "href": "/oauth/token",
+      "method": "POST",
+      "rel": "create",
+      "schema": {
+        "description": "Params to request a new access token",
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "description": "Grant type for the oauth token request.",
+            "enum": [
+              "client_credentials"
+            ],
+            "example": "client_credentials",
+            "type": "string"
+          },
+          "client_id": {
+            "example": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+            "description": "Client id for authentication",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU",
+            "description": "Client secret for authentication",
+            "type": "string"
+          }
+        },
+        "required": [
+          "grant_type",
+          "client_id",
+          "client_secret"
+        ]
+      },
+      "http_header": {
+        "Content-Type": "application/json"
+      },
+      "targetSchema": {
+        "$ref": "/schemata/oauth#/definitions/auth_success_response"
+      },
+      "title": "authentication"
+    }
+  ]
+}

--- a/swagger/v1/prosecution_case.json
+++ b/swagger/v1/prosecution_case.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Prosecution case search results",
+  "description": "Prosecution case search results",
+  "id": "schemata/prosecution_case",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "resource": {
+      "description": "object representing a single prosecution case",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "/schemata/prosecution_case#/definitions/type"
+        },
+        "id": {
+          "$ref": "/schemata/prosecution_case#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "/schemata/prosecution_case#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "/schemata/prosecution_case#/definitions/relationships"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defendants": {
+          "$ref": "/schemata/prosecution_case#/definitions/defendant_relationship"
+        }
+      }
+    },
+    "defendant_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "/schemata/prosecution_case#/definitions/defendant"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defendant": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "/schemata/defendant#/definitions/id"
+        },
+        "type": {
+          "$ref": "/schemata/defendant#/definitions/type"
+        }
+      }
+    },
+    "resource_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "/schemata/prosecution_case#/definitions/resource"
+          },
+          "type": "array"
+        },
+        "included": {
+          "items": {
+            "anyOf":[
+              {
+                "$ref": "/schemata/defendant#/definitions/resource"
+              },
+              {
+                "$ref": "/schemata/offence#/definitions/resource"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "prosecution_case_reference": {
+          "$ref": "/schemata/prosecution_case#/definitions/prosecution_case_reference"
+        }
+      }
+    },
+    "id": {
+      "description": "Unique identifier of prosecution case provided by HMCTS (prosecutionCaseId)",
+      "readOnly": true,
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The prosecution cases type",
+      "enum": [
+        "prosecution_cases"
+      ],
+      "example": "prosecution_cases",
+      "type": "string"
+    },
+    "arrest_summons_number": {
+      "readOnly": true,
+      "example": "MG25A11223344",
+      "description": "The police arrest summons number when the defendant is a person",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "/schemata/prosecution_case#/definitions/id"
+    },
+    "date_of_next_hearing": {
+      "description": "The date of the next hearing for the defendant",
+      "example": "2025-05-04",
+      "readOnly": true,
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      ]
+    },
+    "prosecution_case_reference": {
+      "readOnly": true,
+      "example": "TFL12345",
+      "description": "The prosecuting authorities reference for their prosecution case that is layed before court.  For example PTI-URN from police/cps cases",
+      "type": "string"
+    },
+    "prosecution_case_search": {
+      "description": "Search query parameters",
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "prosecution_case_reference": {
+              "$ref": "/schemata/prosecution_case#/definitions/prosecution_case_reference"
+            }
+          }
+        },
+        {
+          "properties": {
+            "national_insurance_number": {
+              "$ref": "/schemata/defendant#/definitions/nino"
+            }
+          }
+        },
+        {
+          "properties": {
+            "arrest_summons_number": {
+              "$ref": "/schemata/prosecution_case#/definitions/arrest_summons_number"
+            }
+          }
+        },
+        {
+          "properties": {
+            "first_name": {
+              "$ref": "/schemata/defendant#/definitions/first_name"
+            },
+            "last_name": {
+              "$ref": "/schemata/defendant#/definitions/last_name"
+            },
+            "date_of_birth": {
+              "$ref": "/schemata/defendant#/definitions/date_of_birth"
+            }
+          }
+        },
+        {
+          "properties": {
+            "first_name": {
+              "$ref": "/schemata/defendant#/definitions/first_name"
+            },
+            "last_name": {
+              "$ref": "/schemata/defendant#/definitions/last_name"
+            },
+            "date_of_next_hearing": {
+              "$ref": "/schemata/prosecution_case#/definitions/date_of_next_hearing"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "links": [
+    {
+      "description": "Search prosecution cases.",
+      "href": "/api/internal/v1/prosecution_cases",
+      "method": "GET",
+      "rel": "instances",
+      "title": "List",
+      "schema": {
+        "properties": {
+          "filter": {
+            "$ref": "/schemata/prosecution_case#/definitions/prosecution_case_search"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prosecution_case"
+        ]
+      },
+      "targetSchema": {
+        "$ref": "/schemata/prosecution_case#/definitions/resource_collection"
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+    }
+  ],
+  "properties": {
+    "data": {
+      "$ref": "/schemata/prosecution_case#/definitions/resource"
+    }
+  }
+}

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,95 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/internal/v1/prosecution_cases":
+    get:
+      summary: list prosecution_cases
+      description: Search prosecution cases
+      consumes:
+      - application/json
+      security:
+      - oauth:
+        - read
+      parameters:
+      - name: filter[prosecution_case_reference]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/prosecution_case_reference
+        description: Searches prosecution cases by prosecution case reference
+      - name: filter[arrest_summons_number]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/arrest_summons_number
+        description: Searches prosecution cases by arrest summons number
+      - name: filter[national_insurance_number]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/nino
+        description: Searches prosecution cases by national_insurance_number
+      - name: filter[first_name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/first_name
+        description: Searches prosecution cases by first_name
+      - name: filter[last_name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/last_name
+        description: Searches prosecution cases by last_name
+      - name: filter[date_of_birth]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/date_of_birth
+        description: Searches prosecution cases by date_of_birth
+      - name: filter[first_name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/first_name
+        description: Searches prosecution cases by first_name
+      - name: filter[last_name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/last_name
+        description: Searches prosecution cases by last_name
+      - name: filter[date_of_next_hearing]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/date_of_next_hearing
+        description: Searches prosecution cases by date_of_next_hearing
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized
+securityDefinitions:
+  oauth:
+    in: header
+    type: oauth2
+    require: true
+    description: OAuth2 client credentials flow
+    flow: clientCredentials
+    scopes:
+    - read
+    - write
+    tokenUrl: https://localhost:3000/oauth/token


### PR DESCRIPTION
## What

[CACP-243](https://dsdmoj.atlassian.net/browse/CACP-243)

Draft PR for initial work on adding Swagger to the application:

* install `rswag`
* document the `/api/internal/v1/prosecution_cases` for searching by `prosecution_case_reference`, `arrest_summons_number`,`national_insurance_number`, `first_name`, `last_name`, `date_of_birth` and `date_of_next_hearing`.

To run locally, switch to this branch, start the server `rails s` and browse to http://localhost:3000/api-docs/index.html

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
