### PR TITLE
Add username against recorded references

### DIFF
--- a/app/contracts/new_laa_reference_contract.rb
+++ b/app/contracts/new_laa_reference_contract.rb
@@ -5,6 +5,7 @@ class NewLaaReferenceContract < Dry::Validation::Contract
 
   params do
     optional(:maat_reference).value(:integer, lt?: 999_999_999)
+    optional(:user_name).value(:string, max_size?: 10)
     required(:defendant_id).value(:string)
   end
 

--- a/app/contracts/unlink_defendant_contract.rb
+++ b/app/contracts/unlink_defendant_contract.rb
@@ -5,17 +5,13 @@ class UnlinkDefendantContract < Dry::Validation::Contract
 
   json do
     required(:defendant_id).value(:string)
-    required(:user_name).value(:string)
+    required(:user_name).value(:string, max_size?: 10)
     required(:unlink_reason_code).value(:integer)
     optional(:unlink_other_reason_text).value(:string)
   end
 
   rule(:defendant_id) do
     key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
-  end
-
-  rule(:user_name) do
-    key.failure('must not exceed 10 characters') if value.length > 10
   end
 
   rule(:unlink_other_reason_text, :unlink_reason_code) do

--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -7,7 +7,7 @@ module Api
         def create
           contract = NewLaaReferenceContract.new.call(**transformed_params)
           if contract.success?
-            LaaReferenceCreatorWorker.perform_async(Current.request_id, transformed_params[:defendant_id], transformed_params[:maat_reference])
+            LaaReferenceCreatorWorker.perform_async(Current.request_id, transformed_params[:defendant_id], transformed_params[:user_name], transformed_params[:maat_reference])
             render status: :accepted
           else
             render json: contract.errors.to_hash, status: :bad_request
@@ -21,7 +21,7 @@ module Api
         end
 
         def allowed_params
-          %i[maat_reference defendant_id]
+          %i[maat_reference defendant_id user_name]
         end
 
         def transformed_params

--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -3,4 +3,5 @@
 class LaaReference < ApplicationRecord
   validates :defendant_id, presence: true
   validates :maat_reference, presence: true, uniqueness: { conditions: -> { where(linked: true) } }
+  validates :user_name, presence: true
 end

--- a/app/services/laa_reference_creator.rb
+++ b/app/services/laa_reference_creator.rb
@@ -19,7 +19,7 @@ class LaaReferenceCreator < ApplicationService
   private
 
   def create_laa_reference!
-    LaaReference.create!(defendant_id: defendant_id, maat_reference: maat_reference, dummy_maat_reference: dummy_reference?)
+    LaaReference.create!(defendant_id: defendant_id, user_name: user_name, maat_reference: maat_reference, dummy_maat_reference: dummy_reference?)
   end
 
   def push_to_sqs

--- a/app/services/laa_reference_creator.rb
+++ b/app/services/laa_reference_creator.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class LaaReferenceCreator < ApplicationService
-  def initialize(defendant_id:, maat_reference: nil)
+  TEMPORARY_CREATED_USER = 'cpUser'
+
+  def initialize(defendant_id:, user_name: nil, maat_reference: nil)
     @defendant_id = defendant_id
+    @user_name = user_name.presence || TEMPORARY_CREATED_USER
     @maat_reference = maat_reference.presence || dummy_maat_reference
   end
 
@@ -20,7 +23,7 @@ class LaaReferenceCreator < ApplicationService
   end
 
   def push_to_sqs
-    Sqs::PublishLaaReference.call(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference)
+    Sqs::PublishLaaReference.call(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, user_name: user_name, maat_reference: maat_reference)
   end
 
   def call_cp_endpoint
@@ -52,5 +55,5 @@ class LaaReferenceCreator < ApplicationService
     @dummy_maat_reference.present?
   end
 
-  attr_reader :defendant_id, :maat_reference
+  attr_reader :defendant_id, :user_name, :maat_reference
 end

--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -3,7 +3,6 @@
 module Sqs
   class PublishLaaReference < ApplicationService
     TEMPORARY_CJS_AREA_CODE = 16
-    TEMPORARY_CREATED_USER = 'cpUser'
     TEMPORARY_CJS_LOCATION = 'B16BG'
     TEMPORARY_DATE_OF_HEARING = '2020-08-16'
     TEMPORARY_POST_HEARING_CUSTODY = 'R'
@@ -11,9 +10,10 @@ module Sqs
     TEMPORARY_MODE_OF_TRIAL = 1
     TEMPORARY_RESULT_CODE = 3026
 
