### PR TITLE
Enable Rubocop v0.82 cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
   - 'vendor/**/*'
   - 'node_modules/**/*'
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
   - 'spec/**/*'
@@ -42,6 +45,9 @@ Style/BlockDelimiters:
 Style/Documentation:
   Exclude:
   - '**/*'
+
+Style/ExponentialNotation:
+  Enabled: true
 
 Style/SymbolArray:
   EnforcedStyle: percent


### PR DESCRIPTION
## What

Enable the following cops to prevent warnings when Rubocop is run:

 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Style/ExponentialNotation (0.82)

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
