### PR TITLE
expose legislation field

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -21,6 +21,10 @@ class Offence
     body['offenceTitle']
   end
 
+  def legislation
+    body['offenceLegislation']
+  end
+
   def mode_of_trial
     body['modeOfTrial']
   end

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -4,5 +4,5 @@ class OffenceSerializer
   include FastJsonapi::ObjectSerializer
   set_type :offences
 
-  attributes :code, :order_index, :title, :mode_of_trial, :plea, :plea_date
+  attributes :code, :order_index, :title, :legislation, :mode_of_trial, :plea, :plea_date
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Offence, type: :model do
       'offenceCode' => 'AA06001',
       'orderIndex' => 1,
       'offenceTitle' => 'Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility',
-      'offenceLegislation' => 'N/A',
+      'offenceLegislation' => 'Offences against the Person Act 1861 s.24',
       'wording' => 'Random string',
       'arrestDate' => '2020-02-01',
       'chargeDate' => '2020-02-01',
@@ -26,6 +26,7 @@ RSpec.describe Offence, type: :model do
   it { expect(offence.code).to eq('AA06001') }
   it { expect(offence.order_index).to eq(1) }
   it { expect(offence.title).to eq('Fail to wear protective clothing / meet other criteria on entering quarantine centre/facility') }
+  it { expect(offence.legislation).to eq('Offences against the Person Act 1861 s.24') }
   it { expect(offence.mode_of_trial).to eq('Indictable-Only Offence') }
   it { expect(offence.maat_reference).to be_nil }
   it { expect(offence.plea).to be_nil }

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OffenceSerializer do
                     code: 'AA06001',
                     order_index: '0',
                     title: 'Fail to wear protective clothing',
+                    legislation: 'Offences against the Person Act 1861 s.24',
                     mode_of_trial: 'Indictable-Only Offence',
                     plea: 'GUILTY',
                     plea_date: '2020-01-01')
@@ -20,6 +21,7 @@ RSpec.describe OffenceSerializer do
     it { expect(attribute_hash[:code]).to eq('AA06001') }
     it { expect(attribute_hash[:order_index]).to eq('0') }
     it { expect(attribute_hash[:title]).to eq('Fail to wear protective clothing') }
+    it { expect(attribute_hash[:legislation]).to eq('Offences against the Person Act 1861 s.24') }
     it { expect(attribute_hash[:mode_of_trial]).to eq('Indictable-Only Offence') }
     it { expect(attribute_hash[:plea]).to eq('GUILTY') }
     it { expect(attribute_hash[:plea_date]).to eq('2020-01-01') }

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -44,6 +44,12 @@
       "description": "The offence title",
       "type": "string"
     },
+    "legislation": {
+      "readOnly": true,
+      "example": "Offences against the Person Act 1861 s.24",
+      "description": "The offence legislation from reference data",
+      "type": "string"
+    },
     "mode_of_trial": {
       "readOnly": true,
       "anyOf": [
@@ -104,6 +110,9 @@
         "title": {
           "$ref": "#/definitions/title"
         },
+        "legislation": {
+          "$ref": "#/definitions/legislation"
+        },
         "plea": {
           "$ref": "#/definitions/plea"
         },
@@ -137,6 +146,9 @@
     },
     "title": {
       "$ref": "offence.json#/definitions/title"
+    },
+    "legislation": {
+      "$ref": "offence.json#/definitions/legislation"
     },
     "plea": {
       "$ref": "offence.json#/definitions/plea"


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/CACP-488

`offenceLegislation` from CP is available in the rendered payload against `offence` in CDA. Code modified to expose this field to VDA

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
