### PR TITLE
Expose maat_reference on defendant

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -37,7 +37,9 @@ class Defendant
     offences.map(&:id)
   end
 
-  def linked?
-    offences.map(&:maat_reference).compact.present?
+  def maat_reference
+    return nil if offences == [] || offences.first.maat_reference&.first == 'Z'
+
+    offences.first.maat_reference
   end
 end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -38,8 +38,15 @@ class Defendant
   end
 
   def maat_reference
-    return nil if offences == [] || offences.first.maat_reference&.first == 'Z'
+    _maat_reference unless _maat_reference&.start_with?('Z')
+  end
 
-    offences.first.maat_reference
+  private
+
+  def _maat_reference
+    refs = offences.map(&:maat_reference).uniq.compact
+    raise 'Too many maat references' if refs.size > 1
+
+    refs&.first
   end
 end

--- a/app/serializers/defendant_serializer.rb
+++ b/app/serializers/defendant_serializer.rb
@@ -4,8 +4,7 @@ class DefendantSerializer
   include FastJsonapi::ObjectSerializer
   set_type :defendants
 
-  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number, :arrest_summons_number
-  attribute :is_linked, &:linked?
+  attributes :first_name, :last_name, :date_of_birth, :national_insurance_number, :arrest_summons_number, :maat_reference
 
   has_many :offences, record_type: :offences
 end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -21,7 +21,20 @@ RSpec.describe Defendant, type: :model do
   it { expect(defendant.date_of_birth).to eq('1971-05-12') }
   it { expect(defendant.national_insurance_number).to eq('BN102966C') }
   it { expect(defendant.arrest_summons_number).to eq('ARREST123') }
-  it { expect(defendant.linked?).to eq(false) }
+  it { expect(defendant.maat_reference).to eq(nil) }
+
+  context 'when an offence has no maat reference' do
+    let(:offences) do
+      [instance_double('Offence', maat_reference: nil),
+       instance_double('Offence', maat_reference: nil)]
+    end
+
+    before do
+      allow(defendant).to receive(:offences).and_return(offences)
+    end
+
+    it { expect(defendant.maat_reference).to eq(nil) }
+  end
 
   context 'when an offence has a maat reference' do
     let(:offences) do
@@ -33,6 +46,19 @@ RSpec.describe Defendant, type: :model do
       allow(defendant).to receive(:offences).and_return(offences)
     end
 
-    it { expect(defendant.linked?).to eq(true) }
+    it { expect(defendant.maat_reference).to eq('123123') }
+  end
+
+  context 'when an offence has an unlink maat reference' do
+    let(:offences) do
+      [instance_double('Offence', maat_reference: 'Z123123'),
+       instance_double('Offence', maat_reference: nil)]
+    end
+
+    before do
+      allow(defendant).to receive(:offences).and_return(offences)
+    end
+
+    it { expect(defendant.maat_reference).to eq(nil) }
   end
 end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -21,44 +21,65 @@ RSpec.describe Defendant, type: :model do
   it { expect(defendant.date_of_birth).to eq('1971-05-12') }
   it { expect(defendant.national_insurance_number).to eq('BN102966C') }
   it { expect(defendant.arrest_summons_number).to eq('ARREST123') }
-  it { expect(defendant.maat_reference).to eq(nil) }
+  it { expect(defendant.maat_reference).to be_nil }
 
-  context 'when an offence has no maat reference' do
-    let(:offences) do
-      [instance_double('Offence', maat_reference: nil),
-       instance_double('Offence', maat_reference: nil)]
-    end
-
+  describe '#maat_reference' do
     before do
       allow(defendant).to receive(:offences).and_return(offences)
     end
 
-    it { expect(defendant.maat_reference).to eq(nil) }
-  end
+    context 'with no offences' do
+      let(:offences) { [] }
 
-  context 'when an offence has a maat reference' do
-    let(:offences) do
-      [instance_double('Offence', maat_reference: '123123'),
-       instance_double('Offence', maat_reference: nil)]
+      it { expect(defendant.maat_reference).to be_nil }
     end
 
-    before do
-      allow(defendant).to receive(:offences).and_return(offences)
+    context 'when offence with no maat reference' do
+      let(:offences) do
+        [instance_double('Offence', maat_reference: nil)]
+      end
+
+      it { expect(defendant.maat_reference).to be_nil }
     end
 
