### PR TITLE
Enqueue fetching of historic hearings to introduce a bit of delay

### DIFF
--- a/app/services/laa_reference_creator.rb
+++ b/app/services/laa_reference_creator.rb
@@ -13,7 +13,7 @@ class LaaReferenceCreator < ApplicationService
     create_laa_reference!
     push_to_sqs unless dummy_reference?
     call_cp_endpoint
-    ProsecutionCaseHearingsFetcher.call(prosecution_case_id: prosecution_case_id)
+    PastHearingsFetcherWorker.perform_at(30.seconds.from_now, Current.request_id, prosecution_case_id)
   end
 
   private

--- a/app/workers/past_hearings_fetcher_worker.rb
+++ b/app/workers/past_hearings_fetcher_worker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PastHearingsFetcherWorker
+  include Sidekiq::Worker
+
+  def perform(request_id, prosecution_case_id)
+    Current.set(request_id: request_id) do
+      ProsecutionCaseHearingsFetcher.call(prosecution_case_id: prosecution_case_id)
+    end
+  end
+end

--- a/spec/workers/laa_reference_creator_worker_spec.rb
+++ b/spec/workers/laa_reference_creator_worker_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe LaaReferenceCreatorWorker, type: :worker do
   let(:user_name) { nil }
   let(:request_id) { 'XYZ' }
   let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
-  let!(:set_up_linked_prosecution_case) do
-    ProsecutionCase.create(
+
+  before do
+    ProsecutionCase.create!(
       id: prosecution_case_id,
       body: JSON.parse(file_fixture('prosecution_case_search_result.json').read)['cases'][0]
     )

--- a/spec/workers/past_hearings_fetcher_worker_spec.rb
+++ b/spec/workers/past_hearings_fetcher_worker_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'sidekiq/testing'
+
+RSpec.describe PastHearingsFetcherWorker, type: :worker do
+  let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
+  let(:defendant_id) { '2ecc9feb-9407-482f-b081-d9e5c8ba3ed3' }
+  let(:request_id) { 'XYZ' }
+
+  before do
+    ProsecutionCase.create!(
+      id: prosecution_case_id,
+      body: JSON.parse(file_fixture('prosecution_case_search_result.json').read)['cases'][0]
+    )
+    ProsecutionCaseDefendantOffence.create!(prosecution_case_id: prosecution_case_id,
+                                            defendant_id: defendant_id,
+                                            offence_id: 'cacbd4d4-9102-4687-98b4-d529be3d5710')
+  end
+
+  subject(:work) do
+    described_class.perform_async(request_id, prosecution_case_id)
+  end
+
+  it 'queues the job' do
+    expect {
+      work
+    }.to change(described_class.jobs, :size).by(1)
+  end
+
+  it 'calls ProsecutionCaseHearingsFetcher with the provided prosecution_case_id' do
+    Sidekiq::Testing.inline! do
+      expect(ProsecutionCaseHearingsFetcher).to receive(:call).once.with(prosecution_case_id: prosecution_case_id)
+      work
+    end
+  end
+
+  it 'sets the request_id on the Current singleton' do
+    Sidekiq::Testing.inline! do
+      expect(Current).to receive(:set).with(request_id: 'XYZ')
+      work
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-501)
Introduce a bit of delay when fetching historic hearings. Due to the async nature of the link request, this can otherwise cause the historic hearings to be not fetched.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
