### PR TITLE
Add services to handle hearing events endpoint in CP

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Hearing < ApplicationRecord
-  validates :body, presence: true
+  validates :body, presence: true, unless: :events?
+  validates :events, presence: true, unless: :body?
 end

--- a/app/services/api/get_hearing_events.rb
+++ b/app/services/api/get_hearing_events.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  class GetHearingEvents < ApplicationService
+    def initialize(hearing_id:)
+      @hearing_id = hearing_id
+      @response = HearingEventsFetcher.call(hearing_id: hearing_id)
+    end
+
+    def call
+      HearingEventsRecorder.call(hearing_id: hearing_id, events: response.body) if successful_response?
+    end
+
+    private
+
+    def successful_response?
+      response.status == 200
+    end
+
+    attr_reader :hearing_id, :response
+  end
+end

--- a/app/services/hearing_events_fetcher.rb
+++ b/app/services/hearing_events_fetcher.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class HearingEventsFetcher < ApplicationService
+  URL = '/LAAGetHearingLogHttpTrigger'
+
+  def initialize(hearing_id:, shared_key: ENV['SHARED_SECRET_KEY_HEARING'], connection: CommonPlatformConnection.call)
+    @params = { hearingId: hearing_id }
+    @headers = { 'Ocp-Apim-Subscription-Key' => shared_key }
+    @connection = connection
+  end
+
+  def call
+    connection.get(URL, params, headers)
+  end
+
+  private
+
+  attr_reader :params, :headers, :connection
+end

--- a/app/services/hearing_events_recorder.rb
+++ b/app/services/hearing_events_recorder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HearingEventsRecorder < ApplicationService
+  def initialize(hearing_id:, events:)
+    @hearing = Hearing.find_or_initialize_by(id: hearing_id)
+    @events = events
+  end
+
+  def call
+    hearing.update(events: events)
+    hearing
+  end
+
+  private
+
+  attr_reader :hearing, :events
+end

--- a/db/migrate/20200424095754_add_events_to_hearing.rb
+++ b/db/migrate/20200424095754_add_events_to_hearing.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEventsToHearing < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :hearings, :body, true
+    add_column :hearings, :events, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -57,9 +57,10 @@ CREATE SEQUENCE public.dummy_maat_reference_seq
 
 CREATE TABLE public.hearings (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    body jsonb NOT NULL,
+    body jsonb,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    events jsonb
 );
 
 
@@ -331,6 +332,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200304144205'),
 ('20200310210135'),
 ('20200310222258'),
-('20200407083117');
+('20200407083117'),
+('20200424095754');
 
 

