### PR TITLE
Fetch LAA reference info from offences instead of defendant.

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -16,7 +16,7 @@ class HearingsCreator < ApplicationService
   def push_prosecution_cases
     hearing[:prosecutionCases]&.each do |prosecution_case|
       prosecution_case[:defendants].each do |defendant|
-        next if defendant[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z')
+        next if defendant[:offences].map { |offence| offence[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z') }.any?
 
         push_to_sqs(shared_time: shared_time,
                     case_urn: prosecution_case[:prosecutionCaseIdentifier][:caseURN],
@@ -29,7 +29,7 @@ class HearingsCreator < ApplicationService
   def push_appeals
     hearing[:courtApplications]&.each do |appeal|
       defendant = appeal.dig(:applicant, :defendant)
-      next if defendant[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z')
+      next if defendant[:offences].map { |offence| offence[:laaApplnReference][:applicationReference]&.start_with?('A', 'Z') }.any?
 
       push_to_sqs(shared_time: shared_time,
                   case_urn: appeal[:applicationReference],

--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -64,7 +64,7 @@ module Sqs
 
     def message
       {
-        maatId: defendant.dig(:laaApplnReference, :applicationReference).to_i,
+        maatId: maat_reference,
         caseUrn: case_urn,
         jurisdictionType: jurisdiction_type,
         asn: defendant.dig(:personDefendant, :arrestSummonsNumber),
@@ -77,6 +77,10 @@ module Sqs
         session: session_hash,
         ccOutComeData: crown_court_outcome_hash
       }
+    end
+
+    def maat_reference
+      defendant[:offences].first[:laaApplnReference][:applicationReference].to_i
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/app/workers/hearings_creator_worker.rb
+++ b/app/workers/hearings_creator_worker.rb
@@ -5,7 +5,7 @@ class HearingsCreatorWorker
 
   def perform(request_id, hearing, shared_time)
     Current.set(request_id: request_id) do
-      HearingsCreator.call(hearing: hearing, shared_time: shared_time)
+      HearingsCreator.call(hearing: hearing.deep_transform_keys(&:to_sym), shared_time: shared_time)
     end
   end
 end

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -80,12 +80,6 @@ RSpec.describe Sqs::PublishHearing do
           }
         }
       ],
-      'laaApplnReference': {
-        'applicationReference': '123456789',
-        'statusCode': 'AP',
-        'statusDescription': 'Application Pending',
-        'statusDate': '2018-10-24'
-      },
       'defenceOrganisation': {
         'laaAccountNumber': '0A935R'
       }

--- a/spec/workers/hearings_creator_worker_spec.rb
+++ b/spec/workers/hearings_creator_worker_spec.rb
@@ -4,7 +4,20 @@ require 'sidekiq/testing'
 
 RSpec.describe HearingsCreatorWorker, type: :worker do
   let(:hearing_hash) do
-    { 'prosecutionCases' => '[]' }
+    {
+      'prosecutionCases' => [{
+        'defendants' => {}
+      }]
+    }
+  end
+
+  let(:transformed_hearing_hash) do
+    {
+      prosecutionCases: [{
+        defendants: {
+        }
+      }]
+    }
   end
   let(:shared_time) { '2020-06-16' }
   let(:request_id) { 'XYZ' }
@@ -19,9 +32,9 @@ RSpec.describe HearingsCreatorWorker, type: :worker do
     }.to change(described_class.jobs, :size).by(1)
   end
 
-  it 'creates a HearingsCreator and calls it' do
+  it 'creates a HearingsCreator and calls with a transformed hash' do
     Sidekiq::Testing.inline! do
-      expect(HearingsCreator).to receive(:call).once.with(hearing: hearing_hash, shared_time: shared_time).and_call_original
+      expect(HearingsCreator).to receive(:call).once.with(hearing: transformed_hearing_hash, shared_time: shared_time).and_call_original
       work
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-477)
Fetch LAA reference info from offence instead of defendant, as it is no longer available against defendants.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
