### PR TITLE
Enable inclusions on defendant endpoint

### DIFF
--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -48,7 +48,7 @@ module Api
         end
 
         def serialization_options
-          return { include: inclusions, params: { inclusions: inclusions } } if params[:include].present?
+          return { include: inclusions } if params[:include].present?
 
           {}
         end

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -17,7 +17,7 @@ module Api
         def show
           defendant = DefendantFinder.call(defendant_id: params[:id])
           if defendant.present?
-            render json: DefendantSerializer.new(defendant)
+            render json: DefendantSerializer.new(defendant, serialization_options)
           else
             render status: :not_found
           end
@@ -45,6 +45,16 @@ module Api
 
         def transformed_params
           @transformed_params ||= unlink_params.slice(*allowed_params).to_hash.transform_keys(&:to_sym).merge(defendant_id: params[:id])
+        end
+
+        def serialization_options
+          return { include: inclusions, params: { inclusions: inclusions } } if params[:include].present?
+
+          {}
+        end
+
+        def inclusions
+          params[:include].split(',')
         end
       end
     end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -106,7 +106,11 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
                     schema: {
                       '$ref': 'defendant.json#/definitions/id'
                     },
-                    description: 'The unique identifier of the defendant'
+                    description: 'The uuid of the defendant'
+
+          parameter name: 'include', in: :query, required: false, type: :string,
+                    schema: {},
+                    description: 'Return other data through a has_many relationship </br>e.g. include=offences'
 
           let(:Authorization) { "Bearer #{token.token}" }
           let(:id) { 'c6cf04b5-901d-4a89-a9ab-767eb57306e4' }

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
 
   let(:token) { access_token }
   let(:id) { '23d7f10a-067a-476e-bba6-bb855674e23b' }
+  let(:include) {}
   let(:defendant) do
     {
       data: {
@@ -114,6 +115,7 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
 
           let(:Authorization) { "Bearer #{token.token}" }
           let(:id) { 'c6cf04b5-901d-4a89-a9ab-767eb57306e4' }
+          let(:include) { 'offences' }
 
           run_test!
         end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -89,46 +89,66 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
       end
     end
 
-    path '/api/internal/v1/defendants/{id}' do
-      get('fetch a defendant by ID') do
-        description 'find a defendant where it exists within Court Data Adaptor'
-        consumes 'application/json'
-        tags 'Internal - available to other LAA applications'
-        security [oAuth: []]
+    get('fetch a defendant by ID') do
+      description 'find a defendant where it exists within Court Data Adaptor'
+      consumes 'application/json'
+      tags 'Internal - available to other LAA applications'
+      security [oAuth: []]
 
-        response(200, 'Success') do
-          let!(:prosecution_case_result) do
-            VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
-              Api::SearchProsecutionCase.call(prosecution_case_reference: '19GD1001816')
-            end
+      parameter name: :id, in: :path, required: true, type: :uuid,
+                schema: {
+                  '$ref': 'defendant.json#/definitions/id'
+                },
+                description: 'The uuid of the defendant'
+
+      parameter name: 'include', in: :query, required: false, type: :string,
+                schema: {},
+                description: 'Return other data through a has_many relationship </br>e.g. include=offences'
+
+      context 'with success' do
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:id) { 'c6cf04b5-901d-4a89-a9ab-767eb57306e4' }
+        let!(:prosecution_case_result) do
+          VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
+            Api::SearchProsecutionCase.call(prosecution_case_reference: '19GD1001816')
           end
-
-          parameter name: :id, in: :path, required: true, type: :uuid,
-                    schema: {
-                      '$ref': 'defendant.json#/definitions/id'
-                    },
-                    description: 'The uuid of the defendant'
-
-          parameter name: 'include', in: :query, required: false, type: :string,
-                    schema: {},
-                    description: 'Return other data through a has_many relationship </br>e.g. include=offences'
-
-          let(:Authorization) { "Bearer #{token.token}" }
-          let(:id) { 'c6cf04b5-901d-4a89-a9ab-767eb57306e4' }
-          let(:include) { 'offences' }
-
-          run_test!
         end
 
-        context 'not found' do
-          response('404', 'Not found') do
-            let(:Authorization) { "Bearer #{token.token}" }
-            let(:id) { 'c6cf04b5' }
+        context 'with no inclusions' do
+          let(:include) {}
 
-            parameter '$ref' => '#/components/parameters/transaction_id_header'
-
+          response(200, 'Success') do
             run_test!
           end
+        end
+
+        context 'with offences included' do
+          let(:include) { 'offences' }
+
+          response(200, 'Success') do
+            let!(:prosecution_case_result) do
+              VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
+                Api::SearchProsecutionCase.call(prosecution_case_reference: '19GD1001816')
+              end
+            end
+
+            run_test! do |response|
+              hashed = JSON.parse(response.body, symbolize_names: true)
+              included_types = hashed[:included].map { |inc| inc[:type] }
+              expect(included_types).to all(eql('offences'))
+            end
+          end
+        end
+      end
+
+      context 'when not found' do
+        response('404', 'Not found') do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:id) { 'c6cf04b5' }
+
+          parameter '$ref' => '#/components/parameters/transaction_id_header'
+
+          run_test!
         end
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -83,7 +83,13 @@ paths:
         type: uuid
         schema:
           "$ref": defendant.json#/definitions/id
-        description: The unique identifier of the defendant
+        description: The uuid of the defendant
+      - name: include
+        in: query
+        required: false
+        type: string
+        schema: {}
+        description: Return other data through a has_many relationship </br>e.g. include=offences
       - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '200':


### PR DESCRIPTION
## What
Enable the retrieval of offences as part of
a defendant query

## Why
VCD is to query defendants on this endpoint and
display their offences on the same view/page. One
call to include all data is therefore more performant.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.