### PR TITLE
Expose plea and plea_date on offences

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -29,9 +29,21 @@ class Offence
     laa_reference['applicationReference'] if laa_reference.present?
   end
 
+  def plea
+    plea_hash['pleaValue'] if plea_hash.present?
+  end
+
+  def plea_date
+    plea_hash['pleaDate'] if plea_hash.present?
+  end
+
   private
 
   def laa_reference
     body['laaApplnReference']
+  end
+
+  def plea_hash
+    body['plea']
   end
 end

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -4,5 +4,5 @@ class OffenceSerializer
   include FastJsonapi::ObjectSerializer
   set_type :offences
 
-  attributes :code, :order_index, :title, :mode_of_trial
+  attributes :code, :order_index, :title, :mode_of_trial, :plea, :plea_date
 end

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe OffenceSerializer do
                     code: 'AA06001',
                     order_index: '0',
                     title: 'Fail to wear protective clothing',
-                    mode_of_trial: 'Indictable-Only Offence')
+                    mode_of_trial: 'Indictable-Only Offence',
+                    plea: 'GUILTY',
+                    plea_date: '2020-01-01')
   end
 
   subject { described_class.new(offence).serializable_hash }
@@ -19,5 +21,7 @@ RSpec.describe OffenceSerializer do
     it { expect(attribute_hash[:order_index]).to eq('0') }
     it { expect(attribute_hash[:title]).to eq('Fail to wear protective clothing') }
     it { expect(attribute_hash[:mode_of_trial]).to eq('Indictable-Only Offence') }
+    it { expect(attribute_hash[:plea]).to eq('GUILTY') }
+    it { expect(attribute_hash[:plea_date]).to eq('2020-01-01') }
   end
 end

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -57,6 +57,23 @@
         }
       ]
     },
+    "plea": {
+      "readOnly": true,
+      "description": "The defendant's plea for a specific offence",
+      "example": "GUILTY",
+      "type": "string",
+      "enum": [
+        "GUILTY",
+        "NOT_GUILTY"
+      ]
+    },
+    "plea_date": {
+      "readOnly": true,
+      "description": "The date the defendant entered the plea",
+      "example": "2020-02-01",
+      "type": "string",
+      "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+    },
     "resource": {
       "description": "object representing a single offence",
       "type": "object",
@@ -86,6 +103,12 @@
         },
         "title": {
           "$ref": "#/definitions/title"
+        },
+        "plea": {
+          "$ref": "#/definitions/plea"
+        },
+        "plea_date": {
+          "$ref": "#/definitions/plea_date"
         }
       }
     }
@@ -114,6 +137,12 @@
     },
     "title": {
       "$ref": "offence.json#/definitions/title"
+    },
+    "plea": {
+      "$ref": "offence.json#/definitions/plea"
+    },
+    "plea_date": {
+      "$ref": "offence.json#/definitions/plea_date"
     }
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-354)

Expose `plea` and `plea_date` on offences so that they can be displayed in View Court Data. 

Add them to `offence` model, serializer and schema.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
