### PR TITLE
Pluralise provider serialization type

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -2,5 +2,7 @@
 
 class ProviderSerializer
   include FastJsonapi::ObjectSerializer
+  set_type :providers
+
   attributes :name, :role
 end

--- a/spec/serializer/provider_serializer_spec.rb
+++ b/spec/serializer/provider_serializer_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe ProviderSerializer do
+  subject(:serializable_hash) { described_class.new(provider).serializable_hash }
+
   let(:provider) do
     instance_double('Provider',
                     id: 'PROVIDER_UUID',
@@ -8,10 +10,16 @@ RSpec.describe ProviderSerializer do
                     role: 'Junior counsel')
   end
 
-  subject { described_class.new(provider).serializable_hash }
+  context 'data' do
+    subject(:data) { serializable_hash[:data] }
+
+    it { is_expected.to include(id: 'PROVIDER_UUID') }
+    it { is_expected.to include(type: :providers) }
+    it { is_expected.to have_key(:attributes) }
+  end
 
   context 'attributes' do
-    let(:attribute_hash) { subject[:data][:attributes] }
+    let(:attribute_hash) { serializable_hash[:data][:attributes] }
 
     it { expect(attribute_hash[:name]).to eq('Neil Griffiths') }
     it { expect(attribute_hash[:role]).to eq('Junior counsel') }


### PR DESCRIPTION
## What
Pluralize the ProviderSerializer `type`

Currently type is not explictly set, resulting in the type being
automatically set to :provider
(singular). This breaks the pattern for other serializers that are plural.

The result was even when `hearings.providers` was "included" in a query,
and providers returned, the consumer (VCD) was unable to retrieve the
providers following that pattern.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.