### PR TITLE
Crown Court Appeals

### DIFF
--- a/app/services/crown_court_outcome_creator.rb
+++ b/app/services/crown_court_outcome_creator.rb
@@ -6,24 +6,33 @@ class CrownCourtOutcomeCreator < ApplicationService
                        GUILTY_BY_JURY_CONVICTED
                        GUILTY_BUT_OF_LESSER_OFFENCE_CONVICTED].freeze
 
-  def initialize(defendant:)
+  SUCCESSFUL_APPEALS = %w[Granted Allowed].freeze
+
+  def initialize(defendant:, appeal_data:)
     @defendant = defendant
+    @appeal_data = appeal_data
   end
 
   def call
-    return unless result_is_a_conclusion?
-
-    {
-      ccooOutcome: trial_outcome,
-      caseEndDate: case_end_date,
-      appealType: nil
-    }
+    appeal_data.present? ? appeal_hash : trial_hash
   end
 
   private
 
-  def result_is_a_conclusion?
-    defendant.dig(:offences)&.any? { |offence| offence.dig(:verdict).present? }
+  def trial_hash
+    {
+      ccooOutcome: trial_outcome,
+      caseEndDate: trial_end_date,
+      appealType: nil
+    }
+  end
+
+  def appeal_hash
+    {
+      ccooOutcome: appeal_outcome,
+      caseEndDate: appeal_end_date,
+      appealType: appeal_data[:appeal_type]
+    }
   end
 
   def trial_outcome
@@ -37,9 +46,19 @@ class CrownCourtOutcomeCreator < ApplicationService
     'AQUITTED' # This incorrect spelling is used in the MAAT database, and so must be used here to ensure compatibility
   end
 
-  def case_end_date
+  def appeal_outcome
+    return 'SUCCESSFUL' if SUCCESSFUL_APPEALS.include? appeal_data&.dig(:appeal_outcome, :applicationOutcome)
+
+    'UNSUCCESSFUL'
+  end
+
+  def trial_end_date
     defendant.dig(:offences, 0, :verdict, :verdictDate)
   end
 
-  attr_reader :defendant
+  def appeal_end_date
+    appeal_data.dig(:appeal_outcome, :applicationOutcomeDate)
+  end
+
+  attr_reader :defendant, :appeal_data
 end

--- a/spec/services/crown_court_outcome_creator_spec.rb
+++ b/spec/services/crown_court_outcome_creator_spec.rb
@@ -29,61 +29,84 @@ RSpec.describe CrownCourtOutcomeCreator do
       ]
     }
   end
+  let(:appeal_data) { nil }
 
-  subject(:create) { described_class.call(defendant: defendant) }
+  subject(:create) { described_class.call(defendant: defendant, appeal_data: appeal_data) }
 
-  context 'without any verdicts' do
+  context 'for a trial' do
+    context 'with all guilty trial verdicts' do
+      it 'results in a CONVICTED result' do
+        expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'CONVICTED' })
+      end
+    end
+
+    context 'with all not guilty trial verdicts' do
+      let(:defendant) do
+        {
+          'offences': [
+            {
+              'verdict': not_guilty_verdict
+            },
+            {
+              'verdict': not_guilty_verdict
+            }
+          ]
+        }
+      end
+
+      it 'results in a AQUITTED result' do
+        expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'AQUITTED' })
+      end
+    end
+
+    context 'a mix of guity and not guilty trial verdicts' do
+      let(:defendant) do
+        {
+          'offences': [
+            {
+              'verdict': guilty_verdict
+            },
+            {
+              'verdict': not_guilty_verdict
+            }
+          ]
+        }
+      end
+
+      it 'results in a PART CONVICTED result' do
+        expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'PART CONVICTED' })
+      end
+    end
+  end
+
+  context 'for an appeal' do
     let(:defendant) do
       {
         'offences': []
       }
     end
-    it 'does not create a crown court outcome' do
-      expect(create).to eq nil
-    end
-  end
-
-  context 'with all guilty trial verdicts' do
-    it 'results in a CONVICTED result' do
-      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'CONVICTED' })
-    end
-  end
-
-  context 'with all not guilty trial verdicts' do
-    let(:defendant) do
+    let(:appeal_result) { 'Granted' }
+    let(:appeal_data) do
       {
-        'offences': [
-          {
-            'verdict': not_guilty_verdict
-          },
-          {
-            'verdict': not_guilty_verdict
-          }
-        ]
+        'appeal_type': 'ASE',
+        'appeal_outcome': {
+          'applicationOutcomeDate': '2019-01-01',
+          'applicationOutcome': appeal_result
+        }
       }
     end
