### PR TITLE
Cacp 276 generate transaction ID

### DIFF
--- a/app/controllers/api/external/v1/hearings_controller.rb
+++ b/app/controllers/api/external/v1/hearings_controller.rb
@@ -7,7 +7,7 @@ module Api
         def create
           contract = HearingContract.new.call(**transformed_params)
           if contract.success?
-            HearingRecorder.call(params[:hearing][:id], hearing_params)
+            HearingRecorder.call(hearing_id: params[:hearing][:id], body: hearing_params)
             head :accepted
           else
             render json: contract.errors.to_hash, status: :unprocessable_entity

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -7,7 +7,7 @@ module Api
         def update
           contract = UnlinkDefendantContract.new.call(**transformed_params)
           if contract.success?
-            UnlinkLaaReferenceJob.perform_later(**transformed_params)
+            UnlinkLaaReferenceJob.perform_later(body: transformed_params, request_id: Current.request_id)
             render status: :accepted
           else
             render json: contract.errors.to_hash, status: :bad_request

--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -7,7 +7,7 @@ module Api
         def create
           contract = NewLaaReferenceContract.new.call(**transformed_params)
           if contract.success?
-            LaaReferenceCreatorJob.perform_later(**transformed_params)
+            LaaReferenceCreatorJob.perform_later(contract: transformed_params, request_id: Current.request_id)
             render status: :accepted
           else
             render json: contract.errors.to_hash, status: :bad_request

--- a/app/controllers/api/internal/v1/representation_orders_controller.rb
+++ b/app/controllers/api/internal/v1/representation_orders_controller.rb
@@ -7,7 +7,7 @@ module Api
         def create
           contract = NewRepresentationOrderContract.new.call(**transformed_params)
           if contract.success?
