### PR TITLE
Fix defence organisation to match transformed fixture

### DIFF
--- a/app/models/defence_organisation.rb
+++ b/app/models/defence_organisation.rb
@@ -6,7 +6,7 @@ class DefenceOrganisation
   attr_accessor :body
 
   def id
-    body['laa_contract_number']
+    body['laaContractNumber']
   end
 
   def name

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -32,7 +32,7 @@ class Defendant
   def defence_organisation
     return unless representation_order_exists?
 
-    DefenceOrganisation.new(body: case_reference.defence_organisation)
+    DefenceOrganisation.new(body: case_reference.defence_organisation) if case_reference.defence_organisation.present?
   end
 
   def representation_order_date

--- a/spec/fixtures/files/defence_organisation.json
+++ b/spec/fixtures/files/defence_organisation.json
@@ -1,9 +1,9 @@
 {
-  "laa_contract_number": "CONTRACT REFERENCE",
-  "sra_number": "SRA NUMBER",
-  "bar_council_membership_number": "BAR COUNCIL NUMBER",
-  "incorporation_number": "AAA",
-  "registered_charity_number": "BBB",
+  "laaContractNumber": "CONTRACT REFERENCE",
+  "sraNumber": "SRA NUMBER",
+  "barCouncilMembershipNumber": "BAR COUNCIL NUMBER",
+  "incorporationNumber": "AAA",
+  "registeredCharityNumber": "BBB",
   "organisation": {
     "name": "SOME ORGANISATION",
     "address": {
@@ -18,8 +18,8 @@
       "home": "+99999",
       "work": "CALL ME 888",
       "mobile": "+99999",
-      "primary_email": "a@example.com",
-      "secondary_email": "a@example.com",
+      "primaryEmail": "a@example.com",
+      "secondaryEmail": "a@example.com",
       "fax": "ABC123123"
     }
   }

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -33,27 +33,35 @@ RSpec.describe Defendant, type: :model do
         [instance_double('Offence', maat_reference: '123123')]
       end
 
-      it { expect(defendant.maat_reference).to eq('123123') }
       before do
         ProsecutionCase.create!(id: prosecution_case_hash['prosecutionCaseId'], body: '{}')
-        ProsecutionCaseDefendantOffence.create!(prosecution_case_id: prosecution_case_hash['prosecutionCaseId'],
-                                                defendant_id: defendant_hash['defendantId'],
-                                                offence_id: SecureRandom.uuid,
-                                                status_date: '2019-12-12',
-                                                defence_organisation: defence_organisation)
       end
 
-      let(:defence_organisation) do
-        {
-          'organisation' => {
-            'name' => 'SOME ORGANISATION'
-          },
-          'laa_contract_number' => 'CONTRACT REFERENCE'
-        }
-      end
+      it { expect(defendant.maat_reference).to eq('123123') }
+      it { expect(defendant.representation_order_date).to be_nil }
+      it { expect(defendant.defence_organisation_id).to be_nil }
 
-      it { expect(defendant.representation_order_date).to eq('2019-12-12') }
-      it { expect(defendant.defence_organisation_id).to eq('CONTRACT REFERENCE') }
+      context 'when a representation_order is recorded' do
+        before do
+          ProsecutionCaseDefendantOffence.create!(prosecution_case_id: prosecution_case_hash['prosecutionCaseId'],
+                                                  defendant_id: defendant_hash['defendantId'],
+                                                  offence_id: SecureRandom.uuid,
+                                                  status_date: '2019-12-12',
+                                                  defence_organisation: defence_organisation)
+        end
+
+        let(:defence_organisation) do
+          {
+            'organisation' => {
+              'name' => 'SOME ORGANISATION'
+            },
+            'laaContractNumber' => 'CONTRACT REFERENCE'
+          }
+        end
+
+        it { expect(defendant.representation_order_date).to eq('2019-12-12') }
+        it { expect(defendant.defence_organisation_id).to eq('CONTRACT REFERENCE') }
+      end
     end
 
     context 'when there are multiple offences' do


### PR DESCRIPTION
## What
1. As the data sent to CDA is transformed to camelCase before sending over to CP, the database record contains the camelised version.
2. Fix exception occuring on linked cases (without a rep order) by ensuring the relationship between defendant and defence organisation is only populated if it exists.

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
