### PR TITLE
CACP-235 Push unlink requests to SQS

### DIFF
--- a/app/services/sqs/publish_unlink_laa_reference.rb
+++ b/app/services/sqs/publish_unlink_laa_reference.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Sqs
+  class PublishUnlinkLaaReference < ApplicationService
+    def initialize(maat_reference:, user_id:, unlink_reason_id:, unlink_reason_text:)
+      @maat_reference = maat_reference
+      @user_id = user_id
+      @unlink_reason_id = unlink_reason_id
+      @unlink_reason_text = unlink_reason_text
+    end
+
+    def call
+      MessagePublisher.call(message: message)
+    end
+
+    private
+
+    def message
+      {
+        maatId: maat_reference,
+        userId: user_id,
+        unlinkReasonId: unlink_reason_id,
+        unlinkReasonText: unlink_reason_text
+      }
+    end
+
+    attr_reader :maat_reference, :user_id, :unlink_reason_id, :unlink_reason_text
+  end
+end

--- a/spec/services/sqs/publish_unlink_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_unlink_laa_reference_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Sqs::PublishUnlinkLaaReference do
+  let(:maat_reference) { 123_456 }
+  let(:user_id) { 'test@example.com' }
+  let(:unlink_reason_id) { 1 }
+  let(:unlink_reason_text) { 'linked to incorrect case' }
+
+  let(:sqs_payload) do
+    {
+      maatId: maat_reference,
+      userId: user_id,
+      unlinkReasonId: unlink_reason_id,
+      unlinkReasonText: unlink_reason_text
+    }
+  end
+
+  subject { described_class.call(maat_reference: maat_reference, user_id: user_id, unlink_reason_id: unlink_reason_id, unlink_reason_text: unlink_reason_text) }
+
+  it 'triggers a publish call with the sqs payload' do
+    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload)
+    subject
+  end
+end


### PR DESCRIPTION
#  What

[CACP-235](https://dsdmoj.atlassian.net/browse/CACP-235)

Create a `PublishUnlinkLaaReference` class which takes a `maat_reference`, `user_id`, `unlink_reason_id`, and `unlink_reason_text` and creates a message which is pushed to the SQS queue for MAAT-API to consume.

This will be called from a service class which doesn't currently exist yet, so hasn't been wired up. That can be done as part of [CACP-234](https://dsdmoj.atlassian.net/browse/CACP-234) or as a separate change later. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
