### PR TITLE
Add safe navigation when hearingSummary is not provided

### DIFF
--- a/app/services/prosecution_case_hearings_fetcher.rb
+++ b/app/services/prosecution_case_hearings_fetcher.rb
@@ -6,7 +6,7 @@ class ProsecutionCaseHearingsFetcher < ApplicationService
   end
 
   def call
-    prosecution_case.body['hearingSummary'].map { |hearing| Api::GetHearingResults.call(hearing_id: hearing['hearingId'], publish_to_queue: true) }
+    prosecution_case.body['hearingSummary']&.map { |hearing| Api::GetHearingResults.call(hearing_id: hearing['hearingId'], publish_to_queue: true) }
   end
 
   private

--- a/spec/services/prosecution_case_hearings_fetcher_spec.rb
+++ b/spec/services/prosecution_case_hearings_fetcher_spec.rb
@@ -19,4 +19,23 @@ RSpec.describe ProsecutionCaseHearingsFetcher do
     expect(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_id, publish_to_queue: true)
     subject
   end
+
+  context 'when hearingSummary does not exist' do
+    let(:body) do
+      {
+        "cases": [
+          {
+            "caseStatus": 'CLOSED',
+            "prosecutionCaseId": '5edd67eb-9d8c-44f2-a57e-c8d026defaa4',
+            "defendantSummary": []
+          }
+        ]
+      }
+    end
+
+    it 'does not trigger a call to Api::GetHearingResults' do
+      expect(Api::GetHearingResults).not_to receive(:call)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
## What
Since `hearingSummary` is not guaranteed in the `prosecutionCaseSummary` schema,
this change accounts for its absence, and navigates safely instead of raising an exception.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
