### PR TITLE
Use the same attribute for hearing_type in hearing summaries and hearings

### DIFF
--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -9,7 +9,7 @@ class HearingSummary
     body['hearingId']
   end
 
-  def hearing_type_description
+  def hearing_type
     body['hearingType']['description']
   end
 

--- a/app/serializers/hearing_summary_serializer.rb
+++ b/app/serializers/hearing_summary_serializer.rb
@@ -4,5 +4,5 @@ class HearingSummarySerializer
   include FastJsonapi::ObjectSerializer
   set_type :hearing_summaries
 
-  attributes :hearing_type_description, :hearing_days
+  attributes :hearing_type, :hearing_days
 end

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe HearingSummary, type: :model do
   subject(:hearing_summary) { described_class.new(body: hearing_summary_hash) }
 
   it { expect(hearing_summary.id).to eq('b935a64a-6d03-4da4-bba6-4d32cc2e7fb4') }
-  it { expect(hearing_summary.hearing_type_description).to eq('First hearing') }
+  it { expect(hearing_summary.hearing_type).to eq('First hearing') }
   it { expect(hearing_summary.hearing_days).to eq(['2020-02-17T15:00:00Z']) }
 end

--- a/spec/serializer/hearing_summary_serializer_spec.rb
+++ b/spec/serializer/hearing_summary_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HearingSummarySerializer do
   let(:hearing_summary) do
     instance_double('HearingSummary',
                     id: 'UUID',
-                    hearing_type_description: 'Committal for Sentencing',
+                    hearing_type: 'Committal for Sentencing',
                     hearing_days: ['2020-02-01'])
   end
 
@@ -13,7 +13,7 @@ RSpec.describe HearingSummarySerializer do
   context 'attributes' do
     let(:attribute_hash) { subject[:data][:attributes] }
 
-    it { expect(attribute_hash[:hearing_type_description]).to eq('Committal for Sentencing') }
+    it { expect(attribute_hash[:hearing_type]).to eq('Committal for Sentencing') }
     it { expect(attribute_hash[:hearing_days]).to eq(['2020-02-01']) }
   end
 end

--- a/swagger/v1/hearing_summary.json
+++ b/swagger/v1/hearing_summary.json
@@ -21,7 +21,7 @@
       "example": "hearing_summaries",
       "type": "string"
     },
-    "hearing_type_description": {
+    "hearing_type": {
       "readOnly": true,
       "example": "First hearing",
       "description": "A description of the hearing type",
@@ -60,8 +60,8 @@
     "attributes": {
       "type": "object",
       "properties": {
-        "hearing_type_description": {
-          "$ref": "#/definitions/hearing_type_description"
+        "hearing_type": {
+          "$ref": "#/definitions/hearing_type"
         },
         "hearing_days": {
           "$ref": "#/definitions/hearing_days"
@@ -82,8 +82,8 @@
     },
   ],
   "properties": {
-    "hearing_type_description": {
-      "$ref": "#/definitions/hearing_type_description"
+    "hearing_type": {
+      "$ref": "#/definitions/hearing_type"
     },
     "hearing_days": {
       "$ref": "#/definitions/hearing_days"


### PR DESCRIPTION
…ings

## What
Follow up to https://github.com/ministryofjustice/laa-court-data-adaptor/pull/248
The new attribute was added to sync Hearing and HearingSummary as far as possible.
This will allow VCD to use the same attribute name on both the summary and full version.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
