### PR TITLE
Remove deprecated rswag config

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -23,7 +23,6 @@ RSpec.configure do |config|
         version: 'v1'
       },
       paths: {},
-      securityDefinitions: { oAuth: {} },
       components: {
         securitySchemes: {
           oAuth: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -249,8 +249,6 @@ paths:
           application/vnd.api+json:
             schema:
               "$ref": representation_order.json#/definitions/new_resource
-securityDefinitions:
-  oAuth: {}
 components:
   securitySchemes:
     oAuth:


### PR DESCRIPTION
## What

Running rspec gives this error:

```DEPRECATION WARNING: Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)```

`components/securitySchemes` already exists, so this PR simply removes
the securityDefinitions entry from `swagger_helper.rb`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
