### PR TITLE
CACP334 Crown Court Notifications - Trials

### DIFF
--- a/app/services/crown_court_outcome_creator.rb
+++ b/app/services/crown_court_outcome_creator.rb
@@ -23,22 +23,22 @@ class CrownCourtOutcomeCreator < ApplicationService
   private
 
   def result_is_a_conclusion?
-    defendant&.dig(:offences)&.any? { |offence| offence.dig(:verdict).present? }
+    defendant.dig(:offences)&.any? { |offence| offence.dig(:verdict).present? }
   end
 
   def trial_outcome
-    return 'CONVICTED' if defendant&.dig(:offences)&.all? do |offence|
+    return 'CONVICTED' if defendant.dig(:offences)&.all? do |offence|
       GUILTY_VERDICTS.include? offence.dig(:verdict, :verdictType, :categoryType)
     end
-    return 'PART CONVICTED' if defendant&.dig(:offences)&.any? do |offence|
+    return 'PART CONVICTED' if defendant.dig(:offences)&.any? do |offence|
       GUILTY_VERDICTS.include? offence.dig(:verdict, :verdictType, :categoryType)
     end
 
-    'AQUITTED'
+    'AQUITTED' # This incorrect spelling is used in the MAAT database, and so must be used here to ensure compatibility
   end
 
   def case_end_date
-    defendant&.dig(:offences, 0, :verdict, :verdictDate)
+    defendant.dig(:offences, 0, :verdict, :verdictDate)
   end
 
   attr_reader :defendant

--- a/app/services/crown_court_outcome_creator.rb
+++ b/app/services/crown_court_outcome_creator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CrownCourtOutcomeCreator < ApplicationService
+  GUILTY_VERDICTS = %w[GUILTY_BUT_OF_LESSER_OFFENCE_BY_JURY_CONVICTED
+                       GUILTY_CONVICTED
+                       GUILTY_BY_JURY_CONVICTED
+                       GUILTY_BUT_OF_LESSER_OFFENCE_CONVICTED].freeze
+
+  def initialize(defendant:)
+    @defendant = defendant
+  end
+
+  def call
+    return unless result_is_a_conclusion?
+
+    {
+      ccooOutcome: trial_outcome,
+      caseEndDate: case_end_date,
+      appealType: nil
+    }
+  end
+
+  private
+
+  def result_is_a_conclusion?
+    defendant&.dig(:offences)&.any? { |offence| offence.dig(:verdict).present? }
+  end
+
+  def trial_outcome
+    return 'CONVICTED' if defendant&.dig(:offences)&.all? do |offence|
+      GUILTY_VERDICTS.include? offence.dig(:verdict, :verdictType, :categoryType)
+    end
+    return 'PART CONVICTED' if defendant&.dig(:offences)&.any? do |offence|
+      GUILTY_VERDICTS.include? offence.dig(:verdict, :verdictType, :categoryType)
+    end
+
+    'AQUITTED'
+  end
+
+  def case_end_date
+    defendant&.dig(:offences, 0, :verdict, :verdictDate)
+  end
+
+  attr_reader :defendant
+end

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -26,10 +26,10 @@ class HearingsCreator < ApplicationService
 
   def push_to_sqs(shared_time:, case_urn:, defendant:)
     Sqs::PublishHearing.call(shared_time: shared_time,
-                                        jurisdiction_type: jurisdiction_type,
-                                        case_urn: case_urn,
-                                        defendant: defendant,
-                                        cjs_location: cjs_location)
+                             jurisdiction_type: jurisdiction_type,
+                             case_urn: case_urn,
+                             defendant: defendant,
+                             cjs_location: cjs_location)
   end
 
   def jurisdiction_type
@@ -37,7 +37,7 @@ class HearingsCreator < ApplicationService
   end
 
   def cjs_location
