### PR TITLE
Lasb 379 linking when no hearing

### DIFF
--- a/app/contracts/new_laa_reference_contract.rb
+++ b/app/contracts/new_laa_reference_contract.rb
@@ -3,6 +3,7 @@
 class NewLaaReferenceContract < Dry::Validation::Contract
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
   option :maat_reference_validator, default: -> { MaatApi::MaatReferenceValidator }
+  option :link_validator, default: -> { LinkValidator }
 
   params do
     optional(:maat_reference).value(:integer, lt?: 999_999_999)
@@ -12,6 +13,7 @@ class NewLaaReferenceContract < Dry::Validation::Contract
 
   rule(:defendant_id) do
     key.failure('is not a valid uuid') unless uuid_validator.call(uuid: value)
+    key.failure('We do not have all the info needed to link right now, please try again later') unless link_validator.call(defendant_id: value)
   end
 
   rule(:maat_reference) do

--- a/app/models/prosecution_case_defendant_offence.rb
+++ b/app/models/prosecution_case_defendant_offence.rb
@@ -4,4 +4,5 @@ class ProsecutionCaseDefendantOffence < ApplicationRecord
   validates :prosecution_case_id, presence: true
   validates :defendant_id, presence: true
   validates :offence_id, presence: true
+  belongs_to :prosecution_case
 end

--- a/app/services/link_validator.rb
+++ b/app/services/link_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class LinkValidator < ApplicationService
+  def initialize(defendant_id:)
+    @prosecution_case = ProsecutionCaseDefendantOffence.find_by(defendant_id: defendant_id)&.prosecution_case
+  end
+
+  def call
+    prosecution_case&.hearing_summaries&.present? || false
+  end
+
+  private
+
+  attr_reader :prosecution_case
+end

--- a/spec/contracts/new_laa_reference_contract_spec.rb
+++ b/spec/contracts/new_laa_reference_contract_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe NewLaaReferenceContract do
   let(:defendant_id) { '23d7f10a-067a-476e-bba6-bb855674e23b' }
   let(:user_name) { '' }
 
+  let(:link_validity) { true }
+
+  before do
+    allow(LinkValidator).to receive(:call).and_return(link_validity)
+  end
+
   it { is_expected.to be_a_success }
 
   context 'with a maat_reference cast as a string' do
@@ -82,5 +88,12 @@ RSpec.describe NewLaaReferenceContract do
       expect(described_class.new.maat_reference_validator).not_to receive(:call)
       subject
     end
+  end
+
+  context 'when the defendant cannot be linked' do
+    let(:link_validity) { false }
+
+    it { is_expected.not_to be_a_success }
+    it { is_expected.to have_contract_error('We do not have all the info needed to link right now, please try again later') }
   end
 end

--- a/spec/models/prosecution_case_defendant_offence_spec.rb
+++ b/spec/models/prosecution_case_defendant_offence_spec.rb
@@ -27,4 +27,8 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   it { expect(prosecution_case_defendant_offence.rep_order_status).to eq rep_order_status }
   it { expect(prosecution_case_defendant_offence.response_status).to eq response_status }
   it { expect(prosecution_case_defendant_offence.response_body).to eq response_body }
+
+  it do
+    should belong_to(:prosecution_case).class_name('ProsecutionCase')
+  end
 end

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'api/internal/v1/laa_references', type: :request, swagger_doc: 'v
     }
   end
 
+  before do
+    allow(LinkValidator).to receive(:call).and_return(true)
+  end
+
   around do |example|
     VCR.use_cassette('maat_api/maat_reference_success') do
       Sidekiq::Testing.fake! do

--- a/spec/services/link_validator_spec.rb
+++ b/spec/services/link_validator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LinkValidator do
     end
   end
 
-  context 'when the prosecution case defendant offence does not exit' do
+  context 'when the prosecution case defendant offence does not exist' do
     before do
       ProsecutionCaseDefendantOffence.destroy_all
     end

--- a/spec/services/link_validator_spec.rb
+++ b/spec/services/link_validator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe LinkValidator do
+  subject { described_class.call(defendant_id: defendant_id) }
+  let(:defendant_id) { '8cd0ba7e-df89-45a3-8c61-4008a2186d64' }
+  let(:prosecution_case_id) { '7a0c947e-97b4-4c5a-ae6a-26320afc914d' }
+  let!(:prosecution_case) do
+    ProsecutionCase.create!(
+      id: prosecution_case_id,
+      body: JSON.parse(file_fixture('prosecution_case_search_result.json').read)['cases'][0]
+    )
+  end
+
+  before do
+    ProsecutionCaseDefendantOffence.create!(prosecution_case_id: prosecution_case_id,
+                                            defendant_id: defendant_id,
+                                            offence_id: 'cacbd4d4-9102-4687-98b4-d529be3d5710')
+  end
+
+  it 'returns true' do
+    expect(subject).to eq true
+  end
+
+  context 'when the hearing summary does not exist' do
+    before do
+      prosecution_case.body.delete('hearingSummary')
+      prosecution_case.save!
+    end
+
+    it 'returns false' do
+      expect(subject).to eq false
+    end
+  end
+
+  context 'when the prosecution case defendant offence does not exit' do
+    before do
+      ProsecutionCaseDefendantOffence.destroy_all
+    end
+
+    it 'returns false' do
+      expect(subject).to eq false
+    end
+  end
+end


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=454&modal=detail&selectedIssue=LASB-379

Creating a link request when the hearing summary is not available results in a failure. This prevents a failure further down the line as linking a case in MLRA relies on the court location being present from the hearing summary.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
