### PR TITLE
Consume transaction ID originating from view court data or MAAT API

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---require spec_helper
 --require rails_helper

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::API
   private
 
   def set_transaction_id
-    Current.request_id = request.request_id
+    Current.request_id = request.headers['Laa-Transaction-Id'] || request.request_id
     response.set_header('Laa-Transaction-Id', Current.request_id)
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe ApplicationController, type: :controller do
     get :index
     expect(response.headers).to include('Laa-Transaction-Id')
   end
+
+  context 'when the Laa-Transaction-Id is included by an external service' do
+    before do
+      request.headers['Laa-Transaction-Id'] = 'XYZ'
+    end
+
+    it 'returns an Laa-Transaction-Id on every request' do
+      get :index
+      expect(response.headers['Laa-Transaction-Id']).to eq('XYZ')
+    end
+  end
 end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
                   },
                   description: 'Object containing the user_name, unlink_reason_code and unlink_reason_text'
 
+        parameter '$ref' => '#/components/parameters/transaction_id_header'
+
         let(:Authorization) { "Bearer #{token.token}" }
 
         run_test!
@@ -56,6 +58,8 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
           let(:Authorization) { "Bearer #{token.token}" }
           let(:id) { 'X' }
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           run_test!
         end
       end
@@ -63,6 +67,8 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
       context 'unauthorized request' do
         response('401', 'Unauthorized') do
           let(:Authorization) { nil }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/requests/api/internal/v1/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v1/hearings_request_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Api::Internal::V1::Hearings', type: :request do
                   },
                   description: 'The unique identifier of the hearing'
 
+        parameter '$ref' => '#/components/parameters/transaction_id_header'
+
         let(:Authorization) { "Bearer #{token.token}" }
         let(:shared_time) { JSON.parse(file_fixture('valid_hearing.json').read) }
 
@@ -46,6 +48,8 @@ RSpec.describe 'Api::Internal::V1::Hearings', type: :request do
           end
 
           let(:Authorization) { nil }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
                   },
                   description: 'The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings'
 
+        parameter '$ref' => '#/components/parameters/transaction_id_header'
+
         let(:Authorization) { "Bearer #{token.token}" }
 
         run_test!
@@ -61,6 +63,8 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
           before { laa_reference[:data][:attributes].delete(:maat_reference) }
           let(:Authorization) { "Bearer #{token.token}" }
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           run_test!
         end
       end
@@ -70,6 +74,8 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
           let(:Authorization) { "Bearer #{token.token}" }
           before { laa_reference[:data][:attributes][:maat_reference] = 'ABC123123' }
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           run_test!
         end
       end
@@ -77,6 +83,8 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
       context 'unauthorized request' do
         response('401', 'Unauthorized') do
           let(:Authorization) { nil }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/requests/api/internal/v1/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/prosecution_cases_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
                     description: 'Return defendant and offence data through a has_many relationship </br>
                                   eg include=defendants,defendants.offences,defendants.defence_organisation'
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[prosecution_case_reference]') { '19GD1001816' }
           let(:include) { 'defendants,defendants.offences,defendants.defence_organisation' }
@@ -120,6 +122,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
                     },
                     description: 'Searches prosecution cases by arrest summons number'
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[arrest_summons_number]') { 'arrest123' }
 
@@ -142,6 +146,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
                       '$ref': 'defendant.json#/definitions/nino'
                     },
                     description: 'Searches prosecution cases by national_insurance_number'
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[national_insurance_number]') { 'HB133542A' }
@@ -171,6 +177,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
                       '$ref': 'defendant.json#/definitions/date_of_birth'
                     },
                     description: 'Searches prosecution cases by date_of_birth'
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[name]') { 'George Walsh' }
@@ -202,6 +210,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
                     },
                     description: 'Searches prosecution cases by date_of_next_hearing'
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[name]') { 'George Walsh' }
           let(:'filter[date_of_next_hearing]') { '2020-02-17' }
@@ -215,6 +225,8 @@ RSpec.describe 'api/internal/v1/prosecution_cases', type: :request, swagger_doc:
       context 'unauthorized request' do
         response('401', 'Unauthorized') do
           let(:Authorization) { nil }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/requests/api/internal/v1/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v1/representation_orders_request_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe 'api/internal/v1/representation_orders', type: :request, swagger_
                   },
                   description: 'The Representation Order for an offence'
 