-    @cjs_location ||= hearing.dig(:courtCentre, :ouCode)
+    @cjs_location ||= hearing.dig(:courtCentre, :ouCode)[0..4]
   end
 
   attr_reader :shared_time, :hearing

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -25,9 +25,7 @@ class HearingsCreator < ApplicationService
   private
 
   def push_to_sqs(shared_time:, case_urn:, defendant:)
-    return unless jurisdiction_type == 'MAGISTRATES'
-
-    Sqs::PublishMagistratesHearing.call(shared_time: shared_time,
+    Sqs::PublishHearing.call(shared_time: shared_time,
                                         jurisdiction_type: jurisdiction_type,
                                         case_urn: case_urn,
                                         defendant: defendant,

--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -2,7 +2,7 @@
 
 module Sqs
   # rubocop:disable Metrics/ClassLength
-  class PublishMagistratesHearing < ApplicationService
+  class PublishHearing < ApplicationService
     def initialize(shared_time:, jurisdiction_type:, case_urn:, defendant:, cjs_location:)
       @shared_time = shared_time
       @jurisdiction_type = jurisdiction_type

--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -69,7 +69,8 @@ module Sqs
         docLanguage: 'EN',
         inActive: inactive?,
         defendant: defendant_hash,
-        session: session_hash
+        session: session_hash,
+        ccOutComeData: crown_court_outcome_hash
       }
     end
 
@@ -138,6 +139,10 @@ module Sqs
         postHearingCustody: post_hearing_custody,
         sessionValidateDate: defendant.dig(:offences, 0, :judicialResults, 0, :orderedDate)
       }
+    end
+
+    def crown_court_outcome_hash
+      CrownCourtOutcomeCreator.call(defendant: defendant)
     end
 
     attr_reader :shared_time, :jurisdiction_type, :case_urn, :defendant, :cjs_location

--- a/spec/services/crown_court_outcome_creator_spec.rb
+++ b/spec/services/crown_court_outcome_creator_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe CrownCourtOutcomeCreator do
+  let(:guilty_verdict) do
+    {
+      'verdictDate': '2018-10-25',
+      'verdictType': {
+        'categoryType': 'GUILTY_CONVICTED'
+      }
+    }
+  end
+  let(:not_guilty_verdict) do
+    {
+      'verdictDate': '2018-10-25',
+      'verdictType': {
+        'categoryType': 'NOT_GUILTY'
+      }
+    }
+  end
+  let(:defendant) do
+    {
+      'offences': [
+        {
+          'verdict': guilty_verdict
+        },
+        {
+          'verdict': guilty_verdict
+        }
+      ]
+    }
+  end
+
+  subject(:create) { described_class.call(defendant: defendant) }
+
+  context 'without any verdicts' do
+    let(:defendant) do
+      {
+        'offences': []
+      }
+    end
+    it 'does not create a crown court outcome' do
+      expect(create).to eq nil
+    end
+  end
+
+  context 'with all guilty trial verdicts' do
+    it 'results in a CONVICTED result' do
+      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'CONVICTED' })
+    end
+  end
+
+  context 'with all not guilty trial verdicts' do
+    let(:defendant) do
+      {
+        'offences': [
+          {
+            'verdict': not_guilty_verdict
+          },
+          {
+            'verdict': not_guilty_verdict
+          }
+        ]
+      }
+    end
+
+    it 'results in a AQUITTED result' do
+      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'AQUITTED' })
+    end
+  end
+
+  context 'a mix of guity and not guilty trial verdicts' do
+    let(:defendant) do
+      {
+        'offences': [
+          {
+            'verdict': guilty_verdict
+          },
+          {
+            'verdict': not_guilty_verdict
+          }
+        ]
+      }
+    end
+
+    it 'results in a PART CONVICTED result' do
+      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'PART CONVICTED' })
+    end
+  end
+end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe HearingsCreator do
   let(:hearing) do
     {
       jurisdictionType: 'MAGISTRATES',
+      courtCentre: {
+        ouCode: 'B16BG00'
+      },
       prosecutionCases: prosecution_case_array
     }
   end