-    it { expect(defendant.maat_reference).to eq('123123') }
-  end
+    context 'when there are multiple offences' do
+      context 'with nil and not-nil maat references' do
+        let(:offences) do
+          [instance_double('Offence', maat_reference: '123123'),
+           instance_double('Offence', maat_reference: nil)]
+        end
 
-  context 'when an offence has an unlink maat reference' do
-    let(:offences) do
-      [instance_double('Offence', maat_reference: 'Z123123'),
-       instance_double('Offence', maat_reference: nil)]
+        it { expect(defendant.maat_reference).to eq('123123') }
+      end
+
+      context 'with duplicate maat references' do
+        let(:offences) do
+          [instance_double('Offence', maat_reference: '123123'),
+           instance_double('Offence', maat_reference: nil),
+           instance_double('Offence', maat_reference: '123123')]
+        end
+
+        it { expect(defendant.maat_reference).to eq('123123') }
+      end
+
+      context 'with different maat references' do
+        let(:offences) do
+          [instance_double('Offence', maat_reference: '123123'),
+           instance_double('Offence', maat_reference: nil),
+           instance_double('Offence', maat_reference: '321321')]
+        end
+
+        it { expect { defendant.maat_reference }.to raise_error StandardError, 'Too many maat references' }
+      end
     end
 
-    before do
-      allow(defendant).to receive(:offences).and_return(offences)
-    end
+    context 'when an offence has an unlink maat reference' do
+      let(:offences) do
+        [instance_double('Offence', maat_reference: 'Z123123'),
+         instance_double('Offence', maat_reference: nil)]
+      end
 
-    it { expect(defendant.maat_reference).to eq(nil) }
+      it { expect(defendant.maat_reference).to be_nil }
+    end
   end
 end

--- a/spec/serializer/defendant_serializer_spec.rb
+++ b/spec/serializer/defendant_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DefendantSerializer do
                     date_of_birth: '2012-12-12',
                     national_insurance_number: 'XW858621B',
                     arrest_summons_number: 'MG25A11223344',
-                    linked?: false,
+                    maat_reference: '123123',
                     offence_ids: ['55555'])
   end
 
@@ -23,7 +23,7 @@ RSpec.describe DefendantSerializer do
     it { expect(attribute_hash[:date_of_birth]).to eq('2012-12-12') }
     it { expect(attribute_hash[:national_insurance_number]).to eq('XW858621B') }
     it { expect(attribute_hash[:arrest_summons_number]).to eq('MG25A11223344') }
-    it { expect(attribute_hash[:is_linked]).to eq(false) }
+    it { expect(attribute_hash[:maat_reference]).to eq('123123') }
   end
 
   context 'relationships' do

--- a/swagger/v1/defendant.json
+++ b/swagger/v1/defendant.json
@@ -51,12 +51,6 @@
         }
       ]
     },
-    "is_linked": {
-      "readOnly": true,
-      "example": false,
-      "description": "Boolean indicating if a defendant is linked to a MAAT ID or not",
-      "type": "boolean"
-    },
     "nino": {
       "readOnly": true,
       "example": "BN102966C",
@@ -118,8 +112,8 @@
         "national_insurance_number": {
           "$ref": "#/definitions/nino"
         },
-        "is_linked": {
-          "$ref": "#/definitions/is_linked"
+        "maat_reference": {
+          "$ref": "laa_reference.json#/definitions/maat_reference"
         },
         "arrest_summons_number": {
           "$ref": "prosecution_case.json#/definitions/arrest_summons_number"
@@ -225,8 +219,8 @@
     "national_insurance_number": {
       "$ref": "#/definitions/nino"
     },
-    "is_linked": {
-      "$ref": "#/definitions/is_linked"
+    "maat_reference": {
+      "$ref": "laa_reference.json#/definitions/maat_reference"
     },
     "arrest_summons_number": {
       "$ref": "prosecution_case.json#/definitions/arrest_summons_number"


### PR DESCRIPTION
## What

Fixes https://github.com/ministryofjustice/laa-court-data-adaptor/issues/113

Replace the `is_linked` attribute on the defendant model with `maat_reference`. This returns the `maat_reference` of the defendant's first offence unless the `maat_reference` begins with 'Z' - this indicates that the case has been unlinked, and so `nil` is returned instead.

`is_linked` is no longer required as View Court Data can infer this from the presence (or not) of a `maat_reference`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