--- a/spec/cassettes/hearing_events_fetcher/success.yml
+++ b/spec/cassettes/hearing_events_fetcher/success.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingLogHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY_HEARING>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"213560198105189e02ba592a8e352873"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - e90714e0-43b8-490e-982b-4f7437b60867
+      x-runtime:
+      - '0.519503'
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"hearingLog":[{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"1b9c50c4-ad3d-41d2-b511-0af069b3ccaa","recordedLabel":"Est
+        architecto deserunt suscipit.","eventTime":"2020-04-24T09:44:54.745+00:00"},{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"9156b842-0559-4bfb-b8b9-e7751ee7a6f4","recordedLabel":"Tempora
+        architecto autem tempore.","eventTime":"2020-04-24T09:44:54.771+00:00"},{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"cb84e410-ac56-4b57-8fc5-5549c5aba60c","recordedLabel":"Id
+        qui sint iste.","eventTime":"2020-04-24T09:44:54.780+00:00"}]}'
+    http_version: null
+  recorded_at: Fri, 24 Apr 2020 09:45:08 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/hearing_events_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_events_fetcher/unauthorised.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingLogHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Ocp-Apim-Subscription-Key:
+      - INCORRECT KEY
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      content-type:
+      - text/html
+      cache-control:
+      - no-cache
+      x-request-id:
+      - f2474096-fad5-42b4-972b-42812fe1379c
+      x-runtime:
+      - '0.045009'
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: null
+  recorded_at: Fri, 24 Apr 2020 09:45:08 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/hearing_logs_fetcher/success.yml
+++ b/spec/cassettes/hearing_logs_fetcher/success.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingLogHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY_HEARING>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"213560198105189e02ba592a8e352873"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 3739539b-3c3e-4b37-abcf-f0439814ad07
+      x-runtime:
+      - '0.034013'
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"hearingLog":[{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"1b9c50c4-ad3d-41d2-b511-0af069b3ccaa","recordedLabel":"Est
+        architecto deserunt suscipit.","eventTime":"2020-04-24T09:44:54.745+00:00"},{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"9156b842-0559-4bfb-b8b9-e7751ee7a6f4","recordedLabel":"Tempora
+        architecto autem tempore.","eventTime":"2020-04-24T09:44:54.771+00:00"},{"hearingId":"ab746921-d839-4867-bcf9-b41db8ebc852","hearingEventDefinitionId":"cb84e410-ac56-4b57-8fc5-5549c5aba60c","recordedLabel":"Id
+        qui sint iste.","eventTime":"2020-04-24T09:44:54.780+00:00"}]}'
+    http_version: null
+  recorded_at: Fri, 24 Apr 2020 10:02:33 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/hearing_logs_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_logs_fetcher/unauthorised.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingLogHttpTrigger?hearingId=ab746921-d839-4867-bcf9-b41db8ebc852"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Ocp-Apim-Subscription-Key:
+      - INCORRECT KEY
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      content-type:
+      - text/html
+      cache-control:
+      - no-cache
+      x-request-id:
+      - dd6bd443-a6e2-41d7-9b26-8ed83a57abf7
+      x-runtime:
+      - '0.003491'
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: null
+  recorded_at: Fri, 24 Apr 2020 10:02:33 GMT
+recorded_with: VCR 5.1.0

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Hearing, type: :model do
+  let(:hearing) { described_class.new(body: '{}') }
+  subject { hearing }
+
   describe 'validations' do
     it { should validate_presence_of(:body) }
+
+    context 'when the body is missing' do
+      before { hearing.body = nil }
+      it { should validate_presence_of(:events) }
+    end
   end
 end

--- a/spec/services/api/get_hearing_events_spec.rb
+++ b/spec/services/api/get_hearing_events_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::GetHearingEvents do
+  subject { described_class.call(hearing_id: hearing_id) }
+
+  let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }
+
+  let(:response) { double(body: { amazing_body: true }.to_json, status: 200) }
+
+  before do
+    allow(HearingEventsFetcher).to receive(:call).with(hearing_id: hearing_id).and_return(response)
+  end
+
+  it 'calls the HearingEventsRecorder service' do
+    expect(HearingEventsRecorder).to receive(:call).with(hearing_id: hearing_id, events: response.body)
+    subject
+  end
+
+  context 'when the status is a 404' do
+    let(:response) { double(body: {}.to_json, status: 404) }
+
+    it 'does not record the result' do
+      expect(HearingEventsRecorder).not_to receive(:call)
+      subject
+    end
+  end
+end

--- a/spec/services/hearing_events_fetcher_spec.rb
+++ b/spec/services/hearing_events_fetcher_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe HearingEventsFetcher do
+  subject { described_class.call(hearing_id: hearing_id) }
+
+  let(:hearing_id) { 'ab746921-d839-4867-bcf9-b41db8ebc852' }
+
+  it 'returns the requested hearing info' do
+    VCR.use_cassette('hearing_logs_fetcher/success') do
+      expect(subject.body['hearingLog'].map { |x| x['hearingId'] }).to all eq(hearing_id)
+    end
+  end
+
+  context 'with a incorrect key' do
+    subject { described_class.call(hearing_id: hearing_id, shared_key: 'INCORRECT KEY') }
+
+    it 'returns an unauthorised response' do
+      VCR.use_cassette('hearing_logs_fetcher/unauthorised') do
+        expect(subject.status).to eq(401)
+      end
+    end
+  end
+
+  context 'connection' do
+    subject { described_class.call(hearing_id: hearing_id, shared_key: 'SECRET KEY', connection: connection) }
+
+    let(:connection) { double('CommonPlatformConnection') }
+    let(:url) { '/LAAGetHearingLogHttpTrigger' }
+    let(:params) { { hearingId: hearing_id } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key' => 'SECRET KEY' } }
+
+    it 'makes a get request' do
+      expect(connection).to receive(:get).with(url, params, headers)
+      subject
+    end
+  end
+end

--- a/spec/services/hearing_events_recorder_spec.rb
+++ b/spec/services/hearing_events_recorder_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe HearingEventsRecorder do
+  let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
+  let(:events) { { response: 'text' }.to_json }
+
+  subject { described_class.call(hearing_id: hearing_id, events: events) }
+
+  it 'creates a Hearing' do
+    expect {
+      subject
+    }.to change(Hearing, :count).by(1)
+  end
+
+  it 'returns the created Hearing' do
+    expect(subject).to be_a(Hearing)
+  end
+
+  it 'saves the events on the Hearing' do
+    expect(subject.events).to eq(events)
+  end
+
+  context 'when the Hearing exists' do
+    let!(:hearing) { Hearing.create!(id: hearing_id, body: { amazing_body: true }) }
+
+    it 'does not create a new record' do
+      expect {
+        subject
+      }.to change(Hearing, :count).by(0)
+    end
+
+    it 'updates Hearing with new response' do
+      subject
+      expect(hearing.reload.events).to eq(events)
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-330)
Complements https://github.com/ministryofjustice/hmcts-common-platform-mock-api/pull/163
1. Add a service to trigger the Hearing log endpoint in CP.
2. Record the response for replay functionality similar to GET Hearings.

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
