### PR TITLE
Do not base64 encode cert env vars

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
+++ b/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
@@ -25,10 +25,10 @@ env:
   {{- if .Values.mtls_enabled }}
   - name: SSL_CLIENT_CERT
     value: |
-      {{ .Files.Get .Values.ssl_cert_file | b64enc }}
+      {{ .Files.Get .Values.ssl_cert_file | nindent 6 }}
   - name: SSL_CLIENT_KEY
     value: |
-      {{ .Files.Get .Values.ssl_key_file | b64enc }}
+      {{ .Files.Get .Values.ssl_key_file | nindent 6 }}
   {{- end }}
   {{- if .Values.sqs_messaging_enabled }}
   - name: AWS_LINK_QUEUE_URL


### PR DESCRIPTION
## What

Cert env vars do not need to be base64 encoded, but only indented to match the yaml format.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