-            RepresentationOrderCreatorJob.perform_later(**transformed_params)
+            RepresentationOrderCreatorJob.perform_later(contract: transformed_params, request_id: Current.request_id)
             render status: :accepted
           else
             render json: contract.errors.to_hash, status: :bad_request

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  include ActionController::HttpAuthentication::Token::ControllerMethods
+  before_action :set_transaction_id
   before_action :doorkeeper_authorize!
 
   ERROR_MAPPINGS = {
@@ -12,5 +12,12 @@ class ApplicationController < ActionController::API
     rescue_from klass do |error|
       render json: { error: error }, status: status
     end
+  end
+
+  private
+
+  def set_transaction_id
+    Current.request_id = request.request_id
+    response.set_header('Laa-Transaction-Id', Current.request_id)
   end
 end

--- a/app/jobs/hearings_creator_job.rb
+++ b/app/jobs/hearings_creator_job.rb
@@ -3,7 +3,9 @@
 class HearingsCreatorJob < ApplicationJob
   queue_as :default
 
-  def perform(hearing)
-    HearingsCreator.call(**hearing)
+  def perform(body:, request_id:)
+    Current.set(request_id: request_id) do
+      HearingsCreator.call(**body)
+    end
   end
 end

--- a/app/jobs/laa_reference_creator_job.rb
+++ b/app/jobs/laa_reference_creator_job.rb
@@ -3,7 +3,9 @@
 class LaaReferenceCreatorJob < ApplicationJob
   queue_as :default
 
-  def perform(contract)
-    LaaReferenceCreator.call(**contract)
+  def perform(contract:, request_id:)
+    Current.set(request_id: request_id) do
+      LaaReferenceCreator.call(**contract)
+    end
   end
 end

--- a/app/jobs/representation_order_creator_job.rb
+++ b/app/jobs/representation_order_creator_job.rb
@@ -3,7 +3,9 @@
 class RepresentationOrderCreatorJob < ApplicationJob
   queue_as :default
 
-  def perform(contract)
-    RepresentationOrderCreator.call(**contract)
+  def perform(contract:, request_id:)
+    Current.set(request_id: request_id) do
+      RepresentationOrderCreator.call(**contract)
+    end
   end
 end

--- a/app/jobs/unlink_laa_reference_job.rb
+++ b/app/jobs/unlink_laa_reference_job.rb
@@ -3,7 +3,9 @@
 class UnlinkLaaReferenceJob < ApplicationJob
   queue_as :default
 
-  def perform(contract)
-    LaaReferenceUnlinker.call(**contract)
+  def perform(contract:, request_id:)
+    Current.set(request_id: request_id) do
+      LaaReferenceUnlinker.call(**contract)
+    end
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end

--- a/app/services/api/get_hearing_results.rb
+++ b/app/services/api/get_hearing_results.rb
@@ -8,7 +8,7 @@ module Api
     end
 
     def call
-      HearingRecorder.call(hearing_id, response.body) if successful_response?
+      HearingRecorder.call(hearing_id: hearing_id, body: response.body) if successful_response?
     end
 
     private

--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HearingRecorder < ApplicationService
-  def initialize(hearing_id, body)
+  def initialize(hearing_id:, body:)
     @hearing = Hearing.find_or_initialize_by(id: hearing_id)
     @body = body
   end

--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -8,7 +8,8 @@ class HearingRecorder < ApplicationService
 
   def call
     hearing.update(body: body)
-    HearingsCreatorJob.perform_later(**transformed_body)
+    HearingsCreatorJob.perform_later(body: transformed_body, request_id: Current.request_id)
+
     hearing
   end
 

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -11,7 +11,7 @@ class HearingsCreator < ApplicationService
   # rubocop:enable Naming/VariableName
 
   def call
-    hearing[:prosecutionCases].each do |prosecution_case|
+    hearing[:prosecutionCases]&.each do |prosecution_case|
       prosecution_case[:defendants].each do |defendant|
         next if defendant[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z')
 

--- a/app/services/sqs/message_publisher.rb
+++ b/app/services/sqs/message_publisher.rb
@@ -4,8 +4,8 @@ module Sqs
   class MessagePublisher < ApplicationService
     def initialize(message:, queue_url: nil, sqs_client: Aws::SQS::Client.new)
       @sqs_client = sqs_client
-      @message = message
       @queue_url = queue_url
+      @message = message.merge({ metadata: { laaTransactionId: Current.request_id } })
     end
 
     def call

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  let(:valid_token) { 'TOKENTOKEN' }
-  let(:user) { User.create(name: 'HMCTS USER', auth_token: valid_token) }
-  let(:user_id) { user.id }
-
   it_behaves_like 'an unauthorised request'
+
+  it 'returns an Laa-Transaction-Id on every request' do
+    get :index
+    expect(response.headers).to include('Laa-Transaction-Id')
+  end
 end

--- a/spec/jobs/hearings_creator_job_spec.rb
+++ b/spec/jobs/hearings_creator_job_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe HearingsCreatorJob, type: :job do
   include ActiveJob::TestHelper
   let(:argument_hash) do
     {
-      hearing: 'HASH',
+      hearing: {},
       sharedTime: 'DATETIME'
     }
   end
 
   describe '#perform_later' do
     subject(:job) do
-      described_class.perform_later(argument_hash)
+      described_class.perform_later(body: argument_hash, request_id: 'XYZ')
     end
 
     it 'queues a call to publish the hearing' do
@@ -21,7 +21,12 @@ RSpec.describe HearingsCreatorJob, type: :job do
     end
 
     it 'creates a HearingsCreator object and calls it' do
-      expect(HearingsCreator).to receive(:call).once.with(argument_hash)
+      expect(HearingsCreator).to receive(:call).once.with(argument_hash).and_call_original
+      perform_enqueued_jobs { job }
+    end
+
+    it 'sets the request_id on the Current singleton' do
+      expect(Current).to receive(:set).with(request_id: 'XYZ')
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/jobs/laa_reference_creator_job_spec.rb
+++ b/spec/jobs/laa_reference_creator_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe LaaReferenceCreatorJob, type: :job do
   include ActiveJob::TestHelper
   describe '#perform_later' do
     subject(:job) do
-      described_class.perform_later({ defendant_id: 'LONG-UUID' })
+      described_class.perform_later(contract: { defendant_id: 'LONG-UUID' }, request_id: 'XYZ')
     end
 
     it 'queues a call to update the laa reference' do
@@ -15,6 +15,11 @@ RSpec.describe LaaReferenceCreatorJob, type: :job do
 
     it 'creates a LaaReferenceCreator and calls it' do
       expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: 'LONG-UUID')
+      perform_enqueued_jobs { job }
+    end
+
+    it 'sets the request_id on the Current singleton' do
+      expect(Current).to receive(:set).with(request_id: 'XYZ')
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/jobs/representation_order_creator_job_spec.rb
+++ b/spec/jobs/representation_order_creator_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RepresentationOrderCreatorJob, type: :job do
   end
   describe '#perform_later' do
     subject(:job) do
-      described_class.perform_later(argument_hash)
+      described_class.perform_later(contract: argument_hash, request_id: 'XYZ')
     end
 
     it 'queues a call to update the laa reference' do
@@ -25,6 +25,12 @@ RSpec.describe RepresentationOrderCreatorJob, type: :job do
 
     it 'creates a RepresentationOrderCreator and calls it' do
       expect(RepresentationOrderCreator).to receive(:call).once.with(argument_hash)
+      perform_enqueued_jobs { job }
+    end
+
+    it 'sets the request_id on the Current singleton' do
+      allow(RepresentationOrderCreator).to receive(:call)
+      expect(Current).to receive(:set).with(request_id: 'XYZ')
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/jobs/unlink_laa_reference_job_spec.rb
+++ b/spec/jobs/unlink_laa_reference_job_spec.rb
@@ -2,9 +2,19 @@
 
 RSpec.describe UnlinkLaaReferenceJob, type: :job do
   include ActiveJob::TestHelper
+
+  let(:contract) do
+    {
+      user_name: 'ABC',
+      unlink_reason_code: '1',
+      unlink_reason_text: 'Wrong defendant',
+      defendant_id: 'LONG-UUID'
+    }
+  end
+
   describe '#perform_later' do
     subject(:job) do
-      described_class.perform_later({ defendant_id: 'LONG-UUID' })
+      described_class.perform_later(contract: contract, request_id: 'XYZ')
     end
 
     it 'queues a call to update the laa reference' do
@@ -14,7 +24,13 @@ RSpec.describe UnlinkLaaReferenceJob, type: :job do
     end
 
     it 'creates a LaaReferenceUnlinker and calls it' do
-      expect(LaaReferenceUnlinker).to receive(:call).once.with(defendant_id: 'LONG-UUID')
+      expect(LaaReferenceUnlinker).to receive(:call).once.with(contract)
+      perform_enqueued_jobs { job }
+    end
+
+    it 'sets the request_id on the Current singleton' do
+      allow(LaaReferenceUnlinker).to receive(:call)
+      expect(Current).to receive(:set).with(request_id: 'XYZ')
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Current, type: :model do
+  it { is_expected.to respond_to(:request_id) }
+end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
   include AuthorisedRequestHelper
 
   let(:token) { access_token }
+  let(:mock_unlink_job) { instance_double('UnlinkLaaReferenceJob') }
   let(:id) { '23d7f10a-067a-476e-bba6-bb855674e23b' }
   let(:defendant) do
     {
@@ -18,6 +19,11 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
         }
       }
     }
