### PR TITLE
Allow maat_reference to be an integer cast as a string

### DIFF
--- a/app/contracts/new_laa_reference_contract.rb
+++ b/app/contracts/new_laa_reference_contract.rb
@@ -3,7 +3,7 @@
 class NewLaaReferenceContract < Dry::Validation::Contract
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
 
-  json do
+  params do
     optional(:maat_reference).value(:integer, lt?: 999_999_999)
     required(:defendant_id).value(:string)
   end

--- a/spec/contracts/new_laa_reference_contract_spec.rb
+++ b/spec/contracts/new_laa_reference_contract_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe NewLaaReferenceContract do
 
   it { is_expected.to be_a_success }
 
+  context 'with a maat_reference cast as a string' do
+    let(:maat_reference) { '123456789' }
+
+    it { is_expected.to be_a_success }
+  end
+
   context 'with an alphanumeric maat_reference' do
     let(:maat_reference) { 'ABC123' }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-299)
Allow VCD to send across integers as strings which can be typecast by using `params` in our validators.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
