### PR TITLE
Add safe navigation for fetching hearings that do not contain prosecution case info

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -34,9 +34,9 @@ class ProsecutionCase < ApplicationRecord
   private
 
   def case_details
-    hearings.flat_map do |hearing|
-      hearing.body['prosecutionCases'].select { |prosecution_case| prosecution_case['id'] == id }
-    end
+    hearings.flat_map { |hearing|
+      hearing.body.dig('prosecutionCases')&.select { |prosecution_case| prosecution_case['id'] == id }
+    }.compact
   end
 
   def hearings_fetched?

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe ProsecutionCase, type: :model do
           expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: an_instance_of(Hash)).twice
           prosecution_case.defendants
         end
+
+        context 'with no prosecution_case reference' do
+          let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { 'id' => hearing_ids[0] }) }
+          let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { 'id' => hearing_ids[1] }) }
+
+          it 'initialises Defendants without details' do
+            expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil).twice
+            prosecution_case.defendants
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Since `prosecutionCases` on hearings is not a required attribute, we need to ensure safe navigation in its absence.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
