### PR TITLE
Amend pg default table access and default oids use

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -25,7 +39,7 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
+SET default_with_oids = false;
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -


### PR DESCRIPTION
## What
Amend pg default table access and default oids use

## Why
It maybe that I am hitting issues because I am using
postgres 9.6.15 locally, but when i run specs i get errors.

```
psql:../laa-court-data-adaptor/db/structure.sql:28: ERROR:  unrecognized configuration parameter "default_table_access_method"
rails aborted!
...
Tasks: TOP => db:test:load_structure
(See full trace by running task with --trace)
Migrations are pending. To resolve this issue, run:

        rails db:migrate RAILS_ENV=test
No examples found.
```
when i run `rails db:migrate RAILS_ENV=test` it amends
the db/structure.sql as in this commit.


## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.