### PR TITLE
Relax validation on representation order data

### DIFF
--- a/app/contracts/new_representation_order_contract.rb
+++ b/app/contracts/new_representation_order_contract.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class NewRepresentationOrderContract < Dry::Validation::Contract
-  option :email_validator, default: -> { CommonPlatform::EmailValidator }
-  option :phone_validator, default: -> { CommonPlatform::PhoneValidator }
-  option :postcode_validator, default: -> { CommonPlatform::PostcodeValidator }
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
   config.validate_keys = true
 
@@ -49,26 +46,6 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
 
   rule(:defendant_id) do
     key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
-  end
-
-  rule('defence_organisation.organisation.address.postcode') do
-    key.failure('is not a valid postcode') if [key?, !postcode_validator.call(postcode: value)].all?
-  end
-
-  rule('defence_organisation.organisation.contact.primary_email') do
-    key.failure('is not a valid email') if [key?, !email_validator.call(email: value)].all?
-  end
-
-  rule('defence_organisation.organisation.contact.secondary_email') do
-    key.failure('is not a valid email') if [key?, !email_validator.call(email: value)].all?
-  end
-
-  rule('defence_organisation.organisation.contact.home') do
-    key.failure('is not a valid phone number') if [key?, !phone_validator.call(phone: value)].all?
-  end
-
-  rule('defence_organisation.organisation.contact.mobile') do
-    key.failure('is not a valid phone number') if [key?, !phone_validator.call(phone: value)].all?
   end
 
   rule(:offences).each do

--- a/app/services/representation_order_creator.rb
+++ b/app/services/representation_order_creator.rb
@@ -6,6 +6,7 @@ class RepresentationOrderCreator < ApplicationService
     @maat_reference = maat_reference
     @defendant_id = defendant_id
     @defence_organisation = defence_organisation.deep_transform_keys { |key| key.to_s.camelize(:lower).to_sym }
+    sanitise_defence_organisation
   end
 
   def call
@@ -32,5 +33,35 @@ class RepresentationOrderCreator < ApplicationService
     end
   end
 
-  attr_reader :defendant_id, :offences, :maat_reference, :defence_organisation
+  def sanitise_defence_organisation
+    sanitise_postcode if defence_organisation.dig(:organisation, :address, :postcode)
+    sanitise_contact_details
+  end
+
+  def sanitise_postcode
+    postcode = defence_organisation.dig(:organisation, :address, :postcode)
+    defence_organisation[:organisation][:address].delete(:postcode) unless CommonPlatform::PostcodeValidator.new(postcode: postcode).call
+  end
+
+  def sanitise_contact_details
+    @contact = defence_organisation.dig(:organisation, :contact)
+    return unless contact
+
+    sanitise_email_addresses
+    sanitise_phone_numbers
+  end
+
+  def sanitise_email_addresses
+    %i[primaryEmail secondaryEmail].each do |email|
+      defence_organisation[:organisation][:contact].delete(email) unless CommonPlatform::EmailValidator.new(email: contact.dig(email)).call
+    end
+  end
+
+  def sanitise_phone_numbers
+    %i[home mobile].each do |number|
+      defence_organisation[:organisation][:contact].delete(number) unless CommonPlatform::PhoneValidator.new(phone: contact.dig(number)).call
+    end
+  end
+
+  attr_reader :defendant_id, :offences, :maat_reference, :defence_organisation, :contact
 end

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -110,31 +110,31 @@ RSpec.describe NewRepresentationOrderContract do
   context 'with an invalid postcode' do
     before { defence_organisation[:organisation][:address][:postcode] = '99999' }
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 
   context 'with an invalid primary_email' do
     before { defence_organisation[:organisation][:contact][:primary_email] = '99999' }
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 
   context 'with an invalid secondary_email' do
     before { defence_organisation[:organisation][:contact][:secondary_email] = '99999' }
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 
   context 'with an invalid home phone' do
     before { defence_organisation[:organisation][:contact][:home] = 'AAABBBCCC' }
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 
   context 'with an invalid mobile phone' do
     before { defence_organisation[:organisation][:contact][:mobile] = 'AAABBBCCC' }
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 
   context 'with unexpected keys' do

--- a/spec/services/representation_order_creator_spec.rb
+++ b/spec/services/representation_order_creator_spec.rb
@@ -94,4 +94,42 @@ RSpec.describe RepresentationOrderCreator do
       create
     end
   end
+
+  context 'with invalid defence_organisation data' do
+    let(:defence_organisation) do
+      {
+        laa_contract_number: 'CONTRACT REFERENCE',
+        organisation: {
+          name: 'SOME ORGANISATION',
+          address: {
+            address1: 'String',
+            postcode: 'Postcode Not Provided'
+          },
+          contact: {
+            home: 'Phone Not Provided',
+            mobile: 'Phone Not Provided',
+            primary_email: 'Email Not Provided',
+            secondary_email: 'Email Not Provided'
+          }
+        }
+      }
+    end
+    let(:transformed_defence_organisation) do
+      {
+        laaContractNumber: 'CONTRACT REFERENCE',
+        organisation: {
+          name: 'SOME ORGANISATION',
+          address: {
+            address1: 'String'
+          },
+          contact: {}
+        }
+      }
+    end
+
+    it 'sanitises the data' do
+      expect(Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      create
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-369)

MAAT API may send invalid representation order data to CDA. At present this causes contract validation failures and rejection of the data, however it is difficult to resolve this in MAAT-API/MLRA.

Instead, this PR relaxes the contract validation and instead strips any invalid data from the payload before sending it to CP.


## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
