### PR TITLE
Match format of Hearing Resulted schema

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -4,11 +4,11 @@ class Hearing < ApplicationRecord
   validates :body, presence: true
 
   def court_name
-    body['courtCentre']['name']
+    hearing_body['courtCentre']['name']
   end
 
   def hearing_type
-    body['type']['description']
+    hearing_body['type']['description']
   end
 
   def defendant_names
@@ -27,8 +27,12 @@ class Hearing < ApplicationRecord
 
   private
 
+  def hearing_body
+    body['hearing']
+  end
+
   def prosecution_cases
-    body['prosecutionCases']
+    hearing_body['prosecutionCases']
   end
 
   def defendants
@@ -36,7 +40,7 @@ class Hearing < ApplicationRecord
   end
 
   def hearing_event_recordings
-    @hearing_event_recordings ||= body['hearingDays'].flat_map do |hearing_day|
+    @hearing_event_recordings ||= hearing_body['hearingDays'].flat_map do |hearing_day|
       Api::GetHearingEvents.call(hearing_id: id, hearing_date: hearing_day['sittingDay'].to_date)
     end
   end

--- a/app/services/api/get_hearing_results.rb
+++ b/app/services/api/get_hearing_results.rb
@@ -14,7 +14,7 @@ module Api
     private
 
     def successful_response?
-      response.status == 200
+      response.status == 200 && response.body.present?
     end
 
     attr_reader :hearing_id, :response

--- a/spec/cassettes/hearing_logs_fetcher/success.yml
+++ b/spec/cassettes/hearing_logs_fetcher/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingEventLogHttpTriggerFast?date=2020-04-30&hearingId=2c24f897-ffc4-439f-9c4a-ec60c7715cd0"
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingEventLogHttpTriggerFast?date=2020-04-17&hearingId=ee7b9c09-4a6e-49e3-a484-193dc93a4575"
     body:
       encoding: US-ASCII
       string: ''
@@ -21,37 +21,40 @@ http_interactions:
       request-context:
       - appId=cid-v1:e7545c86-6eab-4a30-bf6d-7ed8b5691e3e
       date:
-      - Fri, 15 May 2020 15:57:00 GMT
+      - Fri, 26 Jun 2020 14:39:34 GMT
       x-frame-options:
       - SAMEORIGIN
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: "{\r\n  \"hearingId\": \"2c24f897-ffc4-439f-9c4a-ec60c7715cd0\",\r\n
+      string: "{\r\n  \"hearingId\": \"ee7b9c09-4a6e-49e3-a484-193dc93a4575\",\r\n
         \ \"hasActiveHearing\": true,\r\n  \"events\": [\r\n    {\r\n      \"hearingEventId\":
-        \"b97449bb-5145-4bfc-a8ec-849082406d79\",\r\n      \"hearingEventDefinitionId\":
+        \"550529aa-c21b-47e3-a333-4ae403943a3a\",\r\n      \"hearingEventDefinitionId\":
         \"b71e7d2a-d3b3-4a55-a393-6d451767fc05\",\r\n      \"recordedLabel\": \"Hearing
