### PR TITLE
Use Offence code instead of temporary offence code

### DIFF
--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -6,7 +6,6 @@ module Sqs
     TEMPORARY_CJS_LOCATION = 'B16BG'
     TEMPORARY_DATE_OF_HEARING = '2020-08-16'
     TEMPORARY_POST_HEARING_CUSTODY = 'R'
-    TEMPORARY_OFFENCE_CODE = 'AA06035'
     TEMPORARY_MODE_OF_TRIAL = 1
     TEMPORARY_RESULT_CODE = 3026
 
@@ -56,7 +55,7 @@ module Sqs
       defendant.offences.map do |offence|
         [
           [:offenceId, offence.id],
-          [:offenceCode, TEMPORARY_OFFENCE_CODE],
+          [:offenceCode, offence.code],
           [:asnSeq, offence.order_index],
           [:offenceShortTitle, offence.title],
           [:offenceWording, offence.body['wording']],

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Sqs::PublishLaaReference do
         offences: [
           {
             offenceId: '3f153786-f3cf-4311-bc0c-2d6f48af68a1',
-            offenceCode: 'AA06035',
+            offenceCode: 'PT00011',
             modeOfTrial: 1,
             asnSeq: 1,
             offenceShortTitle: 'Driver / other person fail to immediately move a vehicle from a cordoned area on order of a constable',


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-451)

Use offence code instead of a temporary value.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
