### PR TITLE
Allow AWS_REGION to be set regardless of missing credentials

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/deployment.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/deployment.yaml
@@ -95,9 +95,9 @@ spec:
                 secretKeyRef:
                   name: ca-messaging-queues-output
                   key: secret_access_key
+            {{- end }}
             - name: AWS_REGION
               value: {{ .Values.sqs_region }}
-            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## What

As AWS_REGION is not provided by the k8s secret, it can be set regardless of other credentials.
This will prevent the link calls to not blow up in non dev environments while we wait for queues to be set up.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