-        started\",\r\n      \"eventTime\": \"2020-04-30T16:17:58.610Z\",\r\n      \"lastModifiedTime\":
-        \"2020-04-29T16:17:59.409Z\",\r\n      \"alterable\": false\r\n    },\r\n
-        \   {\r\n      \"hearingEventId\": \"aa2739a2-2126-469e-bee7-e9922aa3142f\",\r\n
-        \     \"hearingEventDefinitionId\": \"d555bd6e-15cc-41f4-9889-f46174b54050\",\r\n
-        \     \"recordedLabel\": \"Hearing type changed to Plea\",\r\n      \"eventTime\":
-        \"2020-04-30T16:18:06.633Z\",\r\n      \"lastModifiedTime\": \"2020-04-29T16:18:06.906Z\",\r\n
-        \     \"alterable\": true\r\n    },\r\n    {\r\n      \"hearingEventId\":
-        \"bc78bb60-9ade-485f-a213-14ff73ec5fbb\",\r\n      \"hearingEventDefinitionId\":
-        \"160ecb51-29ee-4954-bbbf-daab18a24fbb\",\r\n      \"recordedLabel\": \"Hearing
-        paused\",\r\n      \"eventTime\": \"2020-04-30T16:18:07.635Z\",\r\n      \"lastModifiedTime\":
-        \"2020-04-29T16:18:08.476Z\",\r\n      \"alterable\": false\r\n    },\r\n
-        \   {\r\n      \"hearingEventId\": \"037e4a99-2e5d-4d1a-a6d2-4ce6d655bf9a\",\r\n
+        started\",\r\n      \"eventTime\": \"2020-04-17T16:55:26.250Z\",\r\n      \"lastModifiedTime\":
+        \"2020-04-17T16:55:26.276Z\",\r\n      \"alterable\": false\r\n    },\r\n
+        \   {\r\n      \"hearingEventId\": \"b928b2d7-dc7d-46e3-a826-9fd0ab2fae6e\",\r\n
+        \     \"hearingEventDefinitionId\": \"160ecb51-29ee-4954-bbbf-daab18a24fbb\",\r\n
+        \     \"recordedLabel\": \"Hearing paused\",\r\n      \"eventTime\": \"2020-04-17T16:55:43.273Z\",\r\n
+        \     \"lastModifiedTime\": \"2020-04-17T16:55:43.640Z\",\r\n      \"alterable\":
+        false\r\n    },\r\n    {\r\n      \"hearingEventId\": \"4a19f42e-752e-44be-9e39-3cf4857a8150\",\r\n
         \     \"hearingEventDefinitionId\": \"64476e43-2138-46d5-b58b-848582cf9b07\",\r\n
-        \     \"recordedLabel\": \"Hearing resumed\",\r\n      \"eventTime\": \"2020-04-30T16:18:16.664Z\",\r\n
-        \     \"lastModifiedTime\": \"2020-04-29T16:18:16.692Z\",\r\n      \"alterable\":
-        false\r\n    },\r\n    {\r\n      \"hearingEventId\": \"ccd5cecb-5723-46a7-8aea-86a78f7ad201\",\r\n
+        \     \"recordedLabel\": \"Hearing resumed\",\r\n      \"eventTime\": \"2020-04-17T16:55:44.274Z\",\r\n
+        \     \"lastModifiedTime\": \"2020-04-17T16:55:44.954Z\",\r\n      \"alterable\":
+        false\r\n    },\r\n    {\r\n      \"hearingEventId\": \"e484298e-37f7-4cf4-add5-87aecedb9011\",\r\n
         \     \"hearingEventDefinitionId\": \"d555bd6e-15cc-41f4-9889-f46174b54050\",\r\n
-        \     \"recordedLabel\": \"Hearing type changed to Plea and Trial Preparation\",\r\n
-        \     \"eventTime\": \"2020-04-30T16:18:29.704Z\",\r\n      \"lastModifiedTime\":
-        \"2020-04-29T16:18:30.380Z\",\r\n      \"alterable\": true\r\n    }\r\n  ]\r\n}"
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:00 GMT
-recorded_with: VCR 5.1.0
+        \     \"recordedLabel\": \"Hearing type changed to Sentence\",\r\n      \"eventTime\":
+        \"2020-04-17T16:55:52.292Z\",\r\n      \"lastModifiedTime\": \"2020-04-17T16:55:52.815Z\",\r\n
+        \     \"alterable\": true\r\n    },\r\n    {\r\n      \"hearingEventId\":
+        \"44b61d57-ad35-41de-9a6f-e362d3de8dc1\",\r\n      \"hearingEventDefinitionId\":
+        \"31c47709-e0d9-4de5-87cb-e41aa3863763\",\r\n      \"recordedLabel\": \"Defendant
+        Ocean Gagnier released\",\r\n      \"eventTime\": \"2020-04-17T16:56:00.000Z\",\r\n
+        \     \"lastModifiedTime\": \"2020-04-17T16:56:07.518Z\",\r\n      \"alterable\":
+        true\r\n    },\r\n    {\r\n      \"hearingEventId\": \"5b5537a4-9941-4c60-a7dc-f39c977aa323\",\r\n
+        \     \"hearingEventDefinitionId\": \"d555bd6e-15cc-41f4-9889-f46174b54050\",\r\n
+        \     \"recordedLabel\": \"Hearing type changed to Trial\",\r\n      \"eventTime\":
+        \"2020-04-17T16:56:22.340Z\",\r\n      \"lastModifiedTime\": \"2020-04-17T16:56:23.052Z\",\r\n
+        \     \"alterable\": true\r\n    }\r\n  ]\r\n}"
+  recorded_at: Fri, 26 Jun 2020 14:39:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/hearing_logs_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_logs_fetcher/unauthorised.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingEventLogHttpTriggerFast?date=2020-04-30&hearingId=2c24f897-ffc4-439f-9c4a-ec60c7715cd0"
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingEventLogHttpTriggerFast?date=2020-04-17&hearingId=ee7b9c09-4a6e-49e3-a484-193dc93a4575"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,13 +23,12 @@ http_interactions:
       www-authenticate:
       - AzureApiManagementKey realm="https://spnl-sit-apim-int-gw.cpp.nonlive/fa-sit-ccp0101-legalaidagency",name="Ocp-Apim-Subscription-Key",type="header"
       date:
-      - Fri, 15 May 2020 15:57:00 GMT
+      - Fri, 26 Jun 2020 14:39:34 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: '{ "statusCode": 401, "message": "Access denied due to invalid subscription
         key. Make sure to provide a valid key for an active subscription." }'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:01 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/hearing_result_fetcher/success.yml
+++ b/spec/cassettes/hearing_result_fetcher/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingHttpTrigger?hearingId=2c24f897-ffc4-439f-9c4a-ec60c7715cd0"
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingHttpTrigger?hearingId=ee7b9c09-4a6e-49e3-a484-193dc93a4575"
     body:
       encoding: US-ASCII
       string: ''
@@ -21,109 +21,89 @@ http_interactions:
       request-context:
       - appId=cid-v1:e7545c86-6eab-4a30-bf6d-7ed8b5691e3e
       date:
-      - Tue, 19 May 2020 15:21:44 GMT
+      - Fri, 26 Jun 2020 14:39:41 GMT
       x-frame-options:
       - SAMEORIGIN
       transfer-encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: "{\r\n  \"id\": \"2c24f897-ffc4-439f-9c4a-ec60c7715cd0\",\r\n  \"jurisdictionType\":
-        \"MAGISTRATES\",\r\n  \"courtCentre\": {\r\n    \"address\": {\r\n      \"address1\":
-        \"176A Lavender Hill\",\r\n      \"address2\": \"London\",\r\n      \"address3\":
-        \"\",\r\n      \"address4\": \"\",\r\n      \"address5\": \"\",\r\n      \"postcode\":
-        \"SW11 1JU\"\r\n    },\r\n    \"id\": \"f8254db1-1683-483e-afb3-b87fde5a0a26\",\r\n
-        \   \"name\": \"Lavender Hill Magistrates' Court\",\r\n    \"roomId\": \"9e4932f7-97b2-3010-b942-ddd2624e4dd8\",\r\n
-        \   \"roomName\": \"Courtroom 01\"\r\n  },\r\n  \"hearingDays\": [\r\n    {\r\n
-        \     \"listedDurationMinutes\": 0,\r\n      \"listingSequence\": 0,\r\n      \"sittingDay\":
-        \"2020-04-30T09:00:00.000Z\"\r\n    }\r\n  ],\r\n  \"type\": {\r\n    \"description\":
-        \"Trial\",\r\n    \"id\": \"bf8155e1-90b9-4080-b133-bfbad895d6e4\"\r\n  },\r\n
-        \ \"hearingLanguage\": \"ENGLISH\",\r\n  \"prosecutionCases\": [\r\n    {\r\n
-        \     \"id\": \"31cbe62d-b1ec-4e82-89f7-99dced834900\",\r\n      \"prosecutionCaseIdentifier\":
-        {\r\n        \"prosecutionAuthorityCode\": \"DVLA\",\r\n        \"prosecutionAuthorityId\":
-        \"6ae4b163-658b-3ae2-a66d-43401cac2f96\",\r\n        \"prosecutionAuthorityReference\":
-        \"32GD7891820\"\r\n      },\r\n      \"initiationCode\": \"J\",\r\n      \"defendants\":
-        [\r\n        {\r\n          \"id\": \"5633ea06-1381-4952-a17d-91f571d5eca6\",\r\n
-        \         \"prosecutionCaseId\": \"31cbe62d-b1ec-4e82-89f7-99dced834900\",\r\n
-        \         \"offences\": [\r\n            {\r\n              \"id\": \"8730a436-b2df-4e9c-89e3-797c5672d86d\",\r\n
-        \             \"offenceDefinitionId\": \"462325c8-349e-4dcb-a376-c4e683209f5e\",\r\n
-        \             \"offenceCode\": \"TR68107\",\r\n              \"offenceTitle\":
-        \"Drivers hours - cause driver to    exceed 4.5 hours driving without a break
-        - EC\",\r\n              \"wording\": \"Drivers hours - cause driver to    exceed
-        4.5 hours driving without a break - EC\",\r\n              \"startDate\":
-        \"1996-05-04\",\r\n              \"offenceTitleWelsh\": \"Oriau gyrwyr - achosi
-        i yrrwr yrru am fwy na 4.5 awr heb saib - UE\",\r\n              \"offenceLegislation\":
-        \"Contrary to section 96(11A)of    the Transport Act 1968.\",\r\n              \"offenceLegislationWelsh\":
-        \"Yn groes i adran 96(11A) Deddf Trafnidiaeth 1968.\",\r\n              \"modeOfTrial\":
-        \"Summary\",\r\n              \"endDate\": \"2005-05-05\",\r\n              \"chargeDate\":
-        \"2006-05-30\",\r\n              \"orderIndex\": 500,\r\n              \"count\":
-        1,\r\n              \"notifiedPlea\": {\r\n                \"notifiedPleaDate\":
-        \"2020-04-24\",\r\n                \"notifiedPleaValue\": \"NO_NOTIFICATION\",\r\n
-        \               \"offenceId\": \"8730a436-b2df-4e9c-89e3-797c5672d86d\"\r\n
-        \             },\r\n              \"offenceFacts\": {\r\n                \"alcoholReadingAmount\":
-        500,\r\n                \"alcoholReadingMethodCode\": \"A\",\r\n                \"vehicleRegistration\":
-        \"TE4654\"\r\n              },\r\n              \"plea\": {\r\n                \"offenceId\":
-        \"8730a436-b2df-4e9c-89e3-797c5672d86d\",\r\n                \"originatingHearingId\":
-        \"e18ca082-d282-4522-9b95-41951c89d4ad\",\r\n                \"pleaDate\":
-        \"2020-04-24\",\r\n                \"pleaValue\": \"GUILTY\"\r\n              },\r\n
-        \             \"judicialResults\": [\r\n                {\r\n                  \"alwaysPublished\":
-        false,\r\n                  \"category\": \"FINAL\",\r\n                  \"cjsCode\":
-        \"1017\",\r\n                  \"courtClerk\": {\r\n                    \"firstName\":
-        \"Erica\",\r\n                    \"lastName\": \"Wilson\",\r\n                    \"userId\":
-        \"31ec3a16-8721-498c-8da5-f099390ee254\"\r\n                  },\r\n                  \"d20\":
-        false,\r\n                  \"excludedFromResults\": false,\r\n                  \"isAdjournmentResult\":
-        false,\r\n                  \"isAvailableForCourtExtract\": true,\r\n                  \"isConvictedResult\":
-        true,\r\n                  \"isDeleted\": false,\r\n                  \"isFinancialResult\":
-        false,\r\n                  \"judicialResultId\": \"19224e62-64ac-426c-a9e1-4cdc570e48a5\",\r\n
-        \                 \"judicialResultTypeId\": \"b9c6047b-fb84-4b12-97a1-2175e4b8bbac\",\r\n
-        \                 \"label\": \"Absolute discharge\",\r\n                  \"lastSharedDateTime\":
-        \"2020-04-29\",\r\n                  \"lifeDuration\": false,\r\n                  \"orderedDate\":
-        \"2020-04-30\",\r\n                  \"orderedHearingId\": \"2c24f897-ffc4-439f-9c4a-ec60c7715cd0\",\r\n
-        \                 \"postHearingCustodyStatus\": \"A\",\r\n                  \"publishedAsAPrompt\":
-        false,\r\n                  \"rank\": 8600,\r\n                  \"resultText\":
-        \"Absolute discharge\\n\",\r\n                  \"terminatesOffenceProceedings\":
-        false,\r\n                  \"urgent\": false,\r\n                  \"usergroups\":
-        [\r\n                    \"Court Clerks\",\r\n                    \"Legal
-        Advisers\"\r\n                  ],\r\n                  \"welshLabel\": \"Rhyddhad
-        diamod\"\r\n                }\r\n              ],\r\n              \"laaApplnReference\":
-        {\r\n                \"applicationReference\": \"LAA-20191601\",\r\n                \"effectiveEndDate\":
-        \"2019-12-12\",\r\n                \"effectiveStartDate\": \"2019-09-12\",\r\n
-        \               \"laaContractNumber\": \"99998888\",\r\n                \"offenceLevelStatus\":
-        \"Granted\",\r\n                \"statusCode\": \"GRM\",\r\n                \"statusDate\":
-        \"2019-12-16\",\r\n                \"statusDescription\": \"Granted (One Advocate)(Magistrates
-        court jurisdiction)\",\r\n                \"statusId\": \"98e86937-9652-32a3-a9fb-dbd01eda86a5\"\r\n
-        \             }\r\n            }\r\n          ],\r\n          \"associatedPersons\":
-        [\r\n            {\r\n              \"person\": {\r\n                \"address\":
-        {\r\n                  \"address1\": \"1\",\r\n                  \"address2\":
-        \"1\",\r\n                  \"postcode\": \"SL2 5FZ\"\r\n                },\r\n
-        \               \"firstName\": \"ewe\",\r\n                \"gender\": \"NOT_SPECIFIED\",\r\n
-        \               \"lastName\": \"dsvc\",\r\n                \"middleName\":
-        \"ewew\"\r\n              },\r\n              \"role\": \"PARENT\"\r\n            }\r\n
-        \         ],\r\n          \"personDefendant\": {\r\n            \"arrestSummonsNumber\":
-        \"TFL\",\r\n            \"bailConditions\": \"\",\r\n            \"bailReasons\":
-        \"\",\r\n            \"driverNumber\": \"MORGA657054SM9BF\",\r\n            \"personDetails\":
-        {\r\n              \"address\": {\r\n                \"address1\": \"56saon\",\r\n
-        \               \"address2\": \"56Police House\",\r\n                \"address3\":
-        \"StreetDescription1\",\r\n                \"address4\": \"Locality1\",\r\n
-        \               \"address5\": \"Town2\",\r\n                \"postcode\":
-        \"CR0 1XG\"\r\n              },\r\n              \"contact\": {\r\n                \"home\":
-        \"09998021888\",\r\n                \"mobile\": \"09998021889\",\r\n                \"primaryEmail\":
-        \"robert@gmail.com\"\r\n              },\r\n              \"dateOfBirth\":
-        \"2008-08-08\",\r\n              \"documentationLanguageNeeds\": \"ENGLISH\",\r\n
-        \             \"ethnicity\": {\r\n                \"selfDefinedEthnicityCode\":
-        \"W1\",\r\n                \"selfDefinedEthnicityDescription\": \"British\",\r\n
-        \               \"selfDefinedEthnicityId\": \"c4ca4238-a0b9-3382-8dcc-509a6f75849b\"\r\n
-        \             },\r\n              \"firstName\": \"Robert\",\r\n              \"gender\":
-        \"MALE\",\r\n              \"lastName\": \"Ormsby\",\r\n              \"nationalityCode\":
-        \"GBR\",\r\n              \"nationalityDescription\": \"British\",\r\n              \"nationalityId\":
-        \"49433158-3542-49c8-a9af-581a0e746152\",\r\n              \"specificRequirements\":
-        \"SpecialNeeds0\",\r\n              \"title\": \"MR\"\r\n            }\r\n
-        \         },\r\n          \"aliases\": [\r\n            {\r\n              \"firstName\":
-        \"PersonGivenName11\",\r\n              \"lastName\": \"PersonFamilyName2\"\r\n
-        \           }\r\n          ],\r\n          \"proceedingsConcluded\": false\r\n
-        \       }\r\n      ],\r\n      \"caseStatus\": \"SJP_REFERRAL\",\r\n      \"originatingOrganisation\":
-        \"G94DV00\",\r\n      \"statementOfFacts\": \"Prosecution fact text\"\r\n
-        \   }\r\n  ],\r\n  \"hasSharedResults\": true\r\n}"
-    http_version: null
-  recorded_at: Tue, 19 May 2020 15:21:44 GMT
-recorded_with: VCR 5.1.0
+      string: "{\r\n  \"hearing\": {\r\n    \"applicantCounsels\": [],\r\n    \"applicationPartyCounsels\":
+        [],\r\n    \"courtApplicationPartyAttendance\": [],\r\n    \"courtApplications\":
+        [],\r\n    \"courtCentre\": {\r\n      \"address\": {\r\n        \"address1\":
+        \"Norwich Place\",\r\n        \"address2\": \"Bexleyheath\",\r\n        \"address3\":
+        \"Kent\",\r\n        \"address4\": \"\",\r\n        \"address5\": \"\",\r\n
+        \       \"postcode\": \"DA6 7ND\"\r\n      },\r\n      \"id\": \"7e967376-eacf-4fca-9b30-21b0c5aad427\",\r\n
+        \     \"name\": \"Bexley Magistrates' Court\",\r\n      \"roomId\": \"8e912353-3b5d-36c3-953e-ad3b94b19de3\",\r\n
+        \     \"roomName\": \"Courtroom 01\"\r\n    },\r\n    \"defenceCounsels\":
+        [],\r\n    \"defendantAttendance\": [],\r\n    \"defendantHearingYouthMarkers\":
+        [],\r\n    \"defendantReferralReasons\": [\r\n      {\r\n        \"defendantId\":
+        \"ad03a626-d438-44a5-84b6-14111ec363fa\",\r\n        \"description\": \"Case
+        unsuitable for SJP\",\r\n        \"id\": \"d10c5cc4-ec2a-41ac-bd6e-a3659c5cfeb1\"\r\n
+        \     }\r\n    ],\r\n    \"hasSharedResults\": true,\r\n    \"hearingCaseNotes\":
+        [],\r\n    \"hearingDays\": [\r\n      {\r\n        \"listedDurationMinutes\":
+        360,\r\n        \"listingSequence\": 0,\r\n        \"sittingDay\": \"2020-04-17T09:00:00.000Z\"\r\n
+        \     }\r\n    ],\r\n    \"hearingLanguage\": \"ENGLISH\",\r\n    \"id\":
+        \"ee7b9c09-4a6e-49e3-a484-193dc93a4575\",\r\n    \"judiciary\": [],\r\n    \"jurisdictionType\":
+        \"MAGISTRATES\",\r\n    \"prosecutionCases\": [\r\n      {\r\n        \"caseMarkers\":
+        [],\r\n        \"caseStatus\": \"SJP_REFERRAL\",\r\n        \"defendants\":
+        [\r\n          {\r\n            \"aliases\": [],\r\n            \"associatedPersons\":
+        [],\r\n            \"courtProceedingsInitiated\": \"2020-04-03T10:46:55.600Z\",\r\n
+        \           \"id\": \"ad03a626-d438-44a5-84b6-14111ec363fa\",\r\n            \"judicialResults\":
+        [],\r\n            \"masterDefendantId\": \"ad03a626-d438-44a5-84b6-14111ec363fa\",\r\n
+        \           \"numberOfPreviousConvictionsCited\": 2,\r\n            \"offences\":
+        [\r\n              {\r\n                \"chargeDate\": \"2020-01-25\",\r\n
+        \               \"count\": 1,\r\n                \"id\": \"7dc1b279-805f-4ba8-97ea-be635f5764a7\",\r\n
+        \               \"judicialResults\": [\r\n                  {\r\n                    \"alwaysPublished\":
+        false,\r\n                    \"category\": \"FINAL\",\r\n                    \"cjsCode\":
+        \"1017\",\r\n                    \"d20\": false,\r\n                    \"excludedFromResults\":
+        false,\r\n                    \"isAdjournmentResult\": false,\r\n                    \"isAvailableForCourtExtract\":
+        true,\r\n                    \"isConvictedResult\": true,\r\n                    \"isDeleted\":
+        false,\r\n                    \"isFinancialResult\": false,\r\n                    \"judicialResultId\":
+        \"7e5600fe-16aa-4639-84fe-3919165a65c1\",\r\n                    \"judicialResultPrompts\":
+        [],\r\n                    \"label\": \"Absolute discharge\",\r\n                    \"lastSharedDateTime\":
+        \"2020-04-17\",\r\n                    \"lifeDuration\": false,\r\n                    \"orderedDate\":
+        \"2020-04-17\",\r\n                    \"orderedHearingId\": \"ee7b9c09-4a6e-49e3-a484-193dc93a4575\",\r\n
+        \                   \"publishedAsAPrompt\": false,\r\n                    \"rank\":
+        8600,\r\n                    \"resultText\": \"Absolute discharge\\n\",\r\n
+        \                   \"terminatesOffenceProceedings\": false,\r\n                    \"urgent\":
+        false,\r\n                    \"usergroups\": [\r\n                      \"Court
+        Clerks\",\r\n                      \"Legal Advisers\"\r\n                    ],\r\n
+        \                   \"welshLabel\": \"Rhyddhad diamod\"\r\n                  }\r\n
+        \               ],\r\n                \"laaApplnReference\": {\r\n                  \"applicationReference\":
+        \"LAA-20191601\",\r\n                  \"effectiveEndDate\": \"2019-12-12\",\r\n
+        \                 \"effectiveStartDate\": \"2019-09-12\",\r\n                  \"statusCode\":
+        \"GRC\",\r\n                  \"statusDate\": \"2019-12-16\",\r\n                  \"statusDescription\":
+        \"Granted (One Advocate)(Crown court jurisdiction)\",\r\n                  \"statusId\":
+        \"a95d8a0e-95ad-32b8-8ae4-476f8f154fd0\"\r\n                },\r\n                \"modeOfTrial\":
+        \"Summary\",\r\n                \"notifiedPlea\": {\r\n                  \"notifiedPleaDate\":
+        \"2020-04-03\",\r\n                  \"notifiedPleaValue\": \"NO_NOTIFICATION\",\r\n
+        \                 \"offenceId\": \"7dc1b279-805f-4ba8-97ea-be635f5764a7\"\r\n
+        \               },\r\n                \"offenceCode\": \"TR11004\",\r\n                \"offenceDefinitionId\":
+        \"a9ac247c-38b3-4da3-be2d-79332a7a34f0\"\r\n              }\r\n            ],\r\n
+        \           \"personDefendant\": {\r\n              \"bailConditions\": \"\",\r\n
+        \             \"personDetails\": {\r\n                \"address\": {\r\n                  \"address1\":
+        \"Flat 1, Armageddon House\",\r\n                  \"address2\": \"13 Old
+        Road\",\r\n                  \"address3\": \"Giggleswick\",\r\n                  \"address4\":
+        \"Merton\",\r\n                  \"postcode\": \"ME1 1AB\"\r\n                },\r\n
+        \               \"contact\": {},\r\n                \"dateOfBirth\": \"1980-11-25\",\r\n
+        \               \"documentationLanguageNeeds\": \"ENGLISH\",\r\n                \"ethnicity\":
+        {},\r\n                \"firstName\": \"Ocean\",\r\n                \"gender\":
+        \"FEMALE\",\r\n                \"lastName\": \"Gagnier\",\r\n                \"title\":
+        \"MR\"\r\n              }\r\n            },\r\n            \"prosecutionCaseId\":
+        \"18f7b360-9f6d-4588-89e0-0ef8b5349b17\"\r\n          }\r\n        ],\r\n
+        \       \"id\": \"18f7b360-9f6d-4588-89e0-0ef8b5349b17\",\r\n        \"initiationCode\":
+        \"J\",\r\n        \"prosecutionCaseIdentifier\": {\r\n          \"prosecutionAuthorityCode\":
+        \"TFL\",\r\n          \"prosecutionAuthorityId\": \"31af405e-7b60-4dd8-a244-c24c2d3fa595\",\r\n
+        \         \"prosecutionAuthorityReference\": \"TFL23525RRT9G\"\r\n        },\r\n
+        \       \"statementOfFacts\": \"An incident took place at GREEN PARK station
+        whereby you were spoken to by a member of London Underground staff regarding
+        your train journey and the associated fare.The facts of this incidents are
+        now being considered and I must advise you that legal proceedings may be initiated
+        against you regarding this matter in accordance with the LU prosecution policy\"\r\n
+        \     }\r\n    ],\r\n    \"prosecutionCounsels\": [],\r\n    \"respondentCounsels\":
+        [],\r\n    \"type\": {\r\n      \"description\": \"Plea and Trial Preparation\",\r\n
+        \     \"id\": \"06b0c2bf-3f98-46ed-ab7e-56efaf9ecced\"\r\n    }\r\n  },\r\n
+        \ \"sharedTime\": \"2020-04-17T16:57:04.978Z[UTC]\"\r\n}"
+  recorded_at: Fri, 26 Jun 2020 14:39:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/hearing_result_fetcher/unauthorised.yml
+++ b/spec/cassettes/hearing_result_fetcher/unauthorised.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingHttpTrigger?hearingId=2c24f897-ffc4-439f-9c4a-ec60c7715cd0"
+    uri: "<COMMON_PLATFORM_URL>/LAAGetHearingHttpTrigger?hearingId=ee7b9c09-4a6e-49e3-a484-193dc93a4575"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,13 +23,12 @@ http_interactions:
       www-authenticate:
       - AzureApiManagementKey realm="https://spnl-sit-apim-int-gw.cpp.nonlive/fa-sit-ccp0101-legalaidagency",name="Ocp-Apim-Subscription-Key",type="header"
       date:
