### PR TITLE
Add attributes to laa_reference schema

### DIFF
--- a/swagger/v1/laa_reference.json
+++ b/swagger/v1/laa_reference.json
@@ -30,6 +30,23 @@
       "minimum": 0,
       "maximum": 999999999
     },
+    "user_id": {
+      "example": "example-username",
+      "description": "The user_id of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
+    "unlink_reason_id": {
+      "example": 1,
+      "description": "Id of the reason for unlinking the case",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 7
+    },
+    "unlink_reason_text": {
+      "example": "Linked to incorrect case",
+      "description": "Text describing the reason for unlinking the case",
+      "type": "string"
+    },
     "identity": {
       "$ref": "#/definitions/id"
     },
@@ -65,6 +82,15 @@
       "properties": {
         "maat_reference": {
           "$ref": "#/definitions/maat_reference"
+        },
+        "user_id": {
+          "$ref": "#/definitions/user_id"
+        },
+        "unlink_reason_id": {
+          "$ref": "#/definitions/unlink_reason_id"
+        },
+        "unlink_reason_text": {
+          "$ref": "#/definitions/unlink_reason_text"
         }
       }
     },
@@ -140,6 +166,15 @@
   "properties": {
     "maat_reference": {
       "$ref": "#/definitions/maat_reference"
+    },
+    "user_id": {
+      "$ref": "#/definitions/user_id"
+    },
+    "unlink_reason_id": {
+      "$ref": "#/definitions/unlink_reason_id"
+    },
+    "unlink_reason_text": {
+      "$ref": "#/definitions/unlink_reason_text"
     }
   }
 }


### PR DESCRIPTION
#  What

Adds three extra attributes to the `laa_reference` schema:

`user_id`: the id of the user linking/unlinking the case. This is likely to be an email address. MLRA is restricted to 16 characters for this value but the schema currently has no limit. CDA may need to truncate the string received from VCD before sending it to MLRA.
`unlink_reason_id`: the id of the reason for unlinking a case. An integer code from 1 to 7.
`unlink_reason_text`: the text of the reason for unlinking a case

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
