### PR TITLE
CACP-332 - add contract validation to hearing requests

### DIFF
--- a/app/contracts/hearing_contract.rb
+++ b/app/contracts/hearing_contract.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class HearingContract < Dry::Validation::Contract
+  option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
+
+  JURISDICTION_TYPES = %w[MAGISTRATES CROWN].freeze
+  HEARING_TYPES = %w[PLE SEN REV TRL TIS APN BRE EBW GRH STE APL PTR FCM JGT PLY PTP FHG CON].freeze
+
+  json do
+    required(:hearing).hash do
+      required(:id).value(:string)
+      required(:jurisdictionType).value(:string)
+      required(:courtCentre).hash do
+        required(:id).value(:string)
+      end
+      required(:type).hash do
+        required(:id).value(:string)
+        optional(:code).value(:string)
+        optional(:description).value(:string)
+      end
+      required(:hearingDays).array(:hash) do
+        required(:sittingDay).value(:date_time)
+        optional(:listingSequence).value(:integer)
+        required(:listedDurationMinutes).value(:integer)
+      end
+    end
+    required(:sharedTime).value(:date_time)
+  end
+
+  rule('hearing.id') do
+    key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
+  end
+
+  rule('hearing.jurisdictionType') do
+    key.failure('is not a valid jurisdictionType') unless JURISDICTION_TYPES.include? value
+  end
+
+  rule('hearing.courtCentre.id') do
+    key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
+  end
+
+  rule('hearing.type.id') do
+    key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
+  end
+
+  rule('hearing.type.code') do
+    key.failure('is not a valid hearing code') unless !key? || (HEARING_TYPES.include? value)
+  end
+end

--- a/app/controllers/api/external/v1/hearings_controller.rb
+++ b/app/controllers/api/external/v1/hearings_controller.rb
@@ -5,12 +5,12 @@ module Api
     module V1
       class HearingsController < ApplicationController
         def create
-          @hearing = HearingRecorder.call(params[:hearing][:id], hearing_params)
-
-          if @hearing.valid?
-            head :created
+          contract = HearingContract.new.call(**transformed_params)
+          if contract.success?
+            @hearing = HearingRecorder.call(params[:hearing][:id], hearing_params)
+            head :accepted
           else
-            render json: @hearing.errors, status: :unprocessable_entity
+            render json: contract.errors.to_hash, status: :unprocessable_entity
           end
         end
 
@@ -20,6 +20,10 @@ module Api
         def hearing_params
           params.require(%i[sharedTime hearing])
           params.permit(:sharedTime, hearing: {})
+        end
+
+        def transformed_params
+          hearing_params.to_hash.transform_keys(&:to_sym).compact
         end
       end
     end