-      - Tue, 19 May 2020 15:21:44 GMT
+      - Fri, 26 Jun 2020 14:39:41 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: '{ "statusCode": 401, "message": "Access denied due to invalid subscription
         key. Make sure to provide a valid key for an active subscription." }'
-    http_version: null
-  recorded_at: Tue, 19 May 2020 15:21:44 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/laa_reference_recorder/update.yml
+++ b/spec/cassettes/laa_reference_recorder/update.yml
@@ -21,12 +21,11 @@ http_interactions:
       content-length:
       - '0'
       date:
-      - Fri, 15 May 2020 15:57:01 GMT
+      - Fri, 26 Jun 2020 14:39:34 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: ''
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:01 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/representation_order_recorder/update.yml
+++ b/spec/cassettes/representation_order_recorder/update.yml
@@ -22,12 +22,11 @@ http_interactions:
       content-length:
       - '0'
       date:
-      - Fri, 15 May 2020 15:57:00 GMT
+      - Fri, 26 Jun 2020 14:39:35 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: ''
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:00 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_arrest_summons_number_success.yml
@@ -17,39 +17,38 @@ http_interactions:
       message: OK
     headers:
       content-length:
-      - '4250'
+      - '4394'
       content-type:
       - application/vnd.unifiedsearch.query.laa.cases+json
       cppid:
