### PR TITLE
Allow fetching hearings if added to inclusions

### DIFF
--- a/app/controllers/api/internal/v1/hearings_controller.rb
+++ b/app/controllers/api/internal/v1/hearings_controller.rb
@@ -5,7 +5,7 @@ module Api
     module V1
       class HearingsController < ApplicationController
         def show
-          @hearing = Api::GetHearingResults.call(params[:id])
+          @hearing = Api::GetHearingResults.call(hearing_id: params[:id])
           render json: HearingSerializer.new(@hearing, serialization_options)
         end
 

--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -20,9 +20,13 @@ module Api
         end
 
         def serialization_options
-          return { include: params[:include].split(',') } if params[:include].present?
+          return { include: inclusions, params: { inclusions: inclusions } } if params[:include].present?
 
           {}
+        end
+
+        def inclusions
+          params[:include].split(',')
         end
       end
     end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -3,7 +3,7 @@
 class Defendant
   include ActiveModel::Model
 
-  attr_accessor :body
+  attr_accessor :body, :details
 
   def id
     body['defendantId']
@@ -26,7 +26,7 @@ class Defendant
   end
 
   def offences
-    body['offenceSummary'].map { |offence| Offence.new(body: offence) }
+    body['offenceSummary'].map { |offence| Offence.new(body: offence, details: offence_details.dig(offence['offenceId'])) }
   end
 
   def defence_organisation
@@ -54,6 +54,12 @@ class Defendant
   end
 
   private
+
+  def offence_details
+    return {} if details.blank?
+
+    details.dig('offences')&.map { |offence| [offence['id'], offence] }&.to_h
+  end
 
   def valid_maat_reference?
     _maat_reference.present? && !_maat_reference.start_with?('Z')

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -3,7 +3,7 @@
 class Offence
   include ActiveModel::Model
 
-  attr_accessor :body
+  attr_accessor :body, :details
 
   def id
     body['offenceId']
@@ -30,11 +30,11 @@ class Offence
   end
 
   def plea
-    plea_hash['pleaValue'] if plea_hash.present?
+    plea_hash.dig('pleaValue')
   end
 
   def plea_date
-    plea_hash['pleaDate'] if plea_hash.present?
+    plea_hash.dig('pleaDate')
   end
 
   private
@@ -44,6 +44,8 @@ class Offence
   end
 
   def plea_hash
-    body['plea']
+    return {} if details.blank?
+
+    details.dig('plea') || {}
   end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -4,7 +4,7 @@ class ProsecutionCase < ApplicationRecord
   validates :body, presence: true
 
   def defendants
-    body['defendantSummary'].map { |defendant| Defendant.new(body: defendant) }
+    body['defendantSummary'].map { |defendant| Defendant.new(body: defendant, details: defendant_details.dig(defendant['defendantId'])) }
   end
 
   def defendant_ids
@@ -12,14 +12,46 @@ class ProsecutionCase < ApplicationRecord
   end
 
   def hearing_summaries
-    body['hearingSummary'].map { |hearing_summary| HearingSummary.new(body: hearing_summary) }
+    body.dig('hearingSummary')&.map { |hearing_summary| HearingSummary.new(body: hearing_summary) } || []
   end
 
   def hearing_summary_ids
     hearing_summaries.map(&:id)
   end
 
+  def hearings
+    hearing_results.select(&:body)
+  end
+
+  def hearing_ids
+    hearings.map(&:id)
+  end
+
   def prosecution_case_reference
     body['prosecutionCaseReference']
+  end
+
+  private
+
+  def case_details
+    hearings.flat_map do |hearing|
+      hearing.body['prosecutionCases'].select { |prosecution_case| prosecution_case['id'] == id }
+    end
+  end
+
+  def hearings_fetched?
+    @hearing_results.present?
+  end
+
+  def defendant_details
+    return {} unless hearings_fetched?
+
+    case_details.flat_map { |detail| detail['defendants'] }.map { |detail| [detail['id'], detail] }.to_h
+  end
+
+  def hearing_results
+    @hearing_results ||= hearing_summary_ids.map do |hearing_id|
+      Api::GetHearingResults.call(hearing_id: hearing_id)
+    end
   end
 end

--- a/app/serializers/prosecution_case_serializer.rb
+++ b/app/serializers/prosecution_case_serializer.rb
@@ -8,4 +8,5 @@ class ProsecutionCaseSerializer
 
   has_many :defendants, record_type: :defendants
   has_many :hearing_summaries, record_type: :hearing_summaries
