### PR TITLE
Expose eventTime from hearing event

### DIFF
--- a/app/models/hearing_event.rb
+++ b/app/models/hearing_event.rb
@@ -12,4 +12,8 @@ class HearingEvent
   def description
     body['recordedLabel']
   end
+
+  def occurred_at
+    body['eventTime']
+  end
 end

--- a/app/serializers/hearing_event_serializer.rb
+++ b/app/serializers/hearing_event_serializer.rb
@@ -5,4 +5,5 @@ class HearingEventSerializer
   set_type :hearing_events
 
   attributes :description
+  attributes :occurred_at
 end

--- a/spec/models/hearing_event_spec.rb
+++ b/spec/models/hearing_event_spec.rb
@@ -10,4 +10,5 @@ RSpec.describe HearingEvent, type: :model do
   subject(:defendant) { described_class.new(body: hearing_event_hash) }
 
   it { expect(defendant.description).to eq('Hearing started') }
+  it { expect(defendant.occurred_at).to eq('2020-04-30T16:17:58.610Z') }
 end

--- a/spec/serializer/hearing_event_serializer_spec.rb
+++ b/spec/serializer/hearing_event_serializer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe HearingEventSerializer do
   let(:hearing_event) do
     instance_double('HearingEvent',
                     id: 'UUID',
-                    description: 'Hearing type changed to Plea')
+                    description: 'Hearing type changed to Plea',
+                    occurred_at: '2020-04-30T16:17:58.610Z')
   end
 
   context 'data' do
@@ -21,5 +22,6 @@ RSpec.describe HearingEventSerializer do
     subject(:data_attributes) { serializable_hash[:data][:attributes] }
 
     it { expect(data_attributes[:description]).to eq('Hearing type changed to Plea') }
+    it { expect(data_attributes[:occurred_at]).to eq('2020-04-30T16:17:58.610Z') }
   end
 end


### PR DESCRIPTION
## What
Expose the time of an event for use by consumers

## Why
VCD consumer, at least, needs to display this
field.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.