### PR TITLE
Add rubocop config for new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,12 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
   - 'spec/**/*'
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/AbcSize:
   Exclude:
   - 'db/migrate/*'


### PR DESCRIPTION
## What

Add config for new cops to prevents warning below on running rubocop:

```
The following cops were added to RuboCop, but are not configured.
Please set Enabled to either `true` or `false` in your `.rubocop.yml`
file:
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
