### PR TITLE
Fix swagger oauth url

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
             flows: {
               clientCredentials: {
                 scopes: [],
-                tokenUrl: 'http://localhost:3000/oauth/token'
+                tokenUrl: '/oauth/token'
               }
             }
           }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -253,4 +253,4 @@ components:
       flows:
         clientCredentials:
           scopes: []
-          tokenUrl: http://localhost:3000/oauth/token
+          tokenUrl: "/oauth/token"


### PR DESCRIPTION
## What

Swagger was configured to make oauth calls to `http://localhost:3000/oauth/token`. This causes errors when run on a non-local environment.

This commit changes the config to just `/oauth/token`, which results in correct calls.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
