### PR TITLE
Cacp 244 versioning oauth endpoints

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
 --require rails_helper
+--format documentation

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --require spec_helper
 --require rails_helper
---format documentation

--- a/app/controllers/v1/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/v1/doorkeeper/authorizations_controller.rb
@@ -1,0 +1,2 @@
+class V1::Doorkeeper::AuthorizationsController < Doorkeeper::AuthorizationsController
+end

--- a/app/controllers/v1/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/v1/doorkeeper/authorizations_controller.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
-class V1
-  class Doorkeeper
-    class AuthorizationsController < Doorkeeper::AuthorizationsController
-    end
-  end
+class V1::Doorkeeper::AuthorizationsController < Doorkeeper::AuthorizationsController
 end

--- a/app/controllers/v1/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/v1/doorkeeper/authorizations_controller.rb
@@ -1,2 +1,8 @@
-class V1::Doorkeeper::AuthorizationsController < Doorkeeper::AuthorizationsController
+# frozen_string_literal: true
+
+class V1
+  class Doorkeeper
+    class AuthorizationsController < Doorkeeper::AuthorizationsController
+    end
+  end
 end

--- a/app/controllers/v1/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/v1/doorkeeper/authorizations_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/ClassAndModuleChildren
+
 class V1::Doorkeeper::AuthorizationsController < Doorkeeper::AuthorizationsController
 end
+
+# rubocop:enable Style/ClassAndModuleChildren

--- a/app/controllers/v1/doorkeeper/token_info_controller.rb
+++ b/app/controllers/v1/doorkeeper/token_info_controller.rb
@@ -1,0 +1,2 @@
+class V1::Doorkeeper::TokenInfoController < Doorkeeper::TokenInfoController
+end

--- a/app/controllers/v1/doorkeeper/token_info_controller.rb
+++ b/app/controllers/v1/doorkeeper/token_info_controller.rb
@@ -1,2 +1,8 @@
-class V1::Doorkeeper::TokenInfoController < Doorkeeper::TokenInfoController
+# frozen_string_literal: true
+
+class V1
+  class Doorkeeper
+    class TokenInfoController < Doorkeeper::TokenInfoController
+    end
+  end
 end

--- a/app/controllers/v1/doorkeeper/token_info_controller.rb
+++ b/app/controllers/v1/doorkeeper/token_info_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/ClassAndModuleChildren
+
 class V1::Doorkeeper::TokenInfoController < Doorkeeper::TokenInfoController
 end
+
+# rubocop:enable Style/ClassAndModuleChildren

--- a/app/controllers/v1/doorkeeper/token_info_controller.rb
+++ b/app/controllers/v1/doorkeeper/token_info_controller.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
-class V1
-  class Doorkeeper
-    class TokenInfoController < Doorkeeper::TokenInfoController
-    end
-  end
+class V1::Doorkeeper::TokenInfoController < Doorkeeper::TokenInfoController
 end

--- a/app/controllers/v1/doorkeeper/tokens_controller.rb
+++ b/app/controllers/v1/doorkeeper/tokens_controller.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
-class V1
-  class Doorkeeper
-    class TokensController < Doorkeeper::TokensController
-    end
-  end
+class V1::Doorkeeper::TokensController < Doorkeeper::TokensController
 end

--- a/app/controllers/v1/doorkeeper/tokens_controller.rb
+++ b/app/controllers/v1/doorkeeper/tokens_controller.rb
@@ -1,0 +1,5 @@
+class V1::Doorkeeper::TokensController < Doorkeeper::TokensController
+end
+
+
+#

--- a/app/controllers/v1/doorkeeper/tokens_controller.rb
+++ b/app/controllers/v1/doorkeeper/tokens_controller.rb
@@ -1,5 +1,8 @@
-class V1::Doorkeeper::TokensController < Doorkeeper::TokensController
+# frozen_string_literal: true
+
+class V1
+  class Doorkeeper
+    class TokensController < Doorkeeper::TokensController
+    end
+  end
 end
-
-
-#

--- a/app/controllers/v1/doorkeeper/tokens_controller.rb
+++ b/app/controllers/v1/doorkeeper/tokens_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/ClassAndModuleChildren
+
 class V1::Doorkeeper::TokensController < Doorkeeper::TokensController
 end
+
+# rubocop:enable Style/ClassAndModuleChildren

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
-  use_doorkeeper
+
+  api_version(module: 'V1', path: { value: 'v1' }, default: true) do
+    use_doorkeeper
+  end
+
   namespace :api do
     namespace :internal do
       api_version(module: 'V1', path: { value: 'v1' }, default: true) do