@@ -30,9 +33,10 @@ RSpec.describe HearingsCreator do
   context 'with one defendant' do
     it 'calls the Sqs::PublishHearing service once' do
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_urn: '12345',
-                                                                                        defendant: defendant_array.first))
+                                                                             jurisdiction_type: 'MAGISTRATES',
+                                                                             case_urn: '12345',
+                                                                             defendant: defendant_array.first,
+                                                                             cjs_location: 'B16BG'))
       create
     end
   end
@@ -49,13 +53,15 @@ RSpec.describe HearingsCreator do
 
     it 'calls the Sqs::PublishLaaReference service twice' do
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_urn: '12345',
-                                                                                        defendant: defendant_array.first))
+                                                                             jurisdiction_type: 'MAGISTRATES',
+                                                                             case_urn: '12345',
+                                                                             defendant: defendant_array.first,
+                                                                             cjs_location: 'B16BG'))
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_urn: '12345',
-                                                                                        defendant: defendant_array.last))
+                                                                             jurisdiction_type: 'MAGISTRATES',
+                                                                             case_urn: '12345',
+                                                                             defendant: defendant_array.last,
+                                                                             cjs_location: 'B16BG'))
       create
     end
   end
@@ -80,13 +86,15 @@ RSpec.describe HearingsCreator do
 
     it 'calls the Sqs::PublishHearing service twice' do
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_urn: '12345',
-                                                                                        defendant: defendant_array.first))
+                                                                             jurisdiction_type: 'MAGISTRATES',
+                                                                             case_urn: '12345',
+                                                                             defendant: defendant_array.first,
+                                                                             cjs_location: 'B16BG'))
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'MAGISTRATES',
-                                                                                        case_urn: '54321',
-                                                                                        defendant: defendant_array.first))
+                                                                             jurisdiction_type: 'MAGISTRATES',
+                                                                             case_urn: '54321',
+                                                                             defendant: defendant_array.first,
+                                                                             cjs_location: 'B16BG'))
       create
     end
   end
@@ -95,15 +103,19 @@ RSpec.describe HearingsCreator do
     let(:hearing) do
       {
         jurisdictionType: 'CROWN',
+        courtCentre: {
+          ouCode: 'B16BG00'
+        },
         prosecutionCases: prosecution_case_array
       }
     end
 
     it 'calls the Sqs::PublishHearing service' do
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                                        jurisdiction_type: 'CROWN',
-                                                                                        case_urn: '12345',
-                                                                                        defendant: defendant_array.first))
+                                                                             jurisdiction_type: 'CROWN',
+                                                                             case_urn: '12345',
+                                                                             defendant: defendant_array.first,
+                                                                             cjs_location: 'B16BG'))
       create
     end
   end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -16,20 +16,20 @@ RSpec.describe HearingsCreator do
     ]
   end
   let(:shared_time) { '2018-10-25 11:30:00' }
-  let(:mags_hearing) do
+  let(:hearing) do
     {
       jurisdictionType: 'MAGISTRATES',
       prosecutionCases: prosecution_case_array
     }
   end
 
-  before { allow(Sqs::PublishMagistratesHearing).to receive(:call) }
+  before { allow(Sqs::PublishHearing).to receive(:call) }
+
+  subject(:create) { described_class.call(sharedTime: shared_time, hearing: hearing) }
 
   context 'with one defendant' do
-    subject(:create) { described_class.call(sharedTime: shared_time, hearing: mags_hearing) }
-
-    it 'calls the Sqs::PublishMagistratesHearing service once' do
-      expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+    it 'calls the Sqs::PublishHearing service once' do
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
@@ -47,14 +47,12 @@ RSpec.describe HearingsCreator do
       ]
     end
 
-    subject(:create) { described_class.call(sharedTime: shared_time, hearing: mags_hearing) }
-
     it 'calls the Sqs::PublishLaaReference service twice' do
