### PR TITLE
Amend UnlinkDefendant contract to handle 'other reason text'

### DIFF
--- a/app/contracts/unlink_defendant_contract.rb
+++ b/app/contracts/unlink_defendant_contract.rb
@@ -7,7 +7,7 @@ class UnlinkDefendantContract < Dry::Validation::Contract
     required(:defendant_id).value(:string)
     required(:user_name).value(:string)
     required(:unlink_reason_code).value(:integer)
-    required(:unlink_reason_text).value(:string)
+    optional(:unlink_other_reason_text).value(:string)
   end
 
   rule(:defendant_id) do
@@ -16,5 +16,10 @@ class UnlinkDefendantContract < Dry::Validation::Contract
 
   rule(:user_name) do
     key.failure('must not exceed 10 characters') if value.length > 10
+  end
+
+  rule(:unlink_other_reason_text, :unlink_reason_code) do
+    key.failure('must be present') if values[:unlink_other_reason_text].blank? && values[:unlink_reason_code].eql?(7)
+    key.failure('must be absent') if values[:unlink_other_reason_text].present? && !values[:unlink_reason_code].eql?(7)
   end
 end

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -31,7 +31,7 @@ module Api
         end
 
         def allowed_params
-          %i[user_name unlink_reason_code unlink_reason_text]
+          %i[user_name unlink_reason_code unlink_other_reason_text]
         end
 
         def transformed_params

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -22,7 +22,7 @@ module Api
             transformed_params[:defendant_id],
             transformed_params[:user_name],
             transformed_params[:unlink_reason_code],
-            transformed_params[:unlink_reason_text]
+            transformed_params[:unlink_other_reason_text]
           )
         end
 

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class LaaReferenceUnlinker < ApplicationService
-  def initialize(defendant_id:, user_name:, unlink_reason_code:, unlink_reason_text:)
+  def initialize(defendant_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:)
     @defendant_id = defendant_id
     @user_name = user_name
     @unlink_reason_code = unlink_reason_code
-    @unlink_reason_text = unlink_reason_text
+    @unlink_other_reason_text = unlink_other_reason_text
     @maat_reference = offences.first.maat_reference unless offences.first.dummy_maat_reference?
   end
 
@@ -17,7 +17,7 @@ class LaaReferenceUnlinker < ApplicationService
   private
 
   def push_to_sqs
-    Sqs::PublishUnlinkLaaReference.call(maat_reference: maat_reference, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_reason_text: unlink_reason_text)
+    Sqs::PublishUnlinkLaaReference.call(maat_reference: maat_reference, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_other_reason_text: unlink_other_reason_text)
   end
 
   def call_cp_endpoint
@@ -41,5 +41,5 @@ class LaaReferenceUnlinker < ApplicationService
     @dummy_maat_reference ||= "Z#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
   end
 
-  attr_reader :defendant_id, :maat_reference, :user_name, :unlink_reason_code, :unlink_reason_text
+  attr_reader :defendant_id, :maat_reference, :user_name, :unlink_reason_code, :unlink_other_reason_text
 end

--- a/app/services/sqs/publish_unlink_laa_reference.rb
+++ b/app/services/sqs/publish_unlink_laa_reference.rb
@@ -20,7 +20,7 @@ module Sqs
         maatId: maat_reference,
         userId: user_name,
         reasonId: unlink_reason_code,
-        reasonText: unlink_other_reason_text
+        otherReasonText: unlink_other_reason_text
       }
     end
 

--- a/app/services/sqs/publish_unlink_laa_reference.rb
+++ b/app/services/sqs/publish_unlink_laa_reference.rb
@@ -2,11 +2,11 @@
 
 module Sqs
   class PublishUnlinkLaaReference < ApplicationService
-    def initialize(maat_reference:, user_name:, unlink_reason_code:, unlink_reason_text:)
+    def initialize(maat_reference:, user_name:, unlink_reason_code:, unlink_other_reason_text:)
       @maat_reference = maat_reference
       @user_name = user_name
       @unlink_reason_code = unlink_reason_code
-      @unlink_reason_text = unlink_reason_text
+      @unlink_other_reason_text = unlink_other_reason_text
     end
 
     def call
@@ -20,10 +20,10 @@ module Sqs
         maatId: maat_reference,
         userId: user_name,
         reasonId: unlink_reason_code,
-        reasonText: unlink_reason_text
+        reasonText: unlink_other_reason_text
       }
     end
 
-    attr_reader :maat_reference, :user_name, :unlink_reason_code, :unlink_reason_text
+    attr_reader :maat_reference, :user_name, :unlink_reason_code, :unlink_other_reason_text
   end
 end

--- a/app/workers/unlink_laa_reference_worker.rb
+++ b/app/workers/unlink_laa_reference_worker.rb
@@ -3,9 +3,9 @@
 class UnlinkLaaReferenceWorker
   include Sidekiq::Worker
 
-  def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_reason_text)
+  def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text)
     Current.set(request_id: request_id) do