-      - f8a87587-9504-4aca-8963-c988155b1a22
+      - 31bf0d06-d461-411e-ac29-c05b300eef49
       date:
-      - Fri, 15 May 2020 15:57:02 GMT
+      - Fri, 26 Jun 2020 14:39:42 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: '{"totalResults":3,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"65a4d108-5930-4cdc-9ee3-766162680a73","prosecutionCaseReference":"39befafb","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":false,"defendantName":"KAmgoreUoiZW9uNsvr4P
-        Jack Daniels","defendantId":"2e30868d-5b47-4f11-81e1-f75098fbc137","defendantASN":"arrest123","defendantDOB":"1994-09-11","defendantNINO":"NH323232B","offenceSummary":[{"offenceId":"2231be45-c53e-4884-b279-7979e87d550d","offenceCode":"CA03013","offenceTitle":"Obstruct
-        person executing search warrant for TV receiver","offenceLegislation":"Contrary
-        to section 366(8)(a) and (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2019-12-21","endDate":"2019-09-21","startDate":"2019-03-21","chargeDate":"2019-12-21","modeOfTrial":"Summary","orderIndex":0,"wording":"Wound
-        / inflict grievous bodily harm without intent"}]}],"hearingSummary":[{"hearingId":"52f85aed-a33a-4213-bde8-4b4f8480386d","jurisdictionType":"MAGISTRATES","defendantIds":["2e30868d-5b47-4f11-81e1-f75098fbc137"],"hearingDays":[{"sittingDay":"2020-02-07T00:00:00Z","listingSequence":0,"listedDurationMinutes":30}],"courtCentre":{"id":"7e967376-eacf-4fca-9b30-21b0c5aad427","name":"Bexley
-        Magistrates'' Court","roomId":"8e912353-3b5d-36c3-953e-ad3b94b19de3","roomName":"Courtroom
-        01"},"hearingType":{"id":"c6d76309-c912-436b-a21b-a4c4450bc052","description":"Pre-Trial
-        Review"}}]},{"caseStatus":"CLOSED","prosecutionCaseId":"b46887af-e1d3-4cad-9ad9-e9cb3ca22ab6","prosecutionCaseReference":"36b233eb","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":true,"defendantName":"boiInyVDgHE1Xs8WqZzl
-        Jack Daniels","defendantId":"37967565-184b-4f1c-a57b-9a2aad166e29","defendantASN":"arrest123","defendantDOB":"1994-09-11","defendantNINO":"NH323232B","offenceSummary":[{"offenceId":"e405811a-591d-4706-806b-f67f96da2b02","offenceCode":"CA03013","offenceTitle":"Obstruct
-        person executing search warrant for TV receiver","offenceLegislation":"Contrary
-        to section 366(8)(a) and (9) of the Communications Act 2003.","proceedingsConcluded":true,"arrestDate":"2019-12-21","endDate":"2019-09-21","startDate":"2019-03-21","chargeDate":"2019-12-21","modeOfTrial":"Summary","orderIndex":0,"wording":"Wound
-        / inflict grievous bodily harm without intent"}]}],"hearingSummary":[{"hearingId":"448a0556-a350-439f-a7c4-da72929b513c","jurisdictionType":"MAGISTRATES","defendantIds":["37967565-184b-4f1c-a57b-9a2aad166e29"],"hearingDays":[{"sittingDay":"2020-04-28T09:00:00Z","listingSequence":0,"listedDurationMinutes":1}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
-        Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
-        01"},"hearingType":{"id":"c6d76309-c912-436b-a21b-a4c4450bc052","description":"Pre-Trial
-        Review"}}]},{"caseStatus":"ACTIVE","prosecutionCaseId":"dd4dcc9a-6e7e-4c36-88c1-b678b6c365e7","prosecutionCaseReference":"39667867","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":false,"defendantName":"i7NYi2HoffdsCqcOnchV
+      string: '{"totalResults":3,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"dd4dcc9a-6e7e-4c36-88c1-b678b6c365e7","prosecutionCaseReference":"39667867","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":false,"representationOrder":{},"defendantName":"i7NYi2HoffdsCqcOnchV
         Jack Daniels","defendantId":"ded70896-8569-4b62-9187-c7ce948eb882","defendantASN":"arrest123","defendantDOB":"1994-09-11","defendantNINO":"NH323232B","offenceSummary":[{"offenceId":"d18e625e-abfe-407d-af23-d3edb8307fee","offenceCode":"CA03013","offenceTitle":"Obstruct
         person executing search warrant for TV receiver","offenceLegislation":"Contrary
         to section 366(8)(a) and (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2019-12-21","endDate":"2019-09-21","startDate":"2019-03-21","chargeDate":"2019-12-21","modeOfTrial":"Summary","orderIndex":0,"wording":"Wound
-        / inflict grievous bodily harm without intent"}]}],"hearingSummary":[{"hearingId":"88ff38de-f012-4402-902d-3e3cd69adb34","jurisdictionType":"MAGISTRATES","defendantIds":["ded70896-8569-4b62-9187-c7ce948eb882"],"hearingDays":[{"sittingDay":"2020-05-11T09:00:00Z","listingSequence":1,"listedDurationMinutes":1}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
+        / inflict grievous bodily harm without intent","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"88ff38de-f012-4402-902d-3e3cd69adb34","jurisdictionType":"MAGISTRATES","defendantIds":["ded70896-8569-4b62-9187-c7ce948eb882"],"hearingDays":[{"sittingDay":"2020-05-11T09:00:00Z","listingSequence":1,"listedDurationMinutes":1}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
         Hill Magistrates'' Court","roomId":"b4562684-9209-3ec4-a544-7f80dabd94d8","roomName":"Courtroom
         02"},"hearingType":{"id":"c6d76309-c912-436b-a21b-a4c4450bc052","description":"Pre-Trial
+        Review"}}]},{"caseStatus":"ACTIVE","prosecutionCaseId":"b46887af-e1d3-4cad-9ad9-e9cb3ca22ab6","prosecutionCaseReference":"36b233eb","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":true,"representationOrder":{},"defendantName":"boiInyVDgHE1Xs8WqZzl
+        Jack Daniels","defendantId":"37967565-184b-4f1c-a57b-9a2aad166e29","defendantASN":"arrest123","defendantDOB":"1994-09-11","defendantNINO":"NH323232B","offenceSummary":[{"offenceId":"e405811a-591d-4706-806b-f67f96da2b02","offenceCode":"CA03013","offenceTitle":"Obstruct
+        person executing search warrant for TV receiver","offenceLegislation":"Contrary
+        to section 366(8)(a) and (9) of the Communications Act 2003.","proceedingsConcluded":true,"arrestDate":"2019-12-21","endDate":"2019-09-21","startDate":"2019-03-21","chargeDate":"2019-12-21","modeOfTrial":"Summary","orderIndex":0,"wording":"Wound
+        / inflict grievous bodily harm without intent","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"448a0556-a350-439f-a7c4-da72929b513c","jurisdictionType":"MAGISTRATES","defendantIds":["37967565-184b-4f1c-a57b-9a2aad166e29"],"hearingDays":[{"sittingDay":"2020-04-28T09:00:00Z","listingSequence":0,"listedDurationMinutes":1}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
+        Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
+        01"},"hearingType":{"id":"c6d76309-c912-436b-a21b-a4c4450bc052","description":"Pre-Trial
+        Review"}}]},{"caseStatus":"ACTIVE","prosecutionCaseId":"65a4d108-5930-4cdc-9ee3-766162680a73","prosecutionCaseReference":"39befafb","defendantSummary":[{"organisationName":"EY","proceedingsConcluded":false,"representationOrder":{},"defendantName":"KAmgoreUoiZW9uNsvr4P
+        Jack Daniels","defendantId":"2e30868d-5b47-4f11-81e1-f75098fbc137","defendantASN":"arrest123","defendantDOB":"1994-09-11","defendantNINO":"NH323232B","offenceSummary":[{"offenceId":"2231be45-c53e-4884-b279-7979e87d550d","offenceCode":"CA03013","offenceTitle":"Obstruct
+        person executing search warrant for TV receiver","offenceLegislation":"Contrary
+        to section 366(8)(a) and (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2019-12-21","endDate":"2019-09-21","startDate":"2019-03-21","chargeDate":"2019-12-21","modeOfTrial":"Summary","orderIndex":0,"wording":"Wound
+        / inflict grievous bodily harm without intent","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"52f85aed-a33a-4213-bde8-4b4f8480386d","jurisdictionType":"MAGISTRATES","defendantIds":["2e30868d-5b47-4f11-81e1-f75098fbc137"],"hearingDays":[{"sittingDay":"2020-02-07T00:00:00Z","listingSequence":0,"listedDurationMinutes":30}],"courtCentre":{"id":"7e967376-eacf-4fca-9b30-21b0c5aad427","name":"Bexley
+        Magistrates'' Court","roomId":"8e912353-3b5d-36c3-953e-ad3b94b19de3","roomName":"Courtroom
+        01"},"hearingType":{"id":"c6d76309-c912-436b-a21b-a4c4450bc052","description":"Pre-Trial
         Review"}}]}]}'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:02 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
@@ -21,14 +21,14 @@ http_interactions:
       content-type:
       - application/vnd.unifiedsearch.query.laa.cases+json
       cppid:
-      - 995abfd7-ecaa-40dc-b912-f169b7ab1838
+      - 0746e1d7-9f75-442f-a43b-0bd7104f32d9
       date:
-      - Fri, 15 May 2020 15:57:01 GMT
+      - Fri, 26 Jun 2020 14:39:41 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: '{"totalResults":1,"cases":[{"caseStatus":"CLOSED","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
         Walsh","defendantId":"2ecc9feb-9407-482f-b081-d9e5c8ba3ed3","defendantDOB":"1980-01-01","defendantNINO":"HB133542A","offenceSummary":[{"offenceId":"3f153786-f3cf-4311-bc0c-2d6f48af68a1","offenceCode":"PT00011","offenceTitle":"Driver
         / other person fail to immediately move a vehicle from a cordoned area on
         order of a constable","proceedingsConcluded":false,"arrestDate":"2020-02-01","startDate":"2020-02-01","chargeDate":"2020-02-01","modeOfTrial":"Summary","orderIndex":1,"wording":"Test","laaApplnReference":{"applicationReference":"LAA-20191601","statusId":"58ebf081-2b7d-3b1d-8c47-149fe7dbd672","statusCode":"G2","statusDescription":"Granted
@@ -36,6 +36,5 @@ http_interactions:
         Magistrates'' Court","roomId":"8e912353-3b5d-36c3-953e-ad3b94b19de3","roomName":"Courtroom
         01"},"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
         hearing"}}]}]}'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:01 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
@@ -21,14 +21,14 @@ http_interactions:
       content-type:
       - application/vnd.unifiedsearch.query.laa.cases+json
       cppid:
-      - aad635c2-a00c-4e73-8ff0-733b830b3dd7
+      - 9333614a-088c-496a-8cf1-0f58deca01c4
       date:
-      - Fri, 15 May 2020 15:57:02 GMT
+      - Fri, 26 Jun 2020 14:39:42 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: '{"totalResults":1,"cases":[{"caseStatus":"CLOSED","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
         Walsh","defendantId":"2ecc9feb-9407-482f-b081-d9e5c8ba3ed3","defendantDOB":"1980-01-01","defendantNINO":"HB133542A","offenceSummary":[{"offenceId":"3f153786-f3cf-4311-bc0c-2d6f48af68a1","offenceCode":"PT00011","offenceTitle":"Driver
         / other person fail to immediately move a vehicle from a cordoned area on
         order of a constable","proceedingsConcluded":false,"arrestDate":"2020-02-01","startDate":"2020-02-01","chargeDate":"2020-02-01","modeOfTrial":"Summary","orderIndex":1,"wording":"Test","laaApplnReference":{"applicationReference":"LAA-20191601","statusId":"58ebf081-2b7d-3b1d-8c47-149fe7dbd672","statusCode":"G2","statusDescription":"Granted
@@ -36,6 +36,5 @@ http_interactions:
         Magistrates'' Court","roomId":"8e912353-3b5d-36c3-953e-ad3b94b19de3","roomName":"Courtroom
         01"},"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
         hearing"}}]}]}'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:02 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_national_insurance_number_success.yml
@@ -21,14 +21,14 @@ http_interactions:
       content-type:
       - application/vnd.unifiedsearch.query.laa.cases+json
       cppid:
-      - cccf1517-a6f1-4c27-ac8b-9f698841a32a
+      - 14d155c1-3e71-469b-8021-467d362d4f2f
       date:
-      - Fri, 15 May 2020 15:57:01 GMT
+      - Fri, 26 Jun 2020 14:39:42 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: '{"totalResults":1,"cases":[{"caseStatus":"CLOSED","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"5edd67eb-9d8c-44f2-a57e-c8d026defaa4","prosecutionCaseReference":"20GD0217100","defendantSummary":[{"proceedingsConcluded":true,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2019-09-12","effectiveToDate":"2019-12-12","laaContractNumber":"99998888"},"defendantName":"George
         Walsh","defendantId":"2ecc9feb-9407-482f-b081-d9e5c8ba3ed3","defendantDOB":"1980-01-01","defendantNINO":"HB133542A","offenceSummary":[{"offenceId":"3f153786-f3cf-4311-bc0c-2d6f48af68a1","offenceCode":"PT00011","offenceTitle":"Driver
         / other person fail to immediately move a vehicle from a cordoned area on
         order of a constable","proceedingsConcluded":false,"arrestDate":"2020-02-01","startDate":"2020-02-01","chargeDate":"2020-02-01","modeOfTrial":"Summary","orderIndex":1,"wording":"Test","laaApplnReference":{"applicationReference":"LAA-20191601","statusId":"58ebf081-2b7d-3b1d-8c47-149fe7dbd672","statusCode":"G2","statusDescription":"Granted
@@ -36,6 +36,5 @@ http_interactions:
         Magistrates'' Court","roomId":"8e912353-3b5d-36c3-953e-ad3b94b19de3","roomName":"Courtroom
         01"},"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
         hearing"}}]}]}'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:02 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -17,43 +17,42 @@ http_interactions:
       message: OK
     headers:
       content-length:
-      - '3657'
+      - '3799'
       content-type:
       - application/vnd.unifiedsearch.query.laa.cases+json
       cppid:
-      - 6174d45a-61ce-4599-969e-3cf52354a660
+      - 347320b2-1dff-4066-88b6-79630dc7f209
       date:
-      - Fri, 15 May 2020 15:57:01 GMT
+      - Fri, 26 Jun 2020 14:39:42 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"c37c2ca9-d5f9-4758-a224-52ba918a3d64","prosecutionCaseReference":"19GD1001816","defendantSummary":[{"proceedingsConcluded":false,"defendantName":"Robert
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"c37c2ca9-d5f9-4758-a224-52ba918a3d64","prosecutionCaseReference":"19GD1001816","defendantSummary":[{"proceedingsConcluded":false,"representationOrder":{},"defendantName":"Robert
         PersonGivenName20A PersonGivenName30A Ormsby","defendantId":"c6cf04b5-901d-4a89-a9ab-767eb57306e4","defendantASN":"CPS-NE","defendantDOB":"2008-08-08","offenceSummary":[{"offenceId":"aaa55a60-9a7b-423d-8be8-16c1e8aa7312","offenceCode":"PS90010","offenceTitle":"Public
         service vehicle - passenger use altered / defaced travel mandate","offenceLegislation":"Contrary
         to regulation 7(1)(a) of the Public Service Vehicles (Conduct of Drivers,
         Inspectors, Conductors and Passengers) Regulations 1990 and section 25 of
         the Public Passenger Vehicles Act 1981.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse"},{"offenceId":"d8a2963d-e62d-4bbc-8a89-591ecd71bb1c","offenceCode":"CA03013","offenceTitle":"Obstruct    person
+        with witnesse","laaApplnReference":{}},{"offenceId":"d8a2963d-e62d-4bbc-8a89-591ecd71bb1c","offenceCode":"CA03013","offenceTitle":"Obstruct    person
         executing search warrant for TV receiver","offenceLegislation":"Contrary to
         section 366(8)(a) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse"}]},{"proceedingsConcluded":false,"defendantName":"James PersonGivenName20A
-        PersonGivenName30A Smith","defendantId":"b70a36e5-13d3-4bb3-bb24-94db79b7708b","defendantASN":"TSFL","defendantDOB":"2008-08-08","offenceSummary":[{"offenceId":"137afb84-067b-4455-95bc-206ca4051fc1","offenceCode":"PS90010","offenceTitle":"Public
+        with witnesse","laaApplnReference":{}}]},{"proceedingsConcluded":false,"representationOrder":{},"defendantName":"James
+        PersonGivenName20A PersonGivenName30A Smith","defendantId":"b70a36e5-13d3-4bb3-bb24-94db79b7708b","defendantASN":"TSFL","defendantDOB":"2008-08-08","offenceSummary":[{"offenceId":"137afb84-067b-4455-95bc-206ca4051fc1","offenceCode":"PS90010","offenceTitle":"Public
         service vehicle - passenger use altered / defaced travel mandate","offenceLegislation":"Contrary
         to regulation 7(1)(a) of the Public Service Vehicles (Conduct of Drivers,
         Inspectors, Conductors and Passengers) Regulations 1990 and section 25 of
         the Public Passenger Vehicles Act 1981.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse"},{"offenceId":"eb2f7155-5009-46ae-94ac-be5d62c66754","offenceCode":"CA03014","offenceTitle":"Fail    /
+        with witnesse","laaApplnReference":{}},{"offenceId":"eb2f7155-5009-46ae-94ac-be5d62c66754","offenceCode":"CA03014","offenceTitle":"Fail    /
         refuse give assistance to person executing Communications Act search warrant","offenceLegislation":"Contrary
         to section 366(8)(b) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse"}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
+        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
         Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
         01"},"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
         hearing"}}]}]}'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:02 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/unauthorised.yml
+++ b/spec/cassettes/search_prosecution_case/unauthorised.yml
@@ -23,13 +23,12 @@ http_interactions:
       www-authenticate:
       - AzureApiManagementKey realm="https://spnl-sit-apim-int-gw.cpp.nonlive/fa-sit-ccp0101-legalaidagency",name="Ocp-Apim-Subscription-Key",type="header"
       date:
-      - Fri, 15 May 2020 15:57:01 GMT
+      - Fri, 26 Jun 2020 14:39:41 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: '{ "statusCode": 401, "message": "Access denied due to invalid subscription
         key. Make sure to provide a valid key for an active subscription." }'
-    http_version: null
-  recorded_at: Fri, 15 May 2020 15:57:01 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 26 Jun 2020 14:39:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Hearing, type: :model do
   end
 
   describe 'Common Platform search' do
-    let(:hearing_id) { '2c24f897-ffc4-439f-9c4a-ec60c7715cd0' }
+    before do
+      allow(HearingsCreatorWorker).to receive(:perform_async)
+    end
+
+    let(:hearing_id) { 'ee7b9c09-4a6e-49e3-a484-193dc93a4575' }
 
     let(:hearing) do
       VCR.use_cassette('hearing_result_fetcher/success') do
@@ -17,12 +21,12 @@ RSpec.describe Hearing, type: :model do
       end
     end
 
-    it { expect(hearing.court_name).to eq("Lavender Hill Magistrates' Court") }
-    it { expect(hearing.hearing_type).to eq('Trial') }
-    it { expect(hearing.defendant_names).to eq(['Robert Ormsby']) }
+    it { expect(hearing.court_name).to eq("Bexley Magistrates' Court") }
+    it { expect(hearing.hearing_type).to eq('Plea and Trial Preparation') }
+    it { expect(hearing.defendant_names).to eq(['Ocean Gagnier']) }
 
     context 'hearing events' do
-      let(:hearing_day) { '2020-04-30' }
+      let(:hearing_day) { '2020-04-17' }
 
       let(:hearing_event_recording) do
         VCR.use_cassette('hearing_logs_fetcher/success') do

--- a/spec/requests/api/internal/v1/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v1/hearings_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Api::Internal::V1::Hearings', type: :request do
 
   let(:token) { access_token }
 
-  let(:id) { '2c24f897-ffc4-439f-9c4a-ec60c7715cd0' }
+  let(:id) { 'ee7b9c09-4a6e-49e3-a484-193dc93a4575' }
 
   path '/api/internal/v1/hearings/{id}' do
     get('get hearing') do

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::GetHearingResults do
 
   let(:hearing_id) { 'ceb158e3-7171-40ce-915b-441e2c4e3f75' }
 
-  let(:response) { double(body: { amazing_body: true }.to_json, status: 200) }
+  let(:response) { double(body: { amazing_body: true }, status: 200) }
 
   before do
     allow(HearingFetcher).to receive(:call).with(hearing_id: hearing_id).and_return(response)
@@ -16,8 +16,17 @@ RSpec.describe Api::GetHearingResults do
     subject
   end
 
+  context 'when the body is blank' do
+    let(:response) { double(body: {}, status: 200) }
+
+    it 'does not record the result' do
+      expect(HearingRecorder).not_to receive(:call)
+      subject
+    end
+  end
+
   context 'when the status is a 404' do
-    let(:response) { double(body: {}.to_json, status: 404) }
+    let(:response) { double(body: {}, status: 404) }
 
     it 'does not record the result' do
       expect(HearingRecorder).not_to receive(:call)

--- a/spec/services/hearing_events_fetcher_spec.rb
+++ b/spec/services/hearing_events_fetcher_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe HearingEventsFetcher do
   subject { described_class.call(hearing_id: hearing_id, hearing_date: hearing_date) }
 
-  let(:hearing_id) { '2c24f897-ffc4-439f-9c4a-ec60c7715cd0' }
-  let(:hearing_date) { '2020-04-30' }
+  let(:hearing_id) { 'ee7b9c09-4a6e-49e3-a484-193dc93a4575' }
+  let(:hearing_date) { '2020-04-17' }
 
   it 'returns the requested hearing info' do
     VCR.use_cassette('hearing_logs_fetcher/success') do

--- a/spec/services/hearing_fetcher_spec.rb
+++ b/spec/services/hearing_fetcher_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe HearingFetcher do
   subject { described_class.call(hearing_id: hearing_id) }
 
-  let(:hearing_id) { '2c24f897-ffc4-439f-9c4a-ec60c7715cd0' }
+  let(:hearing_id) { 'ee7b9c09-4a6e-49e3-a484-193dc93a4575' }
 
   it 'returns the requested hearing info' do
     VCR.use_cassette('hearing_result_fetcher/success') do
-      expect(subject.body['id']).to eq(hearing_id)
+      expect(subject.body['hearing']['id']).to eq(hearing_id)
     end
   end
 


### PR DESCRIPTION
The CP format for hearing resulted includes an object of the form
`{ hearing: {}, sharedTime: '' }`
which was the format before, but along the course of changes, it was changed to be just the value of `hearing`.
From the latest schemas/CP output it seems to be using the previous format containing a `sharedTime` property. 
An additional benefit to this is that both the hearings resulted and the hearing notification (PUSH from HMCTS) have the same
format and that makes the consumption by CDA easier.

Additionally, in case of a hearing which isn't available, CP returns 200 with an empty body.

Lastly, re-recorded all the VCRs from CP SIT, and tweaked the specs to use them.


## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
