### PR TITLE
Cacp 475 remove offences without status date when ap

### DIFF
--- a/app/contracts/new_representation_order_contract.rb
+++ b/app/contracts/new_representation_order_contract.rb
@@ -6,6 +6,8 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
 
   STATUS_CODES = %w[AP FB FJ FM WD G2 GQ GR].freeze
 
+  NON_PENDING_OUTCOME_STATUS_CODES = %w[FB FJ FM WD G2 GQ GR].freeze
+
   json do
     required(:maat_reference).value(:integer, lt?: 999_999_999)
     required(:defence_organisation).hash do
@@ -38,8 +40,8 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
     required(:offences).array(:hash) do
       required(:offence_id).value(:string)
       required(:status_code).value(:string)
-      required(:status_date).value(:date)
-      required(:effective_start_date).value(:date)
+      optional(:status_date).value(:date)
+      optional(:effective_start_date).value(:date)
       optional(:effective_end_date).value(:date)
     end
   end
@@ -51,5 +53,7 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
   rule(:offences).each do
     key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value[:offence_id])
     key.failure('is not a valid status') unless STATUS_CODES.include? value[:status_code]
+    key.failure('this status requires a status date') if NON_PENDING_OUTCOME_STATUS_CODES.include?(value[:status_code]) && value[:status_date].present? == false
+    key.failure('this status requires an effective start date') if NON_PENDING_OUTCOME_STATUS_CODES.include?(value[:status_code]) && value[:effective_start_date].present? == false
   end
 end

--- a/app/contracts/new_representation_order_contract.rb
+++ b/app/contracts/new_representation_order_contract.rb
@@ -6,8 +6,6 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
 
   STATUS_CODES = %w[AP FB FJ FM WD G2 GQ GR].freeze
 
-  NON_PENDING_OUTCOME_STATUS_CODES = %w[FB FJ FM WD G2 GQ GR].freeze
-
   json do
     required(:maat_reference).value(:integer, lt?: 999_999_999)
     required(:defence_organisation).hash do
@@ -53,7 +51,7 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
   rule(:offences).each do
     key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value[:offence_id])
     key.failure('is not a valid status') unless STATUS_CODES.include? value[:status_code]
-    key.failure('this status requires a status date') if NON_PENDING_OUTCOME_STATUS_CODES.include?(value[:status_code]) && value[:status_date].present? == false
-    key.failure('this status requires an effective start date') if NON_PENDING_OUTCOME_STATUS_CODES.include?(value[:status_code]) && value[:effective_start_date].present? == false
+    key.failure('this status requires a status date') if value[:status_code] != 'AP' && value[:status_date].blank?
+    key.failure('this status requires an effective start date') if value[:status_code] != 'AP' && value[:effective_start_date].blank?
   end
 end

--- a/app/services/representation_order_creator.rb
+++ b/app/services/representation_order_creator.rb
@@ -16,6 +16,8 @@ class RepresentationOrderCreator < ApplicationService
   private
 
   def call_cp_endpoint
+    remove_offences_without_status_date
+
     offences.each do |offence|
       prosecution_case = ProsecutionCaseDefendantOffence.find_by!(defendant_id: defendant_id, offence_id: offence[:offence_id])
 
@@ -30,6 +32,12 @@ class RepresentationOrderCreator < ApplicationService
         effective_end_date: offence[:effective_end_date],
         defence_organisation: defence_organisation
       )
+    end
+  end
+
+  def remove_offences_without_status_date
+    offences.each do |offence|
+      offences.delete(offence) if offence[:status_date].present? == false
     end
   end
 

--- a/app/services/representation_order_creator.rb
+++ b/app/services/representation_order_creator.rb
@@ -2,12 +2,11 @@
 
 class RepresentationOrderCreator < ApplicationService
   def initialize(defendant_id:, offences:, maat_reference:, defence_organisation:)
-    @offences = offences.map(&:with_indifferent_access)
+    @offences = offences.map(&:with_indifferent_access).reject { |offence| offence[:status_date].blank? }
     @maat_reference = maat_reference
     @defendant_id = defendant_id
     @defence_organisation = defence_organisation.deep_transform_keys { |key| key.to_s.camelize(:lower).to_sym }
     sanitise_defence_organisation
-    remove_offences_without_status_date
   end
 
   def call
@@ -31,12 +30,6 @@ class RepresentationOrderCreator < ApplicationService
         effective_end_date: offence[:effective_end_date],
         defence_organisation: defence_organisation
       )
-    end
-  end
-
-  def remove_offences_without_status_date
-    offences.each do |offence|
-      offences.delete(offence) if offence[:status_date].blank?
     end
   end
 

--- a/app/services/representation_order_creator.rb
+++ b/app/services/representation_order_creator.rb
@@ -7,6 +7,7 @@ class RepresentationOrderCreator < ApplicationService
     @defendant_id = defendant_id
     @defence_organisation = defence_organisation.deep_transform_keys { |key| key.to_s.camelize(:lower).to_sym }
     sanitise_defence_organisation
+    remove_offences_without_status_date
   end
 
   def call
@@ -16,8 +17,6 @@ class RepresentationOrderCreator < ApplicationService
   private
 
   def call_cp_endpoint
-    remove_offences_without_status_date
-
     offences.each do |offence|
       prosecution_case = ProsecutionCaseDefendantOffence.find_by!(defendant_id: defendant_id, offence_id: offence[:offence_id])
 