-    def initialize(prosecution_case_id:, defendant_id:, maat_reference:)
+    def initialize(prosecution_case_id:, defendant_id:, user_name:, maat_reference:)
       @prosecution_case = ProsecutionCase.find(prosecution_case_id)
       @maat_reference = maat_reference
+      @user_name = user_name
       @defendant = prosecution_case.defendants.find { |x| x.id == defendant_id }
     end
 
@@ -33,7 +33,7 @@ module Sqs
         caseUrn: prosecution_case.prosecution_case_reference,
         asn: defendant.arrest_summons_number,
         cjsAreaCode: TEMPORARY_CJS_AREA_CODE,
-        createdUser: TEMPORARY_CREATED_USER,
+        createdUser: user_name,
         cjsLocation: TEMPORARY_CJS_LOCATION,
         docLanguage: 'EN',
         isActive: active?,
@@ -80,6 +80,6 @@ module Sqs
       }]
     end
 
-    attr_reader :prosecution_case, :defendant, :maat_reference
+    attr_reader :prosecution_case, :defendant, :user_name, :maat_reference
   end
 end

--- a/app/workers/laa_reference_creator_worker.rb
+++ b/app/workers/laa_reference_creator_worker.rb
@@ -3,9 +3,9 @@
 class LaaReferenceCreatorWorker
   include Sidekiq::Worker
 
-  def perform(request_id, defendant_id, maat_reference = nil)
+  def perform(request_id, defendant_id, user_name = nil, maat_reference = nil)
     Current.set(request_id: request_id) do
-      LaaReferenceCreator.call(defendant_id: defendant_id, maat_reference: maat_reference)
+      LaaReferenceCreator.call(defendant_id: defendant_id, user_name: user_name, maat_reference: maat_reference)
     end
   end
 end

--- a/db/migrate/20200723141728_add_user_name_to_laa_reference.rb
+++ b/db/migrate/20200723141728_add_user_name_to_laa_reference.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUserNameToLaaReference < ActiveRecord::Migration[6.0]
+  def change
+    change_table :laa_references, bulk: true do |t|
+      t.string :user_name, null: false, default: 'cpUser'
+    end
+    change_column_default :laa_references, :user_name, from: 'cpUser', to: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -88,7 +88,8 @@ CREATE TABLE public.laa_references (
     dummy_maat_reference boolean DEFAULT false NOT NULL,
     linked boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    user_name character varying NOT NULL
 );
 
 
@@ -430,6 +431,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200424095754'),
 ('20200429163050'),
 ('20200519141938'),
-('20200720123025');
+('20200720123025'),
+('20200723141728');
 
 

--- a/spec/contracts/new_laa_reference_contract_spec.rb
+++ b/spec/contracts/new_laa_reference_contract_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe NewLaaReferenceContract do
   let(:hash_for_validation) do
     {
       maat_reference: maat_reference,
-      defendant_id: defendant_id
+      defendant_id: defendant_id,
+      user_name: user_name
     }
   end
   let(:maat_reference) { 123_456_789 }
   let(:defendant_id) { '23d7f10a-067a-476e-bba6-bb855674e23b' }
+  let(:user_name) { '' }
 
   it { is_expected.to be_a_success }
 
@@ -18,6 +20,18 @@ RSpec.describe NewLaaReferenceContract do
     let(:maat_reference) { '123456789' }
 
     it { is_expected.to be_a_success }
+  end
+
+  context 'with a user_name' do
+    let(:user_name) { 'johnDoe' }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'with over 10 characters in user name' do
+    let(:user_name) { '12345678910' }
+
+    it { is_expected.to have_contract_error('size cannot be greater than 10') }
   end
 
   context 'with an alphanumeric maat_reference' do

--- a/spec/contracts/unlink_defendant_contract_spec.rb
+++ b/spec/contracts/unlink_defendant_contract_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UnlinkDefendantContract do
 
     it { expect(fullfillment.errors).not_to be_empty }
 
-    it { is_expected.to have_contract_error('must not exceed 10 characters') }
+    it { is_expected.to have_contract_error('size cannot be greater than 10') }
   end
 
   context 'with a non numeric unlink_reason_code' do

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -3,18 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe LaaReference, type: :model do
-  let(:laa_reference) { described_class.new(defendant_id: SecureRandom.uuid, maat_reference: 'A12345') }
+  let(:laa_reference) { described_class.new(defendant_id: SecureRandom.uuid, user_name: 'johnDoe', maat_reference: 'A12345') }
   subject { laa_reference }
 
   describe 'validations' do
     it { should validate_presence_of(:defendant_id) }
     it { should validate_presence_of(:maat_reference) }
+    it { should validate_presence_of(:user_name) }
     it { should validate_uniqueness_of(:maat_reference) }
   end
 
   context 'when an LaaReference is no longer linked' do
     before do
