### PR TITLE
Cacp 517 use latest hearings info

### DIFF
--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -19,6 +19,14 @@ class HearingSummary
     body['hearingDays'].map { |hearing_day| hearing_day['sittingDay'] }
   end
 
+  def hearing_in_past?
+    hearing_days.max.to_date.past?
+  end
+
+  def hearing_in_future?
+    hearing_days.max.to_date.future?
+  end
+
   def resulted?
     Hearing.find_by(id: id).present?
   end

--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -69,21 +69,18 @@ module Sqs
     end
 
     def correct_hearing_summary
-      if all_hearings_in_past?
-        prosecution_case.hearing_summaries.max_by(&:hearing_days)
-      elsif all_hearings_in_future?
-        prosecution_case.hearing_summaries.min_by(&:hearing_days)
-      else
-        prosecution_case.hearing_summaries.delete_if { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }.max_by(&:hearing_days)
-      end
+      return prosecution_case.hearing_summaries.max_by(&:hearing_days) if all_hearings_in_past?
+      return prosecution_case.hearing_summaries.min_by(&:hearing_days) if all_hearings_in_future?
+
+      prosecution_case.hearing_summaries.reject(&:hearing_in_future?).max_by(&:hearing_days)
     end
 
     def all_hearings_in_past?
-      prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.past? }
+      prosecution_case.hearing_summaries.all?(&:hearing_in_past?)
     end
 
     def all_hearings_in_future?
-      prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }
+      prosecution_case.hearing_summaries.all?(&:hearing_in_future?)
     end
 
     attr_reader :prosecution_case, :defendant, :user_name, :maat_reference

--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -70,11 +70,11 @@ module Sqs
 
     def correct_hearing_summary
       if all_hearings_in_past?
-        prosecution_case.hearing_summaries.max_by { |hearing_summary| hearing_summary.hearing_days }
+        prosecution_case.hearing_summaries.max_by(&:hearing_days)
       elsif all_hearings_in_future?
-        prosecution_case.hearing_summaries.min_by { |hearing_summary| hearing_summary.hearing_days }
+        prosecution_case.hearing_summaries.min_by(&:hearing_days)
       else
-        prosecution_case.hearing_summaries.delete_if { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }.max_by { |hearing_summary| hearing_summary.hearing_days }
+        prosecution_case.hearing_summaries.delete_if { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }.max_by(&:hearing_days)
       end
     end
 

--- a/app/services/sqs/publish_laa_reference.rb
+++ b/app/services/sqs/publish_laa_reference.rb
@@ -69,13 +69,21 @@ module Sqs
     end
 
     def correct_hearing_summary
-      if prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.past? }
+      if all_hearings_in_past?
         prosecution_case.hearing_summaries.max_by { |hearing_summary| hearing_summary.hearing_days }
-      elsif prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }
+      elsif all_hearings_in_future?
         prosecution_case.hearing_summaries.min_by { |hearing_summary| hearing_summary.hearing_days }
       else
         prosecution_case.hearing_summaries.delete_if { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }.max_by { |hearing_summary| hearing_summary.hearing_days }
       end
+    end
+
+    def all_hearings_in_past?
+      prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.past? }
+    end
+
+    def all_hearings_in_future?
+      prosecution_case.hearing_summaries.all? { |hearing_summary| hearing_summary.hearing_days.join.to_date.future? }
     end
 
     attr_reader :prosecution_case, :defendant, :user_name, :maat_reference

--- a/spec/fixtures/files/prosecution_case_search_result.json
+++ b/spec/fixtures/files/prosecution_case_search_result.json
@@ -67,6 +67,54 @@
             "roomId": "8e912353-3b5d-36c3-953e-ad3b94b19de3",
             "roomName": "Courtroom 01"
           }
+        },
+        {
+          "hearingId": "9161049a-bde1-4150-83e5-9d5212d762c2",
+          "jurisdictionType": "CROWN",
+          "defendantIds": [
+            "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2020-08-04T08:00:00Z",
+              "listingSequence": 2,
+              "listedDurationMinutes": 30
+            }
+          ],
+          "courtCentre": {
+            "id": "9b583616-049b-30f9-a14f-028a53b7cfe8",
+            "name": "Liverpool Crown Court",
+            "roomId": "7cb09222-49e1-3622-a5a6-ad253d2b3c39",
+            "roomName": "Crown Court 3-1"
+          },
+          "hearingType": {
+            "id": "06b0c2bf-3f98-46ed-ab7e-56efaf9ecced",
+            "description": "Plea and Trial Preparation"
+          }
+        },
+        {
+          "hearingId": "e6487eac-df3d-4175-9c41-c2e90d0a8587",
+          "jurisdictionType": "CROWN",
+          "defendantIds": [
+            "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2020-09-05T08:00:00Z",
+              "listingSequence": 1,
+              "listedDurationMinutes": 720
+            }
+          ],
+          "courtCentre": {
+            "id": "f8254db1-1683-483e-afb3-b87fde5a0a26",
+            "name": "Lavender Hill Magistrates' Court",
+            "roomId": "9e4932f7-97b2-3010-b942-ddd2624e4dd8",
+            "roomName": "Courtroom 01"
+          },
+          "hearingType": {
+            "id": "bf8155e1-90b9-4080-b133-bfbad895d6e4",
+            "description": "Trial"
+          }
         }
       ]
     }

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe HearingSummary, type: :model do
   it { expect(hearing_summary.short_oucode).to eq('B01BH') }
   it { expect(hearing_summary.oucode_l2_code).to eq('1') }
   it { expect(hearing_summary.resulted?).to eq false }