@@ -37,7 +36,7 @@ class RepresentationOrderCreator < ApplicationService
 
   def remove_offences_without_status_date
     offences.each do |offence|
-      offences.delete(offence) if offence[:status_date].present? == false
+      offences.delete(offence) if offence[:status_date].blank?
     end
   end
 

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -142,4 +142,8 @@ RSpec.describe NewRepresentationOrderContract do
 
     it { is_expected.not_to be_a_success }
   end
+
+  context 'two offences with application outcomes and statusDates present' do
+    it { is_expected.to be_a_success }
+  end
 end

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -143,12 +143,25 @@ RSpec.describe NewRepresentationOrderContract do
     it { is_expected.not_to be_a_success }
   end
 
-  context 'Application pending status with a statusDate present' do
-    before do
-      offences_array.shift
-      offences_array[0][:status_code] = 'AP'
-    end
+  let(:offences_array) do
+    [
+      {
+        offence_id: '23d7f10a-067a-476e-bba6-bb855674e23b',
+        status_code: 'AP',
+        status_date: Date.new(2020, 2, 12),
+        effective_start_date: Date.new(2020, 2, 20),
+        effective_end_date: Date.new(2020, 2, 25)
+      }
+    ]
+  end
 
+  context 'Application pending status with a statusDate present' do
     it { is_expected.to be_a_success }
+  end
+
+  context 'Application pending without a statusDate' do
+    before { offences_array[0][:status_date] = nil }
+
+    it { is_expected.not_to be_a_success }
   end
 end

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe NewRepresentationOrderContract do
     it { is_expected.not_to be_a_success }
   end
 
+  context 'with a missing statusDate' do
+    before { offences_array[0].delete(:status_date) }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with a missing effectiveStartDate' do
+    before { offences_array[0].delete(:effective_start_date) }
+
+    it { is_expected.not_to be_a_success }
+  end
+
+  context 'with a status code of AP' do
+    before { offences_array[0][:status_code] = 'AP' }
+
+    it { is_expected.to be_a_success }
+
+    context 'with a missing statusDate ' do
+      before { offences_array[0].delete(:status_date) }
+
+      it { is_expected.to be_a_success }
+
+      context 'and a missing effectiveStartDate' do
+        before { offences_array[0].delete(:effective_start_date) }
+
+        it { is_expected.to be_a_success }
+      end
+    end
+  end
+
   context 'with missing defence_organisation name' do
     before { defence_organisation[:organisation].delete(:name) }
 
@@ -139,28 +169,6 @@ RSpec.describe NewRepresentationOrderContract do
 
   context 'with unexpected keys' do
     before { defence_organisation[:organisation][:contact][:additional_info] = 'Hello' }
-
-    it { is_expected.not_to be_a_success }
-  end
-
-  let(:offences_array) do
-    [
-      {
-        offence_id: '23d7f10a-067a-476e-bba6-bb855674e23b',
-        status_code: 'AP',
-        status_date: Date.new(2020, 2, 12),
-        effective_start_date: Date.new(2020, 2, 20),
-        effective_end_date: Date.new(2020, 2, 25)
-      }
-    ]
-  end
-
-  context 'Application pending status with a statusDate present' do
-    it { is_expected.to be_a_success }
-  end
-
-  context 'Application pending without a statusDate' do
-    before { offences_array[0][:status_date] = nil }
 
     it { is_expected.not_to be_a_success }
   end

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -143,7 +143,12 @@ RSpec.describe NewRepresentationOrderContract do
     it { is_expected.not_to be_a_success }
   end
 
-  context 'two offences with application outcomes and statusDates present' do
+  context 'Application pending status with a statusDate present' do
+    before do
+      offences_array.shift
+      offences_array[0][:status_code] = 'AP'
+    end
+
     it { is_expected.to be_a_success }
   end
 end

--- a/spec/services/representation_order_creator_spec.rb
+++ b/spec/services/representation_order_creator_spec.rb
@@ -77,17 +77,12 @@ RSpec.describe RepresentationOrderCreator do
       create
     end
 
-    context 'one offence has a status of AP' do
-      context 'and does not have a status date' do
-        before do
-          offence_two.delete(:status_date)
-          offence_two[:status_code] = 'AP'
-        end
+    context 'one offence does not have a status date' do
+      before { offence_two.delete(:status_date) }
 
-        it 'calls the Api::RecordRepresentationOrder service once' do
-          expect(Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
-          create
-        end
+      it 'calls the Api::RecordRepresentationOrder service once' do
+        expect(Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+        create
       end
     end
   end

--- a/spec/services/representation_order_creator_spec.rb
+++ b/spec/services/representation_order_creator_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe RepresentationOrderCreator do
       expect(Api::RecordRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create
     end
+
+    context 'one offence has a status of AP' do
+      context 'and does not have a status date' do
+        before do
+          offence_two.delete(:status_date)
+          offence_two[:status_code] = 'AP'
+        end
+
+        it 'calls the Api::RecordRepresentationOrder service once' do
+          expect(Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+          create
+        end
+      end
+    end
   end
 
   context 'with indifferent access' do


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/CACP-475

Amend validations to make statusDate and effectiveStartDate optional when the statusCode is AP when CDA receives data from MAAT API

Filter offences in RepresentationOrderCreator service so only cases with a statusDate are sent to HMCTS Common Platform from CDA

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