+  has_many :hearings, record_type: :hearings, if: proc { |_record, params| params[:inclusions].try(:include?, 'hearings') }
 end

--- a/app/services/api/get_hearing_results.rb
+++ b/app/services/api/get_hearing_results.rb
@@ -2,7 +2,7 @@
 
 module Api
   class GetHearingResults < ApplicationService
-    def initialize(hearing_id)
+    def initialize(hearing_id:)
       @hearing_id = hearing_id
       @response = HearingFetcher.call(hearing_id: hearing_id)
     end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -8,12 +8,19 @@ RSpec.describe Defendant, type: :model do
     prosecution_case_hash['defendantSummary'][0]
   end
 
-  subject(:defendant) { described_class.new(body: defendant_hash) }
+  let(:details_hash) { nil }
+
+  subject(:defendant) { described_class.new(body: defendant_hash, details: details_hash) }
 
   it { expect(defendant.name).to eq('George Walsh') }
   it { expect(defendant.date_of_birth).to eq('1980-01-01') }
   it { expect(defendant.national_insurance_number).to eq('HB133542A') }
   it { expect(defendant.arrest_summons_number).to eq('ARREST123') }
+
+  it 'initialises Offence without details' do
+    expect(Offence).to receive(:new).with(body: defendant_hash['offenceSummary'][0], details: nil)
+    defendant.offences
+  end
 
   context 'post linking' do
     let(:offences) do
@@ -104,6 +111,25 @@ RSpec.describe Defendant, type: :model do
       it { expect(defendant.maat_reference).to be_nil }
       it { expect(defendant.representation_order_date).to be_nil }
       it { expect(defendant.defence_organisation).to be_nil }
+    end
+  end
+
+  context 'when details are available' do
+    let(:details_hash) do
+      {
+        'offences' => [
+          {
+            'id' => '3f153786-f3cf-4311-bc0c-2d6f48af68a1',
+            'offenceCode' => 'TR68107',
+            'modeOfTrial' => 'Summary'
+          }
+        ]
+      }
+    end
+
+    it 'initialises Offence with details' do
+      expect(Offence).to receive(:new).with(body: defendant_hash['offenceSummary'][0], details: details_hash['offences'][0])
+      defendant.offences
     end
   end
 end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hearing, type: :model do
 
     let(:hearing) do
       VCR.use_cassette('hearing_result_fetcher/success') do
-        Api::GetHearingResults.call(hearing_id)
+        Api::GetHearingResults.call(hearing_id: hearing_id)
       end
     end
 

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -19,13 +19,17 @@ RSpec.describe Offence, type: :model do
     }
   end
 