+  it { expect(hearing_summary.hearing_in_past?).to eq true }
+  it { expect(hearing_summary.hearing_in_future?).to eq false }
 
   context 'hearing has resulted' do
     before { Hearing.create!(id: hearing_summary.id, body: { hearing_body: true }) }

--- a/spec/services/prosecution_case_hearings_fetcher_spec.rb
+++ b/spec/services/prosecution_case_hearings_fetcher_spec.rb
@@ -11,12 +11,16 @@ RSpec.describe ProsecutionCaseHearingsFetcher do
     )
   end
 
-  let(:hearing_id) { 'b935a64a-6d03-4da4-bba6-4d32cc2e7fb4' }
+  let(:hearing_id)   { 'b935a64a-6d03-4da4-bba6-4d32cc2e7fb4' }
+  let(:hearing_id_2) { '9161049a-bde1-4150-83e5-9d5212d762c2' }
+  let(:hearing_id_3) { 'e6487eac-df3d-4175-9c41-c2e90d0a8587' }
 
   subject { described_class.call(prosecution_case_id: prosecution_case_id) }
 
   it 'triggers a call to Api::GetHearingResults' do
     expect(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_id, publish_to_queue: true)
+    expect(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_id_2, publish_to_queue: true)
+    expect(Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_id_3, publish_to_queue: true)
     subject
   end
 

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Sqs::PublishLaaReference do
   include ActiveSupport::Testing::TimeHelpers
   let(:prosecution_case_id) { '5edd67eb-9d8c-44f2-a57e-c8d026defaa4' }
@@ -40,9 +41,9 @@ RSpec.describe Sqs::PublishLaaReference do
         ]
       },
       sessions:
-              [{:courtLocation=>"B01BH", :dateOfHearing=>"2020-02-17"},
-              {:courtLocation=>"C05LV", :dateOfHearing=>"2020-08-04"},
-              {:courtLocation=>"B01LY", :dateOfHearing=>"2020-09-05"}],
+              [{ :courtLocation => "B01BH", :dateOfHearing => "2020-02-17" },
+              { :courtLocation => "C05LV", :dateOfHearing => "2020-08-04" },
+              { :courtLocation => "B01LY", :dateOfHearing => "2020-09-05" }]
     }
   end
 

--- a/spec/services/sqs/publish_laa_reference_spec.rb
+++ b/spec/services/sqs/publish_laa_reference_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Sqs::PublishLaaReference do
         ]
       },
       sessions:
-              [{ :courtLocation => "B01BH", :dateOfHearing => "2020-02-17" },
-              { :courtLocation => "C05LV", :dateOfHearing => "2020-08-04" },
-              { :courtLocation => "B01LY", :dateOfHearing => "2020-09-05" }]
+              [{ courtLocation: 'B01BH', dateOfHearing: '2020-02-17' },
+               { courtLocation: 'C05LV', dateOfHearing: '2020-08-04' },
+               { courtLocation: 'B01LY', dateOfHearing: '2020-09-05' }]
     }
   end
 
@@ -73,12 +73,12 @@ RSpec.describe Sqs::PublishLaaReference do
     end
   end
 
-  context 'one hearing is in the past' do
-    let(:cjs_area_code)  { '1' }
-    let(:cjs_location)   { 'B01BH' }
+  context 'one hearing is in the future' do
+    let(:cjs_area_code)  { '5' }
+    let(:cjs_location)   { 'C05LV' }
 
     it 'returns the CJS area code and location from the most recent past hearing ' do
-      travel_to Time.zone.local(2020, 2, 18) do
+      travel_to Time.zone.local(2020, 8, 10) do
         expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url).and_call_original
         subject
       end


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=398&projectKey=CACP&modal=detail&selectedIssue=CACP-517

The CJS code and CJS location are taken from the latest hearing which is in the past. If all hearings are in the future, the next upcoming hearing is used.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
