### PR TITLE
Fetch hearing details from hearing object inside resulted payload

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -35,7 +35,7 @@ class ProsecutionCase < ApplicationRecord
 
   def case_details
     hearings.flat_map { |hearing|
-      hearing.body.dig('prosecutionCases')&.select { |prosecution_case| prosecution_case['id'] == id }
+      hearing.body.dig('hearing', 'prosecutionCases')&.select { |prosecution_case| prosecution_case['id'] == id }
     }.compact
   end
 

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -38,13 +38,16 @@ RSpec.describe ProsecutionCase, type: :model do
         Hearing.create(
           id: hearing_ids[0],
           body: {
-            'id' => hearing_ids[0],
-            'prosecutionCases' => [{
-              'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
-              'defendants' => [{
-                'id' => 'c6cf04b5-901d-4a89-a9ab-767eb57306e4'
+            'hearing' => {
+              'id' => hearing_ids[0],
+              'prosecutionCases' => [{
+                'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
+                'defendants' => [{
+                  'id' => 'c6cf04b5-901d-4a89-a9ab-767eb57306e4'
+                }]
               }]
-            }]
+            },
+            'sharedTime' => '2020-12-12'
           }
         )
       end
@@ -53,13 +56,16 @@ RSpec.describe ProsecutionCase, type: :model do
         Hearing.create(
           id: hearing_ids[1],
           body: {
-            'id' => hearing_ids[1],
-            'prosecutionCases' => [{
-              'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
-              'defendants' => [{
-                'id' => 'b70a36e5-13d3-4bb3-bb24-94db79b7708b'
+            'hearing' => {
+              'id' => hearing_ids[1],
+              'prosecutionCases' => [{
+                'id' => '31cbe62d-b1ec-4e82-89f7-99dced834900',
+                'defendants' => [{
+                  'id' => 'b70a36e5-13d3-4bb3-bb24-94db79b7708b'
+                }]
               }]
-            }]
+            },
+            'sharedTime' => '2020-10-20'
           }
         )
       end
@@ -83,8 +89,8 @@ RSpec.describe ProsecutionCase, type: :model do
         end
 
         context 'with no prosecution_case reference' do
-          let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { 'id' => hearing_ids[0] }) }
-          let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { 'id' => hearing_ids[1] }) }
+          let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { 'hearing' => { 'id' => hearing_ids[0] } }) }
+          let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { 'hearing' => { 'id' => hearing_ids[1] } }) }
 
           it 'initialises Defendants without details' do
             expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-494)
According to v1.7 of the schema resulted hearings are nested in a `hearing` object.
This change enables the data contained inside the nested hearings to be parsed.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