--- a/spec/contracts/hearing_contract_spec.rb
+++ b/spec/contracts/hearing_contract_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+RSpec.describe HearingContract do
+  subject { described_class.new.call(hash_for_validation) }
+
+  let(:hash_for_validation) do
+    {
+      hearing: {
+        id: hearing_id,
+        jurisdictionType: jurisdiction_type,
+        courtCentre: court_centre,
+        type: type,
+        hearingDays: [hearing_days]
+      },
+      sharedTime: shared_time
+    }
+  end
+  let(:hearing_id) { '224b9e22-8957-11ea-bc55-0242ac130003' }
+  let(:jurisdiction_type) { 'MAGISTRATES' }
+  let(:court_centre) { { id: '28746ab8-8957-11ea-bc55-0242ac130003' } }
+  let(:type) do
+    {
+      id: type_id,
+      code: type_code,
+      description: type_description
+    }
+  end
+  let(:type_id) { '2eb85d9e-8957-11ea-bc55-0242ac130003' }
+  let(:type_code) { 'PLE' }
+  let(:type_description) { 'Plea' }
+  let(:hearing_days) do
+    {
+      sittingDay: sitting_day,
+      listingSequence: listing_sequence,
+      listedDurationMinutes: listed_duration_minutes
+    }
+  end
+  let(:sitting_day) { '2018-10-24 10:00:00' }
+  let(:listing_sequence) { 1 }
+  let(:listed_duration_minutes) { 120 }
+  let(:shared_time) { '2018-10-25 11:30:00' }
+
+  it { is_expected.to be_a_success }
+
+  context 'without a hearing id' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          jurisdictionType: jurisdiction_type,
+          courtCentre: court_centre,
+          type: type,
+          hearingDays: [hearing_days]
+        },
+        sharedTime: shared_time
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid hearing id' do
+    let(:hearing_id) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a jurisdictionType' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          id: hearing_id,
+          courtCentre: court_centre,
+          type: type,
+          hearingDays: [hearing_days]
+        },
+        sharedTime: shared_time
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid jurisdictionType' do
+    let(:jurisdiction_type) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a courtCentre' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          id: hearing_id,
+          jurisdictionType: jurisdiction_type,
+          type: type,
+          hearingDays: [hearing_days]
+        },
+        sharedTime: shared_time
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid courtCentre id' do
+    let(:court_centre) { { id: 'TEST' } }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a type' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          id: hearing_id,
+          jurisdictionType: jurisdiction_type,
+          courtCentre: court_centre,
+          hearingDays: [hearing_days]
+        },
+        sharedTime: shared_time
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a type id' do
+    let(:type) do
+      {
+        code: type_code,
+        description: type_description
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid type id' do
+    let(:type_id) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a type code' do
+    let(:type) do
+      {
+        id: type_id,
+        description: type_description
+      }
+    end
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'with an invalid type code' do
+    let(:type_code) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a type description' do
+    let(:type) do
+      {
+        id: type_id,
+        code: type_code
+      }
+    end
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'without hearingDays' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          id: hearing_id,
+          jurisdictionType: jurisdiction_type,
+          courtCentre: court_centre,
+          type: type
+        },
+        sharedTime: shared_time
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without hearingDays sittingDay' do
+    let(:hearing_days) do
+      {
+        listingSequence: listing_sequence,
+        listedDurationMinutes: listed_duration_minutes
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid hearingDays sittingDay' do
+    let(:sitting_day) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a hearingDays listingSequence' do
+    let(:hearing_days) do
+      {
+        sittingDay: sitting_day,
+        listedDurationMinutes: listed_duration_minutes
+      }
+    end
+    it { is_expected.to be_a_success }
+  end
+
+  context 'with an invalid hearingDays listingSequence' do
+    let(:listing_sequence) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a hearingDays listedDurationMinutes' do
+    let(:hearing_days) do
+      {
+        sittingDay: sitting_day,
+        listingSequence: listing_sequence
+      }
+    end
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid hearingDays listedDurationMinutes' do
+    let(:listed_duration_minutes) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'without a sharedTime' do
+    let(:hash_for_validation) do
+      {
+        hearing: {
+          id: hearing_id,
+          jurisdictionType: jurisdiction_type,
+          courtCentre: court_centre,
+          type: type,
+          hearingDays: [hearing_days]
+        }
+      }
+    end
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with an invalid sharedTime' do
+    let(:shared_time) { 'TEST' }
+
+    it { is_expected.not_to be_a_success }
+  end
+end

--- a/spec/controllers/api/external/v1/hearings_controller_spec.rb
+++ b/spec/controllers/api/external/v1/hearings_controller_spec.rb
@@ -7,34 +7,36 @@ RSpec.describe Api::External::V1::HearingsController, type: :controller do
 
   let(:valid_attributes) { JSON.parse(file_fixture('valid_hearing.json').read) }
   let(:invalid_attributes) { JSON.parse(file_fixture('invalid_hearing.json').read) }
+  let(:unprocessable_attributes) { JSON.parse(file_fixture('unprocessable_hearing.json').read) }
 
   describe 'POST #create' do
     context 'with valid params' do
       it 'creates a new Hearing' do
         expect {
-          post :create, params: valid_attributes
+          post :create, params: valid_attributes, as: :json
         }.to change(Hearing, :count).by(1)
       end
 
       it 'renders a JSON response with an empty response' do
-        post :create, params: valid_attributes
-        expect(response).to have_http_status(:created)
+        post :create, params: valid_attributes, as: :json
         expect(response.body).to be_empty
+        expect(response).to have_http_status(:accepted)
       end
     end
 
     context 'with an invalid hearing' do
       it 'renders a JSON response with an unprocessable_entity error' do
         allow(HearingRecorder).to receive(:call).and_return(Hearing.new)
-        post :create, params: valid_attributes
-        expect(response.body).to include("can't be blank")
+        post :create, params: unprocessable_attributes, as: :json
+        expect(response.body).to include('must be an integer')
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
     context 'with invalid params' do
       it 'renders a JSON response with errors for the new hearing' do
-        post :create, params: invalid_attributes
+        post :create, params: invalid_attributes, as: :json
+        expect(response.body).to include('param is missing or the value is empty')
         expect(response).to have_http_status(:bad_request)
       end
     end

--- a/spec/fixtures/files/unprocessable_hearing.json
+++ b/spec/fixtures/files/unprocessable_hearing.json
@@ -12,7 +12,7 @@
       },
       "hearingDays": [{
           "sittingDay": "2018-10-24 10:00:00",
-          "listingSequence": 1,
+          "listingSequence": "test",
           "listedDurationMinutes": 120
       }]
   },

--- a/spec/requests/api/external/v1/hearings_spec.rb
+++ b/spec/requests/api/external/v1/hearings_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'api/external/v1/hearings', type: :request do
       tags 'External - available to Common Platform'
       security [oAuth: []]
 
-      response(201, 'Created') do
+      response(202, 'Accepted') do
         parameter name: :shared_time, in: :body, required: false, type: :object,
                   schema: {
                     '$ref': 'hearing_resulted.json#/definitions/new_resource'
@@ -25,6 +25,15 @@ RSpec.describe 'api/external/v1/hearings', type: :request do
         let(:shared_time) { JSON.parse(file_fixture('valid_hearing.json').read) }
 
         run_test!
+      end
+
+      context 'unprocessable entity' do
+        response('422', 'Unprocessable Entity') do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:shared_time) { JSON.parse(file_fixture('unprocessable_hearing.json').read) }
+
+          run_test!
+        end
       end
 
       context 'invalid data' do

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -18,8 +18,11 @@ paths:
       - oAuth: []
       parameters: []
       responses:
-        '201':
-          description: Created
+        '202':
+          description: Accepted
+          content: {}
+        '422':
+          description: Unprocessable Entity
           content: {}
         '400':
           description: Bad Request


### PR DESCRIPTION
## What

First step of [CACP-332](https://dsdmoj.atlassian.net/browse/CACP-332)

This PR adds a contract to validate hearings updates from common platform - this currently only validates mandatory data, which probably isn't sufficient but can be expanded as other functionality is added.

It amends the `HearingController` class to use the new contract to validate request data, and makes minor changes to specs and swagger as a result
 - adds a missing test scenario to `hearings_spec.rb`
 - adds an extra fixture to allow differentiation between invalid and unprocesseable hearings
 - returns HTTP202 (Accepted) instead of 201 (Created) in line with other controllers

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