-  subject(:offence) { described_class.new(body: offence_hash) }
+  let(:details_hash) { nil }
+
+  subject(:offence) { described_class.new(body: offence_hash, details: details_hash) }
 
   it { expect(offence.code).to eq('AA06001') }
   it { expect(offence.order_index).to eq(1) }
   it { expect(offence.title).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
   it { expect(offence.mode_of_trial).to eq('Indictable-Only Offence') }
   it { expect(offence.maat_reference).to be_nil }
+  it { expect(offence.plea).to be_nil }
+  it { expect(offence.plea_date).to be_nil }
 
   context 'with an LAA reference' do
     let(:laa_reference) do
@@ -43,5 +47,19 @@ RSpec.describe Offence, type: :model do
     subject(:offence) { described_class.new(body: offence_hash.merge(laa_reference)) }
 
     it { expect(offence.maat_reference).to eq('AB746921') }
+  end
+
+  context 'when details are available' do
+    let(:details_hash) do
+      {
+        'plea' => {
+          'pleaDate' => '2020-04-24',
+          'pleaValue' => 'GUILTY'
+        }
+      }
+    end
+
+    it { expect(offence.plea).to eq('GUILTY') }
+    it { expect(offence.plea_date).to eq('2020-04-24') }
   end
 end

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -6,14 +6,73 @@ RSpec.describe ProsecutionCase, type: :model do
   end
 
   describe 'Common Platform search' do
-    let(:prosecution_case) do
+    let(:prosecution_case_result) do
       VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
-        Api::SearchProsecutionCase.call(prosecution_case_reference: '19GD1001816').first
+        ProsecutionCaseSearcher.call(prosecution_case_reference: '19GD1001816')
       end
     end
+
+    let(:prosecution_case) { described_class.create(id: '31cbe62d-b1ec-4e82-89f7-99dced834900', body: prosecution_case_result.body['cases'][0]) }
 
     it { expect(prosecution_case.prosecution_case_reference).to eq('19GD1001816') }
     it { expect(prosecution_case.defendants).to all be_a(Defendant) }
     it { expect(prosecution_case.hearing_summaries).to all be_a(HearingSummary) }
+
+    it 'initialises Defendants without details' do
+      expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil).twice.and_call_original
+      prosecution_case.defendants
+    end
+
+    context 'requesting hearing resulted' do
+      let(:hearing_ids) { %w[311bb2df-4df5-4abe-bae3-82f144e1e5c5 c6cf04b5-901d-4a89-a9ab-767eb57306e4] }
+
+      before do
+        allow(prosecution_case).to receive(:hearing_summary_ids).and_return(hearing_ids)
+        allow(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_ids[0]).and_return(hearing_one)
+        allow(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_ids[1]).and_return(hearing_two)
+      end
+
+      let(:hearing_one) do
+        Hearing.create(
+          id: hearing_ids[0],
+          body: {
+            'id' => hearing_ids[0],
+            'prosecutionCases' => [{
+              'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
+              'defendants' => [{
+                'id' => 'c6cf04b5-901d-4a89-a9ab-767eb57306e4'
+              }]
+            }]
+          }
+        )
+      end
+
+      let(:hearing_two) do
+        Hearing.create(
+          id: hearing_ids[1],
+          body: {
+            'id' => hearing_ids[1],
+            'prosecutionCases' => [{
+              'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
+              'defendants' => [{
+                'id' => 'b70a36e5-13d3-4bb3-bb24-94db79b7708b'
+              }]
+            }]
+          }
+        )
+      end
+
+      it { expect(prosecution_case.hearings).to all be_a(Hearing) }
+      it { expect(prosecution_case.hearing_ids).to eq(hearing_ids) }
+
+      context 'when hearings are loaded' do
+        before { prosecution_case.hearings }
+
+        it 'initialises Defendants with detailed fetched from hearing' do
+          expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: an_instance_of(Hash)).twice
+          prosecution_case.defendants
+        end
+      end
+    end
   end
 end

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProsecutionCaseSerializer do
                     id: 'UUID',
                     prosecution_case_reference: 'AAA',
                     defendant_ids: ['DEFENDANT-UUID'],
+                    hearing_ids: ['HEARING-UUID'],
                     hearing_summary_ids: ['HEARING-UUID'])
   end
 
@@ -22,5 +23,12 @@ RSpec.describe ProsecutionCaseSerializer do
 
     it { expect(relationship_hash[:defendants][:data]).to eq([id: 'DEFENDANT-UUID', type: :defendants]) }
     it { expect(relationship_hash[:hearing_summaries][:data]).to eq([id: 'HEARING-UUID', type: :hearing_summaries]) }
+    it { expect(relationship_hash[:hearings]).to be_nil }
+
+    context 'when hearings are expected in inclusions' do
+      subject { described_class.new(prosecution_case, params: { inclusions: 'hearings' }).serializable_hash }
+
+      it { expect(relationship_hash[:hearings][:data]).to eq([id: 'HEARING-UUID', type: :hearings]) }
+    end
   end
 end

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::GetHearingResults do
-  subject { described_class.call(hearing_id) }
+  subject { described_class.call(hearing_id: hearing_id) }
 
   let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }
 

--- a/swagger/v1/prosecution_case.json
+++ b/swagger/v1/prosecution_case.json
@@ -131,9 +131,16 @@
     },
     "arrest_summons_number": {
       "readOnly": true,
-      "example": "MG25A11223344",
       "description": "The police arrest summons number when the defendant is a person",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "example": "MG25A11223344"
+        }
+      ]
     },
     "identity": {
       "$ref": "#/definitions/id"

--- a/swagger/v1/schema.json
+++ b/swagger/v1/schema.json
@@ -687,10 +687,15 @@
         },
         "arrest_summons_number": {
           "readOnly": true,
-          "example": "MG25A11223344",
           "description": "The police arrest summons number when the defendant is a person",
-          "type": [
-            "string"
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "example": "MG25A11223344"
+            }
           ]
         },
         "identity": {


### PR DESCRIPTION
## What
Introduces a `hearings` relationship on ProsecutionCase. This can be used to query Search + GET Hearings endpoint and returning the information found in the hearings data.
The information fetched from `hearings` is sent across to the respective models as `details` (as opposed to `body` originating in the search summary)

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-354)

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
