### PR TITLE
Remove hearing time

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -37,12 +37,6 @@ class Hearing < ApplicationRecord
     hearing_events.map(&:id)
   end
 
-  def hearing_time
-    hearing_body.dig('hearingDays')&.map do |detail|
-      detail['startTime']
-    end
-  end
-
   def judge_names
     judiciary.map do |judge|
       "#{judge['title']} #{judge['firstName']} #{judge['middleName']} #{judge['lastName']}"

--- a/app/serializers/hearing_serializer.rb
+++ b/app/serializers/hearing_serializer.rb
@@ -4,7 +4,14 @@ class HearingSerializer
   include FastJsonapi::ObjectSerializer
   set_type :hearings
 
-  attributes :court_name, :hearing_type, :defendant_names, :judge_names, :prosecution_advocate_names, :defence_advocate_names, :hearing_time, :hearing_type_description, :hearing_days
+  attributes :court_name,
+             :hearing_type,
+             :hearing_type_description,
+             :hearing_days,
+             :defendant_names,
+             :judge_names,
+             :prosecution_advocate_names,
+             :defence_advocate_names
 
   has_many :hearing_events, record_type: :hearing_events
   has_many :providers, record_type: :providers

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.judge_names).to eq(['Mr Recorder J Patterson']) }
       it { expect(hearing.prosecution_advocate_names).to eq(['John Rob']) }
       it { expect(hearing.defence_advocate_names).to eq(['Neil Griffiths']) }
-      it { expect(hearing.hearing_time).to eq(['10:00:00']) }
       it { expect(hearing.providers).to all be_a(Provider) }
       it { expect(hearing.provider_ids).to eq(['a1e3c7a6-c6da-4191-969b-f370fcce46a8']) }
       it { expect(hearing.hearing_id).to eq('2df3d60a-3826-4099-99b0-f89e2cb5e8ec') }
@@ -69,11 +68,6 @@ RSpec.describe Hearing, type: :model do
       context 'when defenceCounsels are not provided' do
         before { hearing.body['hearing'].delete('defenceCounsels') }
         it { expect(hearing.defence_advocate_names).to be_nil }
-      end
-
-      context 'when a hearing startTime is not provided' do
-        before { hearing.body['hearing']['hearingDays'].map { |detail| detail.delete('startTime') } }
-        it { expect(hearing.hearing_time).to eq([nil]) }
       end
     end
   end

--- a/spec/serializer/hearing_serializer_spec.rb
+++ b/spec/serializer/hearing_serializer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe HearingSerializer do
                     judge_names: ['Mr Recorder J Patterson'],
                     prosecution_advocate_names: ['John Rob'],
                     defence_advocate_names: ['Neil Griffiths'],
-                    hearing_time: ['10:00:00'],
                     provider_ids: ['PROVIDER_UUID'],
                     hearing_type_description: ['Committal for Sentencing'],
                     hearing_days: ['2020-02-01'])
@@ -28,7 +27,6 @@ RSpec.describe HearingSerializer do
     it { expect(attribute_hash[:judge_names]).to eq(['Mr Recorder J Patterson']) }
     it { expect(attribute_hash[:prosecution_advocate_names]).to eq(['John Rob']) }
     it { expect(attribute_hash[:defence_advocate_names]).to eq(['Neil Griffiths']) }
-    it { expect(attribute_hash[:hearing_time]).to eq(['10:00:00']) }
     it { expect(attribute_hash[:hearing_type_description]).to eq(['Committal for Sentencing']) }
     it { expect(attribute_hash[:hearing_days]).to eq(['2020-02-01']) }
   end


### PR DESCRIPTION
## What
Remove hearing time

## Why
Common platform does not expose this
as a separate field as yet (or ever).

see [closed PR on mock for details](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/pull/222)

>seems like: startTime was added by CP around v1.5, but reverted by version 1.7, hence it is no longer available separately:
https://github.com/ministryofjustice/laa-court-data-adaptor/blob/722c9709fe2a2a9f1636f6d84c1013d3015115fd/app/models/hearing.rb#L40-L44

>we should probably remove this from the adaptor

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.