### PR TITLE
Cacp 430 expose all from hearing summary on hearing

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -11,6 +11,10 @@ class Hearing < ApplicationRecord
     hearing_body['type']['description']
   end
 
+  def hearing_type_description
+    hearing_body['type']['description']
+  end
+
   def hearing_id
     hearing_body['id']
   end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -19,6 +19,10 @@ class Hearing < ApplicationRecord
     hearing_body['id']
   end
 
+  def hearing_days
+    hearing_body['hearingDays'].map { |hearing_day| hearing_day['sittingDay'] }
+  end
+
   def defendant_names
     defendants.map do |defendant|
       "#{defendant['personDefendant']['personDetails']['firstName']} #{defendant['personDefendant']['personDetails']['lastName']}"

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -11,6 +11,10 @@ class Hearing < ApplicationRecord
     hearing_body['type']['description']
   end
 
+  def hearing_id
+    hearing_body['id']
+  end
+
   def defendant_names
     defendants.map do |defendant|
       "#{defendant['personDefendant']['personDetails']['firstName']} #{defendant['personDefendant']['personDetails']['lastName']}"

--- a/app/serializers/hearing_serializer.rb
+++ b/app/serializers/hearing_serializer.rb
@@ -4,7 +4,7 @@ class HearingSerializer
   include FastJsonapi::ObjectSerializer
   set_type :hearings
 
-  attributes :court_name, :hearing_type, :defendant_names, :judge_names, :prosecution_advocate_names, :defence_advocate_names, :hearing_time
+  attributes :court_name, :hearing_type, :defendant_names, :judge_names, :prosecution_advocate_names, :defence_advocate_names, :hearing_time, :hearing_type_description, :hearing_days
 
   has_many :hearing_events, record_type: :hearing_events
   has_many :providers, record_type: :providers

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.providers).to all be_a(Provider) }
       it { expect(hearing.provider_ids).to eq(['a1e3c7a6-c6da-4191-969b-f370fcce46a8']) }
       it { expect(hearing.hearing_id).to eq('2df3d60a-3826-4099-99b0-f89e2cb5e8ec') }
+      it { expect(hearing.hearing_type_description).to eq('This is a description') }
 
       context 'when prosecutionCounsels are not provided' do
         before { hearing.body['hearing'].delete('prosecutionCounsels') }

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.hearing_time).to eq(['10:00:00']) }
       it { expect(hearing.providers).to all be_a(Provider) }
       it { expect(hearing.provider_ids).to eq(['a1e3c7a6-c6da-4191-969b-f370fcce46a8']) }
+      it { expect(hearing.hearing_id).to eq('2df3d60a-3826-4099-99b0-f89e2cb5e8ec') }
 
       context 'when prosecutionCounsels are not provided' do
         before { hearing.body['hearing'].delete('prosecutionCounsels') }

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.provider_ids).to eq(['a1e3c7a6-c6da-4191-969b-f370fcce46a8']) }
       it { expect(hearing.hearing_id).to eq('2df3d60a-3826-4099-99b0-f89e2cb5e8ec') }
       it { expect(hearing.hearing_type_description).to eq('This is a description') }
+      it { expect(hearing.hearing_days).to eq(['2019-10-23T16:19:15.000Z']) }
 
       context 'when prosecutionCounsels are not provided' do
         before { hearing.body['hearing'].delete('prosecutionCounsels') }

--- a/spec/serializer/hearing_serializer_spec.rb
+++ b/spec/serializer/hearing_serializer_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe HearingSerializer do
                     prosecution_advocate_names: ['John Rob'],
                     defence_advocate_names: ['Neil Griffiths'],
                     hearing_time: ['10:00:00'],
-                    provider_ids: ['PROVIDER_UUID'])
+                    provider_ids: ['PROVIDER_UUID'],
+                    hearing_type_description: ['Committal for Sentencing'],
+                    hearing_days: ['2020-02-01'])
   end
 
   subject { described_class.new(hearing).serializable_hash }
@@ -27,6 +29,8 @@ RSpec.describe HearingSerializer do
     it { expect(attribute_hash[:prosecution_advocate_names]).to eq(['John Rob']) }
     it { expect(attribute_hash[:defence_advocate_names]).to eq(['Neil Griffiths']) }
     it { expect(attribute_hash[:hearing_time]).to eq(['10:00:00']) }
+    it { expect(attribute_hash[:hearing_type_description]).to eq(['Committal for Sentencing']) }
+    it { expect(attribute_hash[:hearing_days]).to eq(['2020-02-01']) }
   end
 
   context 'relationships' do


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=398&modal=detail&selectedIssue=CACP-430

Describe what you did and why.

Ensure that all fields on HearingSummary model are available on Hearing model - added hearing_type_description, hearing_id and hearing_days methods to Hearing.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
