### PR TITLE
Allow missing prosecution advocate names

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -32,7 +32,7 @@ class Hearing < ApplicationRecord
   end
 
   def prosecution_advocate_names
-    hearing_body['prosecutionCounsels'].map do |prosecution_counsel|
+    hearing_body.dig('prosecutionCounsels')&.map do |prosecution_counsel|
       "#{prosecution_counsel['firstName']} #{prosecution_counsel['lastName']}"
     end
   end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe Hearing, type: :model do
 
       it { expect(hearing.judge_names).to eq(['Mr Recorder J Patterson']) }
       it { expect(hearing.prosecution_advocate_names).to eq(['John Rob']) }
+
+      context 'when prosecutionCounsels are not provided' do
+        before { hearing.body['hearing'].delete('prosecutionCounsels') }
+        it { expect(hearing.prosecution_advocate_names).to be_nil }
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-409)
As the Prosecution Advocate name is optional in the HMCTS schema, hearings which do not contain `prosecutionCounsels` fail.
This PR adds safe navigation to allow this case to be handled gracefully.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
