### PR TITLE
Add offenceId to SQS queue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
   - 'vendor/**/*'
   - 'node_modules/**/*'
 
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 

--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -51,9 +51,11 @@ module Sqs
       }
     end
 
+    # rubocop:disable Metrics/MethodLength
     def offences_map
       defendant.offences.map do |offence|
         [
+          [:offenceId, offence.id],
           [:offenceCode, TEMPORARY_OFFENCE_CODE],
           [:asnSeq, offence.order_index],
           [:offenceShortTitle, offence.title],
@@ -68,6 +70,7 @@ module Sqs
         ].to_h
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def sessions_map
       [{

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Sqs::PublishLaaReference do
         nino: 'HB133542A',
         offences: [
           {
+            offenceId: '3f153786-f3cf-4311-bc0c-2d6f48af68a1',
             offenceCode: 'AA06035',
             modeOfTrial: 1,
             asnSeq: 1,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-370)
Add offenceId to the SQS queue to allow MAAT API to have access to this information when sending a Rep order.

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