-
-    it 'results in a AQUITTED result' do
-      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'AQUITTED' })
-    end
-  end
-
-  context 'a mix of guity and not guilty trial verdicts' do
-    let(:defendant) do
-      {
-        'offences': [
-          {
-            'verdict': guilty_verdict
-          },
-          {
-            'verdict': not_guilty_verdict
-          }
-        ]
-      }
+    context 'with a successful result' do
+      it 'results in a SUCCESSFUL result' do
+        expect(create).to eq({ appealType: 'ASE', caseEndDate: '2019-01-01', ccooOutcome: 'SUCCESSFUL' })
+      end
     end
 
-    it 'results in a PART CONVICTED result' do
-      expect(create).to eq({ appealType: nil, caseEndDate: '2018-10-25', ccooOutcome: 'PART CONVICTED' })
+    context 'with an unsuccessful result' do
+      let(:appeal_result) { 'Refused' }
+
+      it 'results in an UNSUCCESSFUL result' do
+        expect(create).to eq({ appealType: 'ASE', caseEndDate: '2019-01-01', ccooOutcome: 'UNSUCCESSFUL' })
+      end
     end
   end
 end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe HearingsCreator do
       }
     ]
   end
+  let(:application_array) do
+    [
+      {
+        applicationReference: '12345',
+        type: {
+          applicationCode: 'ASE'
+        },
+        applicant: {
+          defendant: defendant_array.first
+        }
+      }
+    ]
+  end
   let(:shared_time) { '2018-10-25 11:30:00' }
   let(:hearing) do
     {
@@ -22,7 +35,8 @@ RSpec.describe HearingsCreator do
       courtCentre: {
         ouCode: 'B16BG00'
       },
-      prosecutionCases: prosecution_case_array
+      prosecutionCases: prosecution_case_array,
+      courtApplications: application_array
     }
   end
 
@@ -30,123 +44,125 @@ RSpec.describe HearingsCreator do
 
   subject(:create) { described_class.call(sharedTime: shared_time, hearing: hearing) }
 
-  context 'with one defendant' do
+  context 'for a trial' do
+    let(:application_array) { nil }
+
+    context 'with one defendant' do
+      it 'calls the Sqs::PublishHearing service once' do
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'MAGISTRATES',
+                                                                               case_urn: '12345',
+                                                                               defendant: defendant_array.first,
+                                                                               cjs_location: 'B16BG'))
+        create
+      end
+    end
+
+    context 'with two defendants' do
+      let(:defendant_array) do
+        [
+          { 'id': 'defendant_one_id',
+            'laaApplnReference': { 'applicationReference': '123456789' } },
+          { 'id': 'defendant_two_id',
+            'laaApplnReference': { 'applicationReference': '987654321' } }
+        ]
+      end
+
+      it 'calls the Sqs::PublishLaaReference service twice' do
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'MAGISTRATES',
+                                                                               case_urn: '12345',
+                                                                               defendant: defendant_array.first,
+                                                                               cjs_location: 'B16BG'))
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'MAGISTRATES',
+                                                                               case_urn: '12345',
+                                                                               defendant: defendant_array.last,
+                                                                               cjs_location: 'B16BG'))
+        create
+      end
+    end
+
+    context 'with two prosecution cases' do
+      let(:prosecution_case_array) do
+        [
+          {
+            prosecutionCaseIdentifier: {
+              caseURN: '12345'
+            },
+            defendants: defendant_array
+          },
+          {
+            prosecutionCaseIdentifier: {
+              caseURN: '54321'
+            },
+            defendants: defendant_array
+          }
+        ]
+      end
+
+      it 'calls the Sqs::PublishHearing service twice' do
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'MAGISTRATES',
+                                                                               case_urn: '12345',
+                                                                               defendant: defendant_array.first,
+                                                                               cjs_location: 'B16BG'))
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'MAGISTRATES',
+                                                                               case_urn: '54321',
+                                                                               defendant: defendant_array.first,
+                                                                               cjs_location: 'B16BG'))
+        create
+      end
+    end
+
+    context 'with a crown court hearing' do
+      let(:hearing) do
+        {
+          jurisdictionType: 'CROWN',
+          courtCentre: {
+            ouCode: 'B16BG00'
+          },
+          prosecutionCases: prosecution_case_array
+        }
+      end
+
+      it 'calls the Sqs::PublishHearing service' do
+        expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
+                                                                               jurisdiction_type: 'CROWN',
+                                                                               case_urn: '12345',
+                                                                               defendant: defendant_array.first,
+                                                                               cjs_location: 'B16BG'))
+        create
+      end
+    end
+
+    context 'with a dummy MAAT ID' do
+      let(:defendant_array) do
+        [
+          { 'id': 'defendant_one_id',
+            'laaApplnReference': { 'applicationReference': 'A123456789' } },
+          { 'id': 'defendant_two_id',
+            'laaApplnReference': { 'applicationReference': 'Z987654321' } }
+        ]
+      end
+
+      it 'does not call the Sqs::PublishHearing service' do
+        expect(Sqs::PublishHearing).not_to receive(:call)
+        create
+      end
+    end
+  end
+
+  context 'for an appeal' do
+    let(:prosecution_case_array) { nil }
+
     it 'calls the Sqs::PublishHearing service once' do
       expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
                                                                              jurisdiction_type: 'MAGISTRATES',
                                                                              case_urn: '12345',
                                                                              defendant: defendant_array.first,
                                                                              cjs_location: 'B16BG'))
