### PR TITLE
CACP-233 Define Unlink JSON Schema

### DIFF
--- a/swagger/v1/laa_reference.json
+++ b/swagger/v1/laa_reference.json
@@ -46,6 +46,18 @@
         "relationships": {
           "$ref": "#/definitions/relationships"
         }
+      },
+    },
+    "resource_to_delete": {
+      "description": "object representing a single laa_reference to be deleted",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
       }
     },
     "attributes": {
@@ -97,6 +109,25 @@
         "properties": {
           "data": {
             "$ref": "#/definitions/new_resource"
+          }
+        }
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+    },
+    {
+      "description": "Delete an LaaReference.",
+      "href": "laa_reference.json",
+      "method": "DELETE",
+      "rel": "empty",
+      "title": "Delete",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/resource_to_delete"
           }
         }
       },


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-233)

Adapt the `laa_reference.json` schema to allow for a `DELETE` request to unlink LAA References.

This request includes the LAA Reference to be unlinked but no defendant id, so the change involves a new definition `resource_to_delete`, which replicates the `new_resource` definition with the omission of the defendant relationship.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