+        parameter '$ref' => '#/components/parameters/transaction_id_header'
+
         let(:Authorization) { "Bearer #{token.token}" }
 
         run_test!
@@ -99,6 +101,8 @@ RSpec.describe 'api/internal/v1/representation_orders', type: :request, swagger_
           let(:Authorization) { "Bearer #{token.token}" }
           before { representation_order[:data][:attributes][:maat_reference] = 'ABC123123' }
 
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
           run_test!
         end
       end
@@ -106,6 +110,8 @@ RSpec.describe 'api/internal/v1/representation_orders', type: :request, swagger_
       context 'unauthorized request' do
         response('401', 'Unauthorized') do
           let(:Authorization) { nil }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/support/authorised_request_helper.rb
+++ b/spec/support/authorised_request_helper.rb
@@ -5,11 +5,6 @@ module AuthorisedRequestHelper
     allow(controller).to receive(:doorkeeper_authorize!).and_return(true)
   end
 
-  def valid_auth_header
-    access_token = Doorkeeper::Application.create(name: 'test').access_tokens.create!
-    { 'Authorization': "Bearer #{access_token.token}" }
-  end
-
   def access_token
     Doorkeeper::Application.create(name: 'test').access_tokens.create!
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -36,6 +36,15 @@ RSpec.configure do |config|
               }
             }
           }
+        },
+        parameters: {
+          transaction_id_header: {
+            type: :uuid,
+            name: 'Laa-Transaction-Id',
+            in: :header,
+            required: false,
+            description: 'A unique identifier for an individual request that can be traced across multiple systems'
+          }
         }
       }
     }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -51,6 +51,9 @@ paths:
         schema:
           "$ref": defendant.json#/definitions/id
         description: The unique identifier of the defendant
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '202':
           description: Accepted
@@ -82,6 +85,8 @@ paths:
         schema:
           "$ref": hearing.json#/definitions/id
         description: The unique identifier of the hearing
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '200':
           description: Success
@@ -98,7 +103,11 @@ paths:
       - Internal - available to other LAA applications
       security:
       - oAuth: []
-      parameters: []
+      parameters:
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '202':
           description: Accepted
@@ -144,6 +153,7 @@ paths:
         description: |-
           Return defendant and offence data through a has_many relationship </br>
                                             eg include=defendants,defendants.offences,defendants.defence_organisation
+      - "$ref": "#/components/parameters/transaction_id_header"
       - name: filter[arrest_summons_number]
         in: query
         required: false
@@ -151,6 +161,7 @@ paths:
         schema:
           "$ref": prosecution_case.json#/definitions/arrest_summons_number
         description: Searches prosecution cases by arrest summons number
+      - "$ref": "#/components/parameters/transaction_id_header"
       - name: filter[national_insurance_number]
         in: query
         required: false
@@ -158,6 +169,7 @@ paths:
         schema:
           "$ref": defendant.json#/definitions/nino
         description: Searches prosecution cases by national_insurance_number
+      - "$ref": "#/components/parameters/transaction_id_header"
       - name: filter[name]
         in: query
         required: false
@@ -172,6 +184,7 @@ paths:
         schema:
           "$ref": defendant.json#/definitions/date_of_birth
         description: Searches prosecution cases by date_of_birth
+      - "$ref": "#/components/parameters/transaction_id_header"
       - name: filter[name]
         in: query
         required: false
@@ -186,6 +199,8 @@ paths:
         schema:
           "$ref": prosecution_case.json#/definitions/date_of_next_hearing
         description: Searches prosecution cases by date_of_next_hearing
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '200':
           description: Success
@@ -259,7 +274,10 @@ paths:
       - Internal - available to other LAA applications
       security:
       - oAuth: []
-      parameters: []
+      parameters:
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '202':
           description: Accepted
@@ -285,3 +303,11 @@ components:
         clientCredentials:
           scopes: []
           tokenUrl: "/oauth/token"
+  parameters:
+    transaction_id_header:
+      type: uuid
+      name: Laa-Transaction-Id
+      in: header
+      required: false
+      description: A unique identifier for an individual request that can be traced
+        across multiple systems


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-277)
Consume `Laa-Transaction-Id` header value coming in from LAA applications and ensure that it is sent across to other apps that request it.

Complements #182 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