-      expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
-      expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.last))
@@ -80,48 +78,49 @@ RSpec.describe HearingsCreator do
       ]
     end
 
-    subject(:create) { described_class.call(sharedTime: shared_time, hearing: mags_hearing) }
-
-    it 'calls the Sqs::PublishMagistratesHearing service twice' do
-      expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+    it 'calls the Sqs::PublishHearing service twice' do
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
                                                                                         case_urn: '12345',
                                                                                         defendant: defendant_array.first))
-      expect(Sqs::PublishMagistratesHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                                         jurisdiction_type: 'MAGISTRATES',
                                                                                         case_urn: '54321',
                                                                                         defendant: defendant_array.first))
       create
     end
+  end
 
-    context 'with a crown court hearing' do
-      let(:mags_hearing) do
-        {
-          jurisdictionType: 'CROWN',
-          prosecutionCases: prosecution_case_array
-        }
-      end
-
-      it 'does not call the Sqs::PublishMagistratesHearing service' do
-        expect(Sqs::PublishMagistratesHearing).not_to receive(:call)
-        create
-      end
+  context 'with a crown court hearing' do
+    let(:hearing) do
+      {
+        jurisdictionType: 'CROWN',
+        prosecutionCases: prosecution_case_array
+      }
     end
 
-    context 'with a dummy MAAT ID' do
-      let(:defendant_array) do
-        [
-          { 'id': 'defendant_one_id',
-            'laaApplnReference': { 'applicationReference': 'A123456789' } },
-          { 'id': 'defendant_two_id',
-            'laaApplnReference': { 'applicationReference': 'Z987654321' } }
-        ]
-      end
+    it 'calls the Sqs::PublishHearing service' do
+      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                                        jurisdiction_type: 'CROWN',
+                                                                                        case_urn: '12345',
+                                                                                        defendant: defendant_array.first))
+      create
+    end
+  end
 
-      it 'does not call the Sqs::PublishMagistratesHearing service' do
-        expect(Sqs::PublishMagistratesHearing).not_to receive(:call)
-        create
-      end
+  context 'with a dummy MAAT ID' do
+    let(:defendant_array) do
+      [
+        { 'id': 'defendant_one_id',
+          'laaApplnReference': { 'applicationReference': 'A123456789' } },
+        { 'id': 'defendant_two_id',
+          'laaApplnReference': { 'applicationReference': 'Z987654321' } }
+      ]
+    end
+
+    it 'does not call the Sqs::PublishHearing service' do
+      expect(Sqs::PublishHearing).not_to receive(:call)
+      create
     end
   end
 end

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Sqs::PublishHearing do
           'allocationDecision': {
             'motReasonCode': 3
           },
+          'verdict': {
+            'verdictDate': '2018-10-25',
+            'verdictType': {
+              'categoryType': 'GUILTY_CONVICTED'
+            }
+          },
           'judicialResults': [
             {
               'cjsCode': '123',
@@ -139,6 +145,11 @@ RSpec.describe Sqs::PublishHearing do
         dateOfHearing: '2018-11-11',
         postHearingCustody: 'R',
         sessionValidateDate: '2018-11-11'
+      },
+      ccOutComeData: {
+        ccooOutcome: 'CONVICTED',
+        caseEndDate: '2018-10-25',
+        appealType: nil
       }
     }
   end

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Sqs::PublishMagistratesHearing do
+RSpec.describe Sqs::PublishHearing do
   let(:shared_time) { '2018-10-25 11:30:00' }
   let(:jurisdiction_type) { 'MAGISTRATES' }
   let(:case_urn) { '12345' }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-334)

Add functionality to include crown court hearing results for trials. This includes 

- refactoring existing classes to remove mention of `magistrates`, as those classes can be reused for crown court results
- adding a new class to handle calculation of crown court outcome data

Not included here is handling crown court appeals. That functionality will be added in a separate PR.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