+  end
+
+  before do
+    allow(UnlinkLaaReferenceJob).to receive(:new).with(hash_including(:request_id)).and_return(mock_unlink_job)
+    allow(mock_unlink_job).to receive(:enqueue)
   end
 
   path '/api/internal/v1/defendants/{id}' do

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
   include AuthorisedRequestHelper
 
   let(:token) { access_token }
-  let(:mock_laa_reference_updater_job) { double LaaReferenceCreatorJob }
+  let(:mock_laa_reference_updater_job) { instance_double('LaaReferenceCreatorJob') }
   let(:laa_reference) do
     {
       data: {
@@ -27,7 +27,7 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
   end
 
   before do
-    allow(LaaReferenceCreatorJob).to receive(:new).and_return(mock_laa_reference_updater_job)
+    allow(LaaReferenceCreatorJob).to receive(:new).with(hash_including(:request_id)).and_return(mock_laa_reference_updater_job)
     allow(mock_laa_reference_updater_job).to receive(:enqueue)
   end
 

--- a/spec/requests/api/internal/v1/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v1/representation_orders_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'api/internal/v1/representation_orders', type: :request, swagger_
   include AuthorisedRequestHelper
 
   let(:token) { access_token }
-  let(:mock_rep_order_creator_job) { double RepresentationOrderCreatorJob }
+  let(:mock_rep_order_creator_job) { instance_double('RepresentationOrderCreatorJob') }
   let(:defence_organisation) do
     {
       laa_contract_number: 'CONTRACT REFERENCE',
@@ -65,7 +65,7 @@ RSpec.describe 'api/internal/v1/representation_orders', type: :request, swagger_
   end
 
   before do
-    allow(RepresentationOrderCreatorJob).to receive(:new).and_return(mock_rep_order_creator_job)
+    allow(RepresentationOrderCreatorJob).to receive(:new).with(hash_including(:request_id)).and_return(mock_rep_order_creator_job)
     allow(mock_rep_order_creator_job).to receive(:enqueue)
   end
 

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::GetHearingResults do
   end
 
   it 'calls the HearingRecorder service' do
-    expect(HearingRecorder).to receive(:call).with(hearing_id, response.body)
+    expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, body: response.body)
     subject
   end
 

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HearingRecorder do
     allow(mock_hearings_creator_job).to receive(:enqueue)
   end
 
-  subject { described_class.call(hearing_id, body) }
+  subject { described_class.call(hearing_id: hearing_id, body: body) }
 
   it 'creates a Hearing' do
     expect {

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe HearingRecorder do
   let(:hearing_id) { 'fa78c710-6a49-4276-bbb3-ad34c8d4e313' }
   let(:body) { { 'response': 'text' } }
-  let(:mock_hearings_creator_job) { double HearingsCreatorJob }
+  let(:mock_hearings_creator_job) { instance_double('HearingsCreatorJob') }
 
   before do
-    allow(HearingsCreatorJob).to receive(:new).and_return(mock_hearings_creator_job)
+    allow(HearingsCreatorJob).to receive(:new).with(hash_including(:request_id)).and_return(mock_hearings_creator_job)
     allow(mock_hearings_creator_job).to receive(:enqueue)
   end
 

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -135,4 +135,19 @@ RSpec.describe HearingsCreator do
       create
     end
   end
+
+  context 'with no prosecution cases' do
+    let(:hearing) do
+      {
+        jurisdictionType: 'CROWN'
+      }
+    end
+
+    subject(:create) { described_class.call(sharedTime: shared_time, hearing: hearing) }
+
+    it 'does not call the Sqs::PublishHearing service' do
+      expect(Sqs::PublishHearing).not_to receive(:call)
+      create
+    end
+  end
 end

--- a/spec/services/sqs/message_publisher_spec.rb
+++ b/spec/services/sqs/message_publisher_spec.rb
@@ -13,8 +13,16 @@ RSpec.describe Sqs::MessagePublisher do
   context 'when the queue url is provided' do
     subject { described_class.call(message: { blah: 'blah' }, queue_url: '/fancy-sqs-url', sqs_client: client_double) }
 
+    before do
+      allow(Current).to receive(:request_id).and_return('XYZ')
+    end
+
+    let(:json_message_body) do
+      '{"blah":"blah","metadata":{"laaTransactionId":"XYZ"}}'
+    end
+
     it 'publishes a message to the sqs queue as json' do
-      expect(client_double).to receive(:send_message).with(queue_url: '/fancy-sqs-url', message_body: '{"blah":"blah"}')
+      expect(client_double).to receive(:send_message).with(queue_url: '/fancy-sqs-url', message_body: json_message_body)
       subject
     end
   end

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -156,12 +156,10 @@ RSpec.describe Sqs::PublishHearing do
 
   subject { described_class.call(shared_time: shared_time, jurisdiction_type: jurisdiction_type, case_urn: case_urn, defendant: defendant, cjs_location: cjs_location) }
 
-  before do
-    allow(Rails.configuration.x.aws).to receive(:sqs_url_hearing_resulted).and_return('/hearing-resulted-sqs-url')
-  end
+  let(:queue_url) { Rails.configuration.x.aws.sqs_url_hearing_resulted }
 
   it 'triggers a publish call with the sqs payload' do
-    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: '/hearing-resulted-sqs-url')
+    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url).and_call_original
     subject
   end
 end

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -50,12 +50,10 @@ RSpec.describe Sqs::PublishLaaReference do
 
   subject { described_class.call(prosecution_case_id: prosecution_case_id, defendant_id: defendant_id, maat_reference: maat_reference) }
 
-  before do
-    allow(Rails.configuration.x.aws).to receive(:sqs_url_link).and_return('/link-sqs-url')
-  end
+  let(:queue_url) { Rails.configuration.x.aws.sqs_url_link }
 
   it 'triggers a publish call with the sqs payload' do
-    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: '/link-sqs-url')
+    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url).and_call_original
     subject
   end
 end

--- a/spec/services/sqs/publish_unlink_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_unlink_laa_reference_spec.rb
@@ -17,12 +17,10 @@ RSpec.describe Sqs::PublishUnlinkLaaReference do
 
   subject { described_class.call(maat_reference: maat_reference, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_reason_text: unlink_reason_text) }
 
-  before do
-    allow(Rails.configuration.x.aws).to receive(:sqs_url_unlink).and_return('/unlink-sqs-url')
-  end
+  let(:queue_url) { Rails.configuration.x.aws.sqs_url_unlink }
 
   it 'triggers a publish call with the sqs payload' do
-    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: '/unlink-sqs-url')
+    expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url).and_call_original
     subject
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-276)

- Adds a model called `Current` based on [`ActiveSupport::CurrentAttributes`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) which enables having a globally available singleton, used to represent a single request.

- All the background jobs that we have running are wrapped in a `Current.request_id` context to ensure that the request_id is sent across to the propogated processes.

- Add an `Laa-Transaction-Id` header which is pretty much a copy of the default rails `X-Request-Id` header, which should be hopefully customisable once Rails 6.1.0 is released.

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.