-      LaaReferenceUnlinker.call(defendant_id: defendant_id, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_reason_text: unlink_reason_text)
+      LaaReferenceUnlinker.call(defendant_id: defendant_id, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_other_reason_text: unlink_other_reason_text)
     end
   end
 end

--- a/spec/contracts/unlink_defendant_contract_spec.rb
+++ b/spec/contracts/unlink_defendant_contract_spec.rb
@@ -4,35 +4,64 @@ RSpec.describe UnlinkDefendantContract do
   let(:defendant_id) { '23d7f10a-067a-476e-bba6-bb855674e23b' }
   let(:user_name) { 'johnDoe' }
   let(:unlink_reason_code) { 1 }
+  let(:unlink_other_reason_text) { '' }
 
   let(:hash_for_validation) do
     {
       defendant_id: defendant_id,
       user_name: user_name,
       unlink_reason_code: unlink_reason_code,
-      unlink_reason_text: 'Incorrect defendant'
+      unlink_other_reason_text: unlink_other_reason_text
     }
   end
 
-  subject { described_class.new.call(hash_for_validation).errors }
+  subject(:fullfillment) { described_class.new.call(hash_for_validation) }
 
-  it { is_expected.to be_empty }
+  it { is_expected.not_to have_contract_error }
 
   context 'with over 10 characters in user name' do
     let(:user_name) { '12345678910' }
 
-    it { is_expected.not_to be_empty }
+    it { expect(fullfillment.errors).not_to be_empty }
+
+    it { is_expected.to have_contract_error('must not exceed 10 characters') }
   end
 
   context 'with a non numeric unlink_reason_code' do
-    let(:unlink_reason_code) { 'ABC' }
+    let(:unlink_reason_code) { '1' }
 
-    it { is_expected.not_to be_empty }
+    it { expect(fullfillment.errors).not_to be_empty }
+
+    it { is_expected.to have_contract_error('must be an integer') }
   end
 
   context 'with an invalid defendant_id' do
     let(:defendant_id) { '23d7f10a' }
 
-    it { is_expected.not_to be_empty }
+    it { expect(fullfillment.errors).not_to be_empty }
+
+    it { is_expected.to have_contract_error('not a valid uuid') }
+  end
+
+  context 'with unlink_other_reason_text present' do
+    let(:unlink_other_reason_text) { 'Incorrect defendant' }
+
+    it { is_expected.to have_contract_error('must be absent') }
+  end
+
+  context 'with unlink_reason_code for \'Other\'' do
+    let(:unlink_reason_code) { 7 }
+
+    context 'with unlink_other_reason_text present' do
+      let(:unlink_other_reason_text) { 'Incorrect defendant' }
+
+      it { is_expected.not_to have_contract_error }
+    end
+
+    context 'with unlink_other_reason_text absent' do
+      let(:unlink_other_reason_text) { '' }
+
+      it { is_expected.to have_contract_error('must be present') }
+    end
   end
 end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
         attributes: {
           user_name: 'johnDoe',
           unlink_reason_code: 1,
-          unlink_reason_text: 'Wrong defendant'
+          unlink_other_reason_text: ''
         }
       }
     }
@@ -45,14 +45,14 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
                   schema: {
                     '$ref': 'defendant.json#/definitions/resource_to_unlink'
                   },
-                  description: 'Object containing the user_name, unlink_reason_code and unlink_reason_text'
+                  description: 'Object containing the user_name, unlink_reason_code and unlink_other_reason_text'
 
         parameter '$ref' => '#/components/parameters/transaction_id_header'
 
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with(String, id, 'johnDoe', 1, 'Wrong defendant').and_call_original
+          expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with(String, id, 'johnDoe', 1, '').and_call_original
         end
 
         run_test!

--- a/spec/services/laa_reference_unlinker_spec.rb
+++ b/spec/services/laa_reference_unlinker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe LaaReferenceUnlinker do
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
   let(:user_name) { 'johnDoe' }
   let(:unlink_reason_code) { 1 }
-  let(:unlink_reason_text) { 'Wrong MAAT ID' }
+  let(:unlink_other_reason_text) { 'Wrong defendant' }
   before do
     ProsecutionCase.create!(
       id: prosecution_case_id,
@@ -19,7 +19,7 @@ RSpec.describe LaaReferenceUnlinker do
     allow(Api::RecordLaaReference).to receive(:call)
   end
 
-  subject(:create) { described_class.call(defendant_id: defendant_id, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_reason_text: unlink_reason_text) }
+  subject(:create) { described_class.call(defendant_id: defendant_id, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_other_reason_text: unlink_other_reason_text) }
 
   it 'creates a dummy maat_reference starting with Z' do
     expect(Api::RecordLaaReference).to receive(:call).with(hash_including(application_reference: 'Z10000000'))
@@ -32,7 +32,7 @@ RSpec.describe LaaReferenceUnlinker do
       .with(maat_reference: '101010',
             user_name: user_name,
             unlink_reason_code: unlink_reason_code,
-            unlink_reason_text: unlink_reason_text)
+            unlink_other_reason_text: unlink_other_reason_text)
     create
   end
 
