### PR TITLE
Do not process non resulted hearings

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -50,8 +50,8 @@ class ProsecutionCase < ApplicationRecord
   end
 
   def hearing_results
-    @hearing_results ||= hearing_summary_ids.map do |hearing_id|
+    @hearing_results ||= hearing_summary_ids.map { |hearing_id|
       Api::GetHearingResults.call(hearing_id: hearing_id)
-    end
+    }.compact
   end
 end

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe ProsecutionCase, type: :model do
       it { expect(prosecution_case.hearings).to all be_a(Hearing) }
       it { expect(prosecution_case.hearing_ids).to eq(hearing_ids) }
 
+      context 'when a hearing has not resulted' do
+        let(:hearing_one) { nil }
+        let(:hearing_two) { nil }
+
+        it { expect(prosecution_case.hearings).to be_empty }
+      end
+
       context 'when hearings are loaded' do
         before { prosecution_case.hearings }
 


### PR DESCRIPTION
## What
Bugfix: When a hearing has not resulted in CP, it cannot be queried by CDA. 
This change ensures that we do not attempt to process empty hearings. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
