### PR TITLE
Refactor inactive flag

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -16,7 +16,6 @@ class HearingsCreator < ApplicationService
         next if defendant[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z')
 
         push_to_sqs(shared_time: shared_time,
-                    case_status: prosecution_case[:caseStatus],
                     case_urn: prosecution_case[:prosecutionCaseIdentifier][:caseURN],
                     defendant: defendant)
       end
@@ -25,12 +24,11 @@ class HearingsCreator < ApplicationService
 
   private
 
-  def push_to_sqs(shared_time:, case_status:, case_urn:, defendant:)
+  def push_to_sqs(shared_time:, case_urn:, defendant:)
     return unless jurisdiction_type == 'MAGISTRATES'
 
     Sqs::PublishMagistratesHearing.call(shared_time: shared_time,
                                         jurisdiction_type: jurisdiction_type,
-                                        case_status: case_status,
                                         case_urn: case_urn,
                                         defendant: defendant)
   end

--- a/app/services/sqs/publish_magistrates_hearing.rb
+++ b/app/services/sqs/publish_magistrates_hearing.rb
@@ -8,10 +8,9 @@ module Sqs
     TEMPORARY_OFFENCE_CLASSIFICATION = 'Temporary Offence Classification'
     TEMPORARY_SESSION_VALIDATE_DATE = '2020-01-01'
 
-    def initialize(shared_time:, jurisdiction_type:, case_status:, case_urn:, defendant:)
+    def initialize(shared_time:, jurisdiction_type:, case_urn:, defendant:)
       @shared_time = shared_time
       @jurisdiction_type = jurisdiction_type
-      @case_status = case_status
       @case_urn = case_urn
       @defendant = defendant
     end
@@ -23,7 +22,7 @@ module Sqs
     private
 
     def inactive?
-      case_status == 'Open' ? 'N' : 'Y'
+      jurisdiction_type == 'MAGISTRATES' ? 'N' : 'Y'
     end
 
     def defendant_details
@@ -141,7 +140,7 @@ module Sqs
       }
     end
 
-    attr_reader :shared_time, :jurisdiction_type, :case_status, :case_urn, :defendant
+    attr_reader :shared_time, :jurisdiction_type, :case_urn, :defendant
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe HearingsCreator do
   let(:prosecution_case_array) do
     [
       {
-        caseStatus: 'Open',
         prosecutionCaseIdentifier: {
           caseURN: '12345'
         },
@@ -32,7 +31,6 @@ RSpec.describe HearingsCreator do
     it 'calls the Sqs::PublishMagistratesHearing service once' do
       expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_status: 'Open',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
       create
@@ -54,12 +52,10 @@ RSpec.describe HearingsCreator do
     it 'calls the Sqs::PublishLaaReference service twice' do
       expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_status: 'Open',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
       expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_status: 'Open',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.last))
       create
@@ -70,14 +66,12 @@ RSpec.describe HearingsCreator do
     let(:prosecution_case_array) do
       [
         {
-          caseStatus: 'Open',
           prosecutionCaseIdentifier: {
             caseURN: '12345'
           },
           defendants: defendant_array
         },
         {
-          caseStatus: 'Closed',
           prosecutionCaseIdentifier: {
             caseURN: '54321'
           },
@@ -91,12 +85,10 @@ RSpec.describe HearingsCreator do
     it 'calls the Sqs::PublishMagistratesHearing service twice' do
       expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_status: 'Open',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
       expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_status: 'Closed',
                                                                                         case_urn: '54321',
                                                                                         defendant: defendant_array.first))
       create

--- a/spec/services/sqs/publish_magistrates_hearing_spec.rb
+++ b/spec/services/sqs/publish_magistrates_hearing_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe Sqs::PublishMagistratesHearing do
   let(:shared_time) { '2018-10-25 11:30:00' }
   let(:jurisdiction_type) { 'MAGISTRATES' }
-  let(:case_status) { 'Open' }
   let(:case_urn) { '12345' }
   let(:defendant) do
     {
@@ -139,7 +138,7 @@ RSpec.describe Sqs::PublishMagistratesHearing do
     }
   end
 
-  subject { described_class.call(shared_time: shared_time, jurisdiction_type: jurisdiction_type, case_status: case_status, case_urn: case_urn, defendant: defendant) }
+  subject { described_class.call(shared_time: shared_time, jurisdiction_type: jurisdiction_type, case_urn: case_urn, defendant: defendant) }
 
   before do
     allow(Rails.configuration.x.aws).to receive(:sqs_url_hearing_resulted).and_return('/hearing-resulted-sqs-url')


### PR DESCRIPTION
## What

The `inactive` flag passed to MAAT-API in mag hearing updates is currently derived from the `caseStatus` received from CP.

This is incorrect as the `inactive` flag is used by MLRA to identify if a case is active in the magistrates court, whereas the `caseStatus` in CP. will be active if the case is open in either the mags court _or_ crown court.

This PR amends the `inactive` flag so it is more accurately derived from the court `jurisdictionType` instead of the `caseStatus`, and removes references to `caseStatus` from elsewhere in the code.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