@@ -50,7 +50,7 @@ RSpec.describe LaaReferenceUnlinker do
         .with(maat_reference: '101010',
               user_name: user_name,
               unlink_reason_code: unlink_reason_code,
-              unlink_reason_text: unlink_reason_text)
+              unlink_other_reason_text: unlink_other_reason_text)
       create
     end
 

--- a/spec/services/sqs/publish_unlink_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_unlink_laa_reference_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe Sqs::PublishUnlinkLaaReference do
   let(:maat_reference) { 123_456 }
   let(:user_name) { 'test@example.com' }
   let(:unlink_reason_code) { 1 }
-  let(:unlink_reason_text) { 'linked to incorrect case' }
+  let(:unlink_other_reason_text) { 'linked to incorrect case' }
 
   let(:sqs_payload) do
     {
       maatId: maat_reference,
       userId: user_name,
       reasonId: unlink_reason_code,
-      reasonText: unlink_reason_text
+      reasonText: unlink_other_reason_text
     }
   end
 
-  subject { described_class.call(maat_reference: maat_reference, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_reason_text: unlink_reason_text) }
+  subject { described_class.call(maat_reference: maat_reference, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_other_reason_text: unlink_other_reason_text) }
 
   let(:queue_url) { Rails.configuration.x.aws.sqs_url_unlink }
 

--- a/spec/services/sqs/publish_unlink_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_unlink_laa_reference_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Sqs::PublishUnlinkLaaReference do
       maatId: maat_reference,
       userId: user_name,
       reasonId: unlink_reason_code,
-      reasonText: unlink_other_reason_text
+      otherReasonText: unlink_other_reason_text
     }
   end
 

--- a/spec/support/matchers/have_contract_error.rb
+++ b/spec/support/matchers/have_contract_error.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+# have_contract_error
+# e.g.
+# expect(contract.call(my_integer: '1')).to have_contract_error('must be an integer')
+#
+RSpec::Matchers.define :have_contract_error do |message|
+  match do |fullfillment|
+    fullfillment.errors.map(&:text).any? { |msg| msg.match?(message) }
+  end
+
+  description do
+    'have contract error'
+  end
+
+  failure_message do |fullfillment|
+    errors = fullfillment.errors.to_h
+    "expected contract fullfillment errors to include message: \"#{message}\"\n" \
+      "but received: #{errors.empty? ? 'none' : errors}"
+  end
+
+  failure_message_when_negated do |fullfillment|
+    "expected contract fullfillment not to include error message \"#{message}\"\n" \
+      "but it was included in #{fullfillment.errors.to_h}"
+  end
+end

--- a/spec/workers/unlink_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_laa_reference_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   let(:defendant_id) { '2ecc9feb-9407-482f-b081-d9e5c8ba3ed3' }
   let(:user_name) { 'ABC' }
   let(:unlink_reason_code) { 1 }
-  let(:unlink_reason_text) { 'Wrong defendant' }
+  let(:unlink_other_reason_text) { 'Wrong defendant' }
   let(:request_id) { 'XYZ' }
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
   let(:set_up_linked_prosecution_case) do
@@ -22,7 +22,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   end
 
   subject(:work) do
-    described_class.perform_async(request_id, defendant_id, user_name, unlink_reason_code, unlink_reason_text)
+    described_class.perform_async(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text)
   end
 
   it 'queues the job' do
@@ -38,7 +38,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
         defendant_id: defendant_id,
         user_name: user_name,
         unlink_reason_code: unlink_reason_code,
-        unlink_reason_text: unlink_reason_text
+        unlink_other_reason_text: unlink_other_reason_text
       ).and_call_original
       work
     end

--- a/swagger/v1/defendant.json
+++ b/swagger/v1/defendant.json
@@ -71,9 +71,9 @@
       "minimum": 1,
       "maximum": 7
     },
-    "unlink_reason_text": {
+    "unlink_other_reason_text": {
       "example": "Linked to incorrect case",
-      "description": "Text describing the reason for unlinking the case",
+      "description": "Text describing a reason for unlinking the case when code is 7/other",
       "type": "string"
     },
     "representation_order_date": {
@@ -135,8 +135,8 @@
             "unlink_reason_code": {
               "$ref": "#/definitions/unlink_reason_code"
             },
-            "unlink_reason_text": {
-              "$ref": "#/definitions/unlink_reason_text"
+            "unlink_other_reason_text": {
+              "$ref": "#/definitions/unlink_other_reason_text"
             }
           }
         }


### PR DESCRIPTION
## What
amend validations on unlinking reasons

[Link to story](https://dsdmoj.atlassian.net/browse/CBO-1270)

## Why
MLRA/MAAT only needs the reason code except when this
code maps to "Other reason (please specify)". In the latter
case unlink_other_reason_text should be provided.

## Linked to 

Relates to [this PR in laa-court-data-ui](https://github.com/ministryofjustice/laa-court-data-ui/pull/192)

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.