-      described_class.create(defendant_id: SecureRandom.uuid, maat_reference: 'A12345', linked: false)
+      described_class.create!(defendant_id: SecureRandom.uuid, user_name: 'johnDoe', maat_reference: 'A12345', linked: false)
     end
 
     it { is_expected.to be_valid }

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
       data: {
         type: 'laa_references',
         attributes: {
-          maat_reference: 1_231_231
+          maat_reference: 1_231_231,
+          user_name: 'JaneDoe'
         },
         relationships: {
           defendant: {
@@ -58,7 +59,7 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(LaaReferenceCreatorWorker).to receive(:perform_async).with(String, String, 1_231_231).and_call_original
+          expect(LaaReferenceCreatorWorker).to receive(:perform_async).with(String, String, 'JaneDoe', 1_231_231).and_call_original
         end
 
         run_test!
@@ -72,7 +73,22 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
           parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           before do
-            expect(LaaReferenceCreatorWorker).to receive(:perform_async).with(String, String, nil).and_call_original
+            expect(LaaReferenceCreatorWorker).to receive(:perform_async).with(String, String, 'JaneDoe', nil).and_call_original
+          end
+
+          run_test!
+        end
+      end
+
+      context 'with a blank user_name' do
+        response(202, 'Accepted') do
+          before { laa_reference[:data][:attributes].delete(:user_name) }
+          let(:Authorization) { "Bearer #{token.token}" }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
+          before do
+            expect(LaaReferenceCreatorWorker).to receive(:perform_async).with(String, String, nil, 1_231_231).and_call_original
           end
 
           run_test!

--- a/spec/services/laa_reference_creator_spec.rb
+++ b/spec/services/laa_reference_creator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe LaaReferenceCreator do
   end
 
   context 'when an LaaReference exists' do
-    let!(:existing_laa_reference) { LaaReference.create!(defendant_id: SecureRandom.uuid, maat_reference: maat_reference) }
+    let!(:existing_laa_reference) { LaaReference.create!(defendant_id: SecureRandom.uuid, user_name: 'MrDoe', maat_reference: maat_reference) }
 
     it 'raises an ActiveRecord::RecordInvalid error' do
       expect {

--- a/spec/services/laa_reference_creator_spec.rb
+++ b/spec/services/laa_reference_creator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe LaaReferenceCreator do
   let(:defendant_id) { '8cd0ba7e-df89-45a3-8c61-4008a2186d64' }
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
   let(:laa_reference) { LaaReference.last }
+  let(:user_name) { 'caseWorker' }
   before do
     ProsecutionCase.create!(
       id: prosecution_case_id,
@@ -21,7 +22,7 @@ RSpec.describe LaaReferenceCreator do
     allow(Api::GetHearingResults).to receive(:call)
   end
 
-  subject(:create) { described_class.call(maat_reference: maat_reference, defendant_id: defendant_id) }
+  subject(:create) { described_class.call(maat_reference: maat_reference, user_name: user_name, defendant_id: defendant_id) }
 
   it 'creates an LaaReference' do
     expect {
@@ -47,7 +48,7 @@ RSpec.describe LaaReferenceCreator do
   end
 
   it 'calls the Sqs::PublishLaaReference service once' do
-    expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference)
+    expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference, user_name: user_name)
     create
   end
 
@@ -81,7 +82,7 @@ RSpec.describe LaaReferenceCreator do
     end
 
     it 'calls the Sqs::PublishLaaReference service once' do
-      expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference)
+      expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference, user_name: user_name)
       create
     end
 
@@ -91,6 +92,13 @@ RSpec.describe LaaReferenceCreator do
     end
   end
 
+  context 'with no user name' do
+    let(:user_name) { nil }
+    it 'calls the Sqs::PublishLaaReference service once with user_name as cpUser' do
+      expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: maat_reference, user_name: 'cpUser')
+      create
+    end
+  end
   context 'with no maat reference' do
     let(:maat_reference) { nil }
 

--- a/spec/services/laa_reference_unlinker_spec.rb
+++ b/spec/services/laa_reference_unlinker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LaaReferenceUnlinker do
   let(:user_name) { 'johnDoe' }
   let(:unlink_reason_code) { 1 }
   let(:unlink_other_reason_text) { 'Wrong defendant' }
-  let!(:linked_laa_reference) { LaaReference.create(defendant_id: defendant_id, maat_reference: 101_010) }
+  let!(:linked_laa_reference) { LaaReference.create(defendant_id: defendant_id, user_name: 'cpUser', maat_reference: 101_010) }
   before do
     ProsecutionCase.create!(
       id: prosecution_case_id,

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Sqs::PublishLaaReference do
       asn: 'ARREST123',
       cjsAreaCode: 16,
       cjsLocation: 'B16BG',
-      createdUser: 'cpUser',
+      createdUser: 'bossMan',
       docLanguage: 'EN',
       isActive: false,
       defendant: {
@@ -48,7 +48,7 @@ RSpec.describe Sqs::PublishLaaReference do
     }
   end
 
-  subject { described_class.call(prosecution_case_id: prosecution_case_id, defendant_id: defendant_id, maat_reference: maat_reference) }
+  subject { described_class.call(prosecution_case_id: prosecution_case_id, defendant_id: defendant_id, user_name: 'bossMan', maat_reference: maat_reference) }
 
   let(:queue_url) { Rails.configuration.x.aws.sqs_url_link }
 

--- a/spec/workers/laa_reference_creator_worker_spec.rb
+++ b/spec/workers/laa_reference_creator_worker_spec.rb
@@ -5,6 +5,7 @@ require 'sidekiq/testing'
 RSpec.describe LaaReferenceCreatorWorker, type: :worker do
   let(:defendant_id) { '2ecc9feb-9407-482f-b081-d9e5c8ba3ed3' }
   let(:maat_reference) { nil }
+  let(:user_name) { nil }
   let(:request_id) { 'XYZ' }
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
   let!(:set_up_linked_prosecution_case) do
@@ -20,7 +21,7 @@ RSpec.describe LaaReferenceCreatorWorker, type: :worker do
   end
 
   subject(:work) do
-    described_class.perform_async(request_id, defendant_id, maat_reference)
+    described_class.perform_async(request_id, defendant_id, user_name, maat_reference)
   end
 
   it 'queues the job' do
@@ -31,7 +32,7 @@ RSpec.describe LaaReferenceCreatorWorker, type: :worker do
 
   it 'creates a LaaReferenceCreator and calls it' do
     Sidekiq::Testing.inline! do
-      expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: defendant_id, maat_reference: nil).and_call_original
+      expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: defendant_id, user_name: nil, maat_reference: nil).and_call_original
       work
     end
   end
