### PR TITLE
Pluralize the HearingEventSerializer `type`

### DIFF
--- a/app/serializers/hearing_event_serializer.rb
+++ b/app/serializers/hearing_event_serializer.rb
@@ -2,6 +2,7 @@
 
 class HearingEventSerializer
   include FastJsonapi::ObjectSerializer
+  set_type :hearing_events
 
   attributes :description
 end

--- a/spec/serializer/hearing_event_serializer_spec.rb
+++ b/spec/serializer/hearing_event_serializer_spec.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe HearingEventSerializer do
+  subject(:serializable_hash) { described_class.new(hearing_event).serializable_hash }
+
   let(:hearing_event) do
     instance_double('HearingEvent',
                     id: 'UUID',
                     description: 'Hearing type changed to Plea')
   end
 
-  subject { described_class.new(hearing_event).serializable_hash }
+  context 'data' do
+    subject(:data) { serializable_hash[:data] }
 
-  context 'attributes' do
-    let(:attribute_hash) { subject[:data][:attributes] }
+    it { is_expected.to include(id: 'UUID') }
+    it { is_expected.to include(type: :hearing_events) }
+    it { is_expected.to have_key(:attributes) }
+  end
 
-    it { expect(attribute_hash[:description]).to eq('Hearing type changed to Plea') }
+  context 'data attributes' do
+    subject(:data_attributes) { serializable_hash[:data][:attributes] }
+
+    it { expect(data_attributes[:description]).to eq('Hearing type changed to Plea') }
   end
 end


### PR DESCRIPTION
## What
Pluralize the HearingEventSerializer `type`

## Why
Currently type is not explictly set, resulting in
the type being automatically set to :hearing_event
(singular). This breaks the pattern for other serializers
that are plural.

The result was even when `hearings.hearing_events` was "included"
in a query, and hearing events returned, the consumer (VCD) was unable
to retrieve the hearing events following there patterns.

The type should, ideally, be being tested for in all serialiazers as
it can silently break consumers when not plural.

I notice the `provider_serializer` is not setting type either and `defence_organizaion_serializer` 
explicitly sets type to a singular name. Did not change these as am unclear on the impact.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.