-      create
-    end
-  end
-
-  context 'with two defendants' do
-    let(:defendant_array) do
-      [
-        { 'id': 'defendant_one_id',
-          'laaApplnReference': { 'applicationReference': '123456789' } },
-        { 'id': 'defendant_two_id',
-          'laaApplnReference': { 'applicationReference': '987654321' } }
-      ]
-    end
-
-    it 'calls the Sqs::PublishLaaReference service twice' do
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                             jurisdiction_type: 'MAGISTRATES',
-                                                                             case_urn: '12345',
-                                                                             defendant: defendant_array.first,
-                                                                             cjs_location: 'B16BG'))
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                             jurisdiction_type: 'MAGISTRATES',
-                                                                             case_urn: '12345',
-                                                                             defendant: defendant_array.last,
-                                                                             cjs_location: 'B16BG'))
-      create
-    end
-  end
-
-  context 'with two prosecution cases' do
-    let(:prosecution_case_array) do
-      [
-        {
-          prosecutionCaseIdentifier: {
-            caseURN: '12345'
-          },
-          defendants: defendant_array
-        },
-        {
-          prosecutionCaseIdentifier: {
-            caseURN: '54321'
-          },
-          defendants: defendant_array
-        }
-      ]
-    end
-
-    it 'calls the Sqs::PublishHearing service twice' do
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                             jurisdiction_type: 'MAGISTRATES',
-                                                                             case_urn: '12345',
-                                                                             defendant: defendant_array.first,
-                                                                             cjs_location: 'B16BG'))
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                             jurisdiction_type: 'MAGISTRATES',
-                                                                             case_urn: '54321',
-                                                                             defendant: defendant_array.first,
-                                                                             cjs_location: 'B16BG'))
-      create
-    end
-  end
-
-  context 'with a crown court hearing' do
-    let(:hearing) do
-      {
-        jurisdictionType: 'CROWN',
-        courtCentre: {
-          ouCode: 'B16BG00'
-        },
-        prosecutionCases: prosecution_case_array
-      }
-    end
-
-    it 'calls the Sqs::PublishHearing service' do
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: '2018-10-25 11:30:00',
-                                                                             jurisdiction_type: 'CROWN',
-                                                                             case_urn: '12345',
-                                                                             defendant: defendant_array.first,
-                                                                             cjs_location: 'B16BG'))
-      create
-    end
-  end
-
-  context 'with a dummy MAAT ID' do
-    let(:defendant_array) do
-      [
-        { 'id': 'defendant_one_id',
-          'laaApplnReference': { 'applicationReference': 'A123456789' } },
-        { 'id': 'defendant_two_id',
-          'laaApplnReference': { 'applicationReference': 'Z987654321' } }
-      ]
-    end
-
-    it 'does not call the Sqs::PublishHearing service' do
-      expect(Sqs::PublishHearing).not_to receive(:call)
-      create
-    end
-  end
-
-  context 'with no prosecution cases' do
-    let(:hearing) do
-      {
-        jurisdictionType: 'CROWN'
-      }
-    end
-
-    subject(:create) { described_class.call(sharedTime: shared_time, hearing: hearing) }
-
-    it 'does not call the Sqs::PublishHearing service' do
-      expect(Sqs::PublishHearing).not_to receive(:call)
       create
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-334)

Add functionality to process crown court appeals received from Common Platform.

This mainly is a change to the `CrownCourtOutcomeCreator` class to populate the `CrownCourtOutcome` part of the payload sent to MAAT-API with appeal data instead of trial data.

This also involves amending the `HearingsCreator` and `PublishHearing` classes to propagate relevant appeal data to the `CrownCourtOutcomeCreator` class.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