@@ -40,7 +41,17 @@ RSpec.describe LaaReferenceCreatorWorker, type: :worker do
     let(:maat_reference) { 909_090 }
     it 'creates a LaaReferenceCreator and calls it' do
       Sidekiq::Testing.inline! do
-        expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: defendant_id, maat_reference: 909_090)
+        expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: defendant_id, user_name: nil, maat_reference: 909_090)
+        work
+      end
+    end
+  end
+
+  context 'with a non-nil user_name' do
+    let(:user_name) { 'johnDoe' }
+    it 'creates a LaaReferenceCreator and calls it' do
+      Sidekiq::Testing.inline! do
+        expect(LaaReferenceCreator).to receive(:call).once.with(defendant_id: defendant_id, user_name: 'johnDoe', maat_reference: nil)
         work
       end
     end

--- a/spec/workers/unlink_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_laa_reference_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   let(:request_id) { 'XYZ' }
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
   let(:set_up_linked_prosecution_case) do
-    LaaReference.create(defendant_id: defendant_id, maat_reference: 101_010)
+    LaaReference.create(defendant_id: defendant_id, user_name: 'cpUser', maat_reference: 101_010)
     ProsecutionCase.create(
       id: prosecution_case_id,
       body: JSON.parse(file_fixture('prosecution_case_search_result.json').read)['cases'][0]

--- a/swagger/v1/laa_reference.json
+++ b/swagger/v1/laa_reference.json
@@ -23,6 +23,11 @@
       "example": "laa_references",
       "type": "string"
     },
+    "user_name": {
+      "example": "example-username",
+      "description": "The user_name of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
     "maat_reference": {
       "example": 314159265,
       "description": "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings",
@@ -53,7 +58,10 @@
       "properties": {
         "maat_reference": {
           "$ref": "#/definitions/maat_reference"
-        }
+        },
+        "user_name": {
+          "$ref": "#/definitions/user_name"
+        },
       }
     },
     "relationships": {
@@ -109,6 +117,9 @@
   "properties": {
     "maat_reference": {
       "$ref": "#/definitions/maat_reference"
+    },
+    "user_name": {
+      "$ref": "#/definitions/user_name"
     }
   }
 }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -108,6 +108,7 @@ paths:
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '202':
           description: Accepted


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-267)
When an LaaReference request is created, VCD can now send an optional `user_name` attribute, similar to the one sent during unlinking.
For the sake of compatibility, this can be mandatory only once added to VCD.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