--- a/spec/routing/v1/doorkeeper/authorize_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/authorize_routing_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe 'routing', type: :routing do
+  it 'routes to #new' do
+    expect(get: '/v1/oauth/authorize').to route_to('v1/doorkeeper/authorizations#new')
+  end
+
+  it 'routes to #show' do
+    expect(get: '/v1/oauth/authorize/native').to route_to('v1/doorkeeper/authorizations#show')
+  end
+
+  it 'routes to #destroy' do
+    expect(delete: '/v1/oauth/authorize/').to route_to('v1/doorkeeper/authorizations#destroy')
+  end
+
+  it 'routes to #create' do
+    expect(post: '/v1/oauth/authorize').to route_to('v1/doorkeeper/authorizations#create')
+  end
+
+
+  context 'when no API version is specified' do
+    it 'routes to #create' do
+      expect(get: '/oauth/authorize').to route_to('v1/doorkeeper/authorizations#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/oauth/authorize/native').to route_to('v1/doorkeeper/authorizations#show')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/oauth/authorize').to route_to('v1/doorkeeper/authorizations#new')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/oauth/authorize').to route_to('v1/doorkeeper/authorizations#destroy')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/oauth/authorize').to route_to('v1/doorkeeper/authorizations#create')
+    end
+  end
+end

--- a/spec/routing/v1/doorkeeper/authorize_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/authorize_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'routing', type: :routing do
   it 'routes to #new' do
     expect(get: '/v1/oauth/authorize').to route_to('v1/doorkeeper/authorizations#new')
@@ -14,7 +16,6 @@ RSpec.describe 'routing', type: :routing do
   it 'routes to #create' do
     expect(post: '/v1/oauth/authorize').to route_to('v1/doorkeeper/authorizations#create')
   end
-
 
   context 'when no API version is specified' do
     it 'routes to #create' do

--- a/spec/routing/v1/doorkeeper/token_info_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/token_info_routing_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe 'routing', type: :routing do
+  it 'routes to #show' do
+    expect(get: '/v1/oauth/token/info').to route_to('v1/doorkeeper/token_info#show')
+  end
+
+  context 'when no API version is specified' do
+    it 'routes to #show' do
+      expect(get: '/oauth/token/info').to route_to('v1/doorkeeper/token_info#show')
+    end
+  end
+end

--- a/spec/routing/v1/doorkeeper/token_info_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/token_info_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'routing', type: :routing do
   it 'routes to #show' do
     expect(get: '/v1/oauth/token/info').to route_to('v1/doorkeeper/token_info#show')

--- a/spec/routing/v1/doorkeeper/token_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/token_routing_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe 'routing', type: :routing do
+
+  it 'routes to #create' do
+    expect(post: '/v1/oauth/token').to route_to('v1/doorkeeper/tokens#create')
+  end
+
+  it 'routes to #revoke' do
+    expect(post: '/v1/oauth/revoke').to route_to('v1/doorkeeper/tokens#revoke')
+  end
+
+  it 'routes to #introspect' do
+    expect(post: '/v1/oauth/introspect').to route_to('v1/doorkeeper/tokens#introspect')
+  end
+
+  context 'when no API version is specified' do
+    it 'routes to #revoke' do
+      expect(post: '/oauth/revoke').to route_to('v1/doorkeeper/tokens#revoke')
+    end
+
+    it 'routes to #introspect' do
+      expect(post: '/oauth/introspect').to route_to('v1/doorkeeper/tokens#introspect')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/oauth/token').to route_to('v1/doorkeeper/tokens#create')
+    end
+  end
+end

--- a/spec/routing/v1/doorkeeper/token_routing_spec.rb
+++ b/spec/routing/v1/doorkeeper/token_routing_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe 'routing', type: :routing do
+# frozen_string_literal: true
 
+RSpec.describe 'routing', type: :routing do
   it 'routes to #create' do
     expect(post: '/v1/oauth/token').to route_to('v1/doorkeeper/tokens#create')
   end


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=398&projectKey=CACP&modal=detail&selectedIssue=CACP-244

Versioning of OAUTH Endpoints 
-Versioning of routes provided by doorkeeper gem 
-Creation of authorization, token info and tokens controllers 
-Updated RSPEC test suite accordingly

This ensures that future changes will not break current functionality. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
