### PR TITLE
change user_name to be required

### DIFF
--- a/app/contracts/new_laa_reference_contract.rb
+++ b/app/contracts/new_laa_reference_contract.rb
@@ -7,7 +7,7 @@ class NewLaaReferenceContract < Dry::Validation::Contract
 
   params do
     optional(:maat_reference).value(:integer, lt?: 999_999_999)
-    optional(:user_name).value(:string, max_size?: 10)
+    required(:user_name).value(:string, min_size?: 1, max_size?: 10)
     required(:defendant_id).value(:string)
   end
 

--- a/spec/contracts/new_laa_reference_contract_spec.rb
+++ b/spec/contracts/new_laa_reference_contract_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NewLaaReferenceContract do
   end
   let(:maat_reference) { 123_456_789 }
   let(:defendant_id) { "23d7f10a-067a-476e-bba6-bb855674e23b" }
-  let(:user_name) { "" }
+  let(:user_name) { "johnDoe" }
 
   let(:link_validity) { true }
 
@@ -34,10 +34,10 @@ RSpec.describe NewLaaReferenceContract do
     it { is_expected.to be_a_success }
   end
 
-  context "with a user_name" do
-    let(:user_name) { "johnDoe" }
+  context "without a user_name" do
+    let(:user_name) { "" }
 
-    it { is_expected.to be_a_success }
+    it { is_expected.not_to be_a_success }
   end
 
   context "with over 10 characters in user name" do
@@ -79,7 +79,7 @@ RSpec.describe NewLaaReferenceContract do
 
   context "without a maat_reference" do
     let(:hash_for_validation) do
-      { defendant_id: defendant_id }
+      { defendant_id: defendant_id, user_name: user_name }
     end
 
     it { is_expected.to be_a_success }

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -88,14 +88,14 @@ RSpec.describe "api/internal/v1/laa_references", type: :request, swagger_doc: "v
       end
 
       context "with a blank user_name" do
-        response(202, "Accepted") do
+        response("400", "Bad Request") do
           let(:Authorization) { "Bearer #{token.token}" }
 
           parameter "$ref" => "#/components/parameters/transaction_id_header"
 
           before do
             laa_reference[:data][:attributes].delete(:user_name)
-            expect(LaaReferenceCreator).to receive(:call).with(defendant_id: defendant_id, user_name: nil, maat_reference: 1_231_231).and_call_original
+            expect(LaaReferenceCreator).not_to receive(:call)
           end
 
           run_test!


### PR DESCRIPTION
## What

[Link to story]https://dsdmoj.atlassian.net/browse/CACP-442

When a new link request (LAA reference creation) is requested in CDA, a user_name attribute is optionally allowed to be sent. The constraints on this attribute have been changed to be required.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
