### PR TITLE
Ensure that the maat reference sent from CDA is a string

### DIFF
--- a/app/services/api/record_representation_order.rb
+++ b/app/services/api/record_representation_order.rb
@@ -16,7 +16,7 @@ module Api
 
       @offence_id = offence_id
       @status_code = status_code
-      @application_reference = application_reference
+      @application_reference = application_reference.to_s
       @status_date = status_date
       @effective_start_date = effective_start_date
       @effective_end_date = effective_end_date

--- a/spec/cassettes/representation_order_recorder/update.yml
+++ b/spec/cassettes/representation_order_recorder/update.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<COMMON_PLATFORM_URL>/prosecutionCases/representationOrder/cases/5edd67eb-9d8c-44f2-a57e-c8d026defaa4/defendants/2ecc9feb-9407-482f-b081-d9e5c8ba3ed3/offences/3f153786-f3cf-4311-bc0c-2d6f48af68a1"
     body:
       encoding: UTF-8
-      string: '{"statusCode":"ABCDEF","applicationReference":"SOME SORT OF MAAT ID","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15","effectiveEndDate":"2020-12-15","defenceOrganisation":{"organisation":{"name":"SOME
+      string: '{"statusCode":"ABCDEF","applicationReference":"999999","statusDate":"2019-12-12","effectiveStartDate":"2019-12-15","effectiveEndDate":"2020-12-15","defenceOrganisation":{"organisation":{"name":"SOME
         ORGANISATION"},"laaContractNumber":"CONTRACT REFERENCE"}}'
     headers:
       Ocp-Apim-Subscription-Key:
@@ -22,11 +22,11 @@ http_interactions:
       content-length:
       - '0'
       date:
-      - Tue, 21 Jul 2020 10:02:03 GMT
+      - Mon, 27 Jul 2020 14:47:53 GMT
       x-frame-options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Tue, 21 Jul 2020 10:02:03 GMT
+  recorded_at: Mon, 27 Jul 2020 14:47:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/services/api/record_representation_order_spec.rb
+++ b/spec/services/api/record_representation_order_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::RecordRepresentationOrder do
       defendant_id: defendant_id,
       offence_id: offence_id,
       status_code: 'ABCDEF',
-      application_reference: 'SOME SORT OF MAAT ID',
+      application_reference: 999_999,
       status_date: '2019-12-12',
       effective_start_date: '2019-12-15',
       effective_end_date: '2020-12-15',
@@ -47,7 +47,7 @@ RSpec.describe Api::RecordRepresentationOrder do
     let(:request_params) do
       {
         statusCode: 'ABCDEF',
-        applicationReference: 'SOME SORT OF MAAT ID',
+        applicationReference: '999999',
         statusDate: '2019-12-12',
         effectiveStartDate: '2019-12-15',
         effectiveEndDate: '2020-12-15',
@@ -85,7 +85,7 @@ RSpec.describe Api::RecordRepresentationOrder do
       let(:request_params) do
         {
           statusCode: 'ABCDEF',
-          applicationReference: 'SOME SORT OF MAAT ID',
+          applicationReference: '999999',
           statusDate: '2019-12-12',
           effectiveStartDate: '2019-12-15',
           defenceOrganisation: defence_organisation


### PR DESCRIPTION
As CP expects a string value as opposed to an integer

## What
When a MAAT reference is sent across to CP (for a rep order), it is expected to be converted to a string, failing which CP responds with a validation failure.
This PR fixes the issue by transforming the MAAT reference to a string.
[Link to ticket](https://dsdmoj.atlassian.net/browse/CACP-443)

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
