### PR TITLE
Expose `details` via defendant endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'rubocop-performance'
   gem 'rubocop-rails', require: false
   gem 'vcr'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
+    crack (0.4.4)
     crass (1.0.6)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -145,6 +146,7 @@ GEM
     ffi (1.11.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
@@ -319,6 +321,10 @@ GEM
       activesupport (>= 3)
       railties (>= 3)
       yard (~> 0.9.20)
+    webmock (3.9.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -365,6 +371,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   vcr
   versionist
+  webmock
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -16,6 +16,7 @@ module Api
 
         def show
           defendant = DefendantFinder.call(defendant_id: params[:id])
+
           if defendant.present?
             render json: DefendantSerializer.new(defendant, serialization_options)
           else

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -22,6 +22,7 @@ class ProsecutionCase < ApplicationRecord
   def hearings
     hearing_results.select(&:body)
   end
+  alias fetch_details hearings
 
   def hearing_ids
     hearings.map(&:id)

--- a/app/services/defendant_finder.rb
+++ b/app/services/defendant_finder.rb
@@ -36,5 +36,5 @@ class DefendantFinder < ApplicationService
     @prosecution_case ||= ProsecutionCase.find(prosecution_case_defendant.prosecution_case_id)
   end
 
-  attr_reader :defendant_id, :prosecution_case_defendant, :inclusions
+  attr_reader :defendant_id, :prosecution_case_defendant
 end

--- a/app/services/defendant_finder.rb
+++ b/app/services/defendant_finder.rb
@@ -7,10 +7,34 @@ class DefendantFinder < ApplicationService
   end
 
   def call
-    ProsecutionCase.find(prosecution_case_defendant.prosecution_case_id).defendants.find { |defendant| defendant.id == defendant_id } if prosecution_case_defendant.present?
+    cp_defendant
   end
 
   private
 
-  attr_reader :defendant_id, :prosecution_case_defendant
+  def cp_defendant
+    @cp_defendant ||= cp_prosecution_case&.defendants&.find { |d| d.id.eql?(defendant_id) }
+  end
+
+  def cp_prosecution_case
+    return unless prosecution_case_urn
+
+    # fetch details needed to include plea and mode of trial reason, at least
+    @cp_prosecution_case ||=  Api::SearchProsecutionCase
+                              .call(prosecution_case_reference: prosecution_case_urn)
+                              &.first
+                              &.tap(&:fetch_details)
+  end
+
+  def prosecution_case_urn
+    @prosecution_case_urn ||= prosecution_case&.body&.fetch('prosecutionCaseReference', nil)
+  end
+
+  def prosecution_case
+    return unless prosecution_case_defendant&.prosecution_case_id
+
+    @prosecution_case ||= ProsecutionCase.find(prosecution_case_defendant.prosecution_case_id)
+  end
+
+  attr_reader :defendant_id, :prosecution_case_defendant, :inclusions
 end

--- a/app/services/defendant_finder.rb
+++ b/app/services/defendant_finder.rb
@@ -31,7 +31,7 @@ class DefendantFinder < ApplicationService
   end
 
   def prosecution_case
-    return unless prosecution_case_defendant&.prosecution_case_id
+    return unless prosecution_case_defendant
 
     @prosecution_case ||= ProsecutionCase.find(prosecution_case_defendant.prosecution_case_id)
   end

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_birth_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?defendantDOB=1980-01-01&defendantName=George+Walsh"
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?defendantDOB=1980-01-01&defendantName=George%20Walsh"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_name_and_date_of_next_hearing_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?dateOfNextHearing=2020-02-17&defendantName=George+Walsh"
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?dateOfNextHearing=2020-02-17&defendantName=George%20Walsh"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -11,20 +11,24 @@ http_interactions:
       - "<SHARED_SECRET_KEY>"
       User-Agent:
       - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
-      content-length:
+      Content-Length:
       - '3901'
-      content-type:
+      Content-Type:
       - application/vnd.unifiedsearch.query.laa.cases+json
-      cppid:
-      - c1c170bb-9bcf-4c90-b44e-51feb8edf1be
-      date:
-      - Wed, 26 Aug 2020 16:53:44 GMT
-      x-frame-options:
+      Cppid:
+      - 1bddc005-6200-46a5-9e80-a5d83f75539d
+      Date:
+      - Mon, 09 Nov 2020 17:51:50 GMT
+      X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: UTF-8
@@ -54,5 +58,98 @@ http_interactions:
         hearing"},"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
         Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
         01"}}]}]}'
-  recorded_at: Wed, 26 Aug 2020 16:53:44 GMT
+  recorded_at: Mon, 09 Nov 2020 17:51:50 GMT
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=19GD1001816"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3901'
+      Content-Type:
+      - application/vnd.unifiedsearch.query.laa.cases+json
+      Cppid:
+      - fd3f50f0-e58e-413c-b223-e5ec1cce80dc
+      Date:
+      - Mon, 09 Nov 2020 17:51:50 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"c37c2ca9-d5f9-4758-a224-52ba918a3d64","prosecutionCaseReference":"19GD1001816","defendantSummary":[{"proceedingsConcluded":false,"representationOrder":{},"defendantId":"c6cf04b5-901d-4a89-a9ab-767eb57306e4","defendantASN":"CPS-NE","defendantFirstName":"Robert","defendantMiddleName":"PersonGivenName20A
+        PersonGivenName30A","defendantLastName":"Ormsby","defendantDOB":"2008-08-08","offenceSummary":[{"offenceId":"aaa55a60-9a7b-423d-8be8-16c1e8aa7312","offenceCode":"PS90010","offenceTitle":"Public
+        service vehicle - passenger use altered / defaced travel mandate","offenceLegislation":"Contrary
+        to regulation 7(1)(a) of the Public Service Vehicles (Conduct of Drivers,
+        Inspectors, Conductors and Passengers) Regulations 1990 and section 25 of
+        the Public Passenger Vehicles Act 1981.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{}},{"offenceId":"d8a2963d-e62d-4bbc-8a89-591ecd71bb1c","offenceCode":"CA03013","offenceTitle":"Obstruct    person
+        executing search warrant for TV receiver","offenceLegislation":"Contrary to
+        section 366(8)(a) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{}}]},{"proceedingsConcluded":false,"representationOrder":{},"defendantId":"b70a36e5-13d3-4bb3-bb24-94db79b7708b","defendantASN":"TSFL","defendantFirstName":"James","defendantMiddleName":"PersonGivenName20A
+        PersonGivenName30A","defendantLastName":"Smith","defendantDOB":"2008-08-08","offenceSummary":[{"offenceId":"137afb84-067b-4455-95bc-206ca4051fc1","offenceCode":"PS90010","offenceTitle":"Public
+        service vehicle - passenger use altered / defaced travel mandate","offenceLegislation":"Contrary
+        to regulation 7(1)(a) of the Public Service Vehicles (Conduct of Drivers,
+        Inspectors, Conductors and Passengers) Regulations 1990 and section 25 of
+        the Public Passenger Vehicles Act 1981.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{}},{"offenceId":"eb2f7155-5009-46ae-94ac-be5d62c66754","offenceCode":"CA03014","offenceTitle":"Fail    /
+        refuse give assistance to person executing Communications Act search warrant","offenceLegislation":"Contrary
+        to section 366(8)(b) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
+        hearing"},"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
+        Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
+        01"}}]}]}'
+  recorded_at: Mon, 09 Nov 2020 17:51:50 GMT
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/hearing/results?hearingId=e8d88eaa-e73f-4b59-8148-d0cfbbd3520b"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/plain; charset=utf-8
+      Request-Context:
+      - appId=cid-v1:fa402f79-a77a-4ded-8114-1ca5377aa0ab
+      Date:
+      - Mon, 09 Nov 2020 17:51:53 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 09 Nov 2020 17:51:54 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/files/full_hearing.json
+++ b/spec/fixtures/files/full_hearing.json
@@ -1,0 +1,333 @@
+{
+  "hearing": {
+    "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+    "jurisdictionType": "CROWN",
+    "reportingRestrictionReason": "reporting restriction because...",
+    "courtCentre": {
+      "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "name": "Warrington CCU (Decom)",
+      "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "roomName": "Warrington CCU (Decom)"
+    },
+    "hearingLanguage": "WELSH",
+    "hasSharedResults": false,
+    "type": {
+      "id": "63003e58-d753-46e2-a2c8-47fd15341592",
+      "description": "Mention - Defendant to Attend (MDA)"
+    },
+    "prosecutionCases": [
+      {
+        "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+        "prosecutionCaseIdentifier": {
+          "caseURN": "20GD0217100",
+          "prosecutionAuthorityReference": "UXJYGCVRXJ",
+          "prosecutionAuthorityId": "094e3de2-a07f-472f-81ed-da9b254c6c7c",
+          "prosecutionAuthorityCode": "UBTMWMUUIJ"
+        },
+        "originatingOrganisation": "Goldner, Prohaska and Hauck",
+        "initiationCode": "O",
+        "caseStatus": "CLOSED",
+        "policeOfficerInCase": {
+          "personDetails": {
+            "title": "MISS",
+            "firstName": "Alfredine",
+            "middleName": "Treutel",
+            "lastName": "Parker",
+            "dateOfBirth": "1971-05-12",
+            "nationalityId": "a1c2f090-4fb6-4c50-a08d-3ef23aac83da",
+            "nationalityCode": "Gibraltar",
+            "nationalityDescription": "Good habits formed at youth make all the difference",
+            "additionalNationalityId": "12b33a32-8857-4602-b7fa-47280bdc660d",
+            "additionalNationalityCode": "Irish",
+            "additionalNationalityDescription": "The unexamined life is not worth living.",
+            "disabilityStatus": "blind",
+            "gender": "NOT_SPECIFIED",
+            "interpreterLanguageNeeds": "Swedish",
+            "documentationLanguageNeeds": "ENGLISH",
+            "nationalInsuranceNumber": "BN102966C",
+            "occupation": "Global Real-Estate Strategist",
+            "occupationCode": "4033",
+            "specificRequirements": "Unleash back-end relationships"
+          },
+          "policeOfficerRank": "Captain",
+          "policeWorkerReferenceNumber": "4233223423",
+          "policeWorkerLocationCode": "AK"
+        },
+        "statementOfFacts": "Veritatis cardigan +1.",
+        "statementOfFactsWelsh": "Actually small batch in ea.",
+        "breachProceedingsPending": true,
+        "appealProceedingsPending": false,
+        "defendants": [
+          {
+            "id": "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3",
+            "prosecutionCaseId": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+            "numberOfPreviousConvictionsCited": 3106,
+            "prosecutionAuthorityReference": "iusto",
+            "witnessStatement": "Harum exercitationem in. Non nulla aut. Eligendi molestiae saepe.",
+            "witnessStatementWelsh": "Eius numquam qui. Sed aspernatur expedita. Doloribus voluptas quis.",
+            "mitigation": "Et earum dolorem. Sapiente fugiat mollitia. Aut iste consequatur.",
+            "mitigationWelsh": "Repellendus officiis autem. Rem qui id. Doloribus quis quibusdam.",
+            "offences": [
+              {
+                "id": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
+                "offenceDefinitionId": "084cc312-8e01-485e-a836-c52273e83d5a",
+                "offenceCode": "PT00011",
+                "offenceTitle": "Driver / other person fail to immediately move a vehicle from a cordoned area on order of a constable",
+                "offenceTitleWelsh": "some welsh for that offence",
+                "offenceLegislation": "Common law",
+                "offenceLegislationWelsh": "Firearms Act 1968 s.2",
+                "modeOfTrial": "Either way",
+                "wording": "Random string",
+                "wordingWelsh": "Llinyn ar hap",
+                "startDate": "2019-10-17",
+                "endDate": "2019-10-17",
+                "arrestDate": "2019-10-17",
+                "chargeDate": "2019-10-17",
+                "laidDate": "2019-10-17",
+                "dateOfInformation": "2019-10-17",
+                "orderIndex": 1,
+                "count": 1,
+                "convictionDate": "2019-10-17",
+                "aquittalDate": "2019-10-17",
+                "isDiscontinued": false,
+                "proceedingsConcluded": false,
+                "allocationDecision": {
+                  "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                  "motReasonId": "d47268e9-db2e-3aa3-827b-ba3afb7ff94a",
+                  "motReasonDescription": "Court directs trial by jury",
+                  "motReasonCode": "5",
+                  "sequenceNumber": 20,
+                  "allocationDecisionDate": "2020-02-13",
+                  "courtIndicatedSentence": {
+                    "courtIndicatedSentenceTypeId": "f7f76e0b-366b-4746-b0b0-4d8a46c6ad4e",
+                    "courtIndicatedSentenceDescription": "Aut laborum quia et."
+                  }
+                },
+                "plea": {
+                  "originatingHearingId": "818d572c-a9e8-4bf2-8eb7-6abf98cd7a5f",
+                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                  "pleaDate": "2020-04-12",
+                  "pleaValue": "NOT_GUILTY"
+                },
+                "laaApplnReference": {
+                  "applicationReference": "A10000099",
+                  "statusId": "38944fbb-c8a6-45ff-9b5c-e09e9867eabc",
+                  "statusCode": "AP",
+                  "statusDescription": "FAKE NEWS",
+                  "statusDate": "2020-11-05"
+                }
+              }
+            ],
+            "associatedPersons": [
+              {
+                "person": {
+                  "title": "MS",
+                  "firstName": "Katelynn",
+                  "middleName": "Harvey",
+                  "lastName": "Kunze",
+                  "dateOfBirth": "2002-10-10",
+                  "nationalityId": "fba0fbc1-3a78-46d0-9a45-9bf76d196793",
+                  "nationalityCode": "BY",
+                  "nationalityDescription": "Belarus",
+                  "additionalNationalityId": "38af2450-1717-47bf-ab1a-c17fd4745e78",
+                  "additionalNationalityCode": "AZ",
+                  "additionalNationalityDescription": "Azerbaijan",
+                  "disabilityStatus": "atque",
+                  "ethnicity": {
+                    "observedEthnicityId": "a505bd30-9727-4ece-9312-74737d4696af",
+                    "observedEthnicityCode": "B1",
+                    "observedEthnicityDescription": "Caribbean",
+                    "selfDefinedEthnicityId": "dcad92c4-53a2-43fb-b1a8-d8241458e0d3",
+                    "selfDefinedEthnicityCode": "W9",
+                    "selfDefinedEthnicityDescription": "Any other White background"
+                  },
+                  "gender": "FEMALE",
+                  "interpreterLanguageNeeds": "Tagalog",
+                  "documentationLanguageNeeds": "WELSH",
+                  "nationalInsuranceNumber": "EJ099885C",
+                  "occupation": "pharmacist",
+                  "occupationCode": "3914",
+                  "specificRequirements": "molestias",
+                  "address": {
+                    "address1": "4637 Victorina Trail",
+                    "address2": "Suite 623",
+                    "address3": "2989",
+                    "address4": "North Porfirio",
+                    "address5": "Palestinian Territory",
+                    "postcode": "51314-0859"
+                  },
+                  "contact": {
+                    "home": "1-867-889-8179",
+                    "work": "1-893-936-4102",
+                    "mobile": "640-287-7987",
+                    "primaryEmail": "anastacia@stoltenberg.io",
+                    "secondaryEmail": "joane_goyette@purdy-purdy.com",
+                    "fax": "1-275-412-9791 x8048"
+                  }
+                },
+                "role": "Uncle"
+              }
+            ],
+            "defenceOrganisation": {
+              "name": "Gutkowski-Schumm",
+              "incorporationNumber": "75-6181739",
+              "registeredCharityNumber": "44-273-5167"
+            },
+            "associatedDefenceOrganisation": {
+              "organisation": {
+                "name": "Gutkowski-Schumm",
+                "incorporationNumber": "75-6181739",
+                "registeredCharityNumber": "44-273-5167"
+              },
+              "fundingType": "PRIVATE",
+              "associationStartDate": "2020-11-18",
+              "associationEndDate": "2020-12-24",
+              "isAssociatedByLAA": true,
+              "applicationReference": "A10000099"
+            },
+            "personDefendant": {
+              "personDetails": {
+                "title": "MR",
+                "firstName": "Jammy",
+                "middleName": "",
+                "lastName": "Dodger",
+                "dateOfBirth": "1987-05-21",
+                "nationalityId": "0fbfa618-77d1-4791-924a-4a1ea02dd041",
+                "nationalityCode": "MQ",
+                "nationalityDescription": "Martinique",
+                "additionalNationalityId": "740c8ea4-b6e3-4167-9d56-2ed0eadf8169",
+                "additionalNationalityCode": "HK",
+                "additionalNationalityDescription": "Hong Kong",
+                "disabilityStatus": "perferendis",
+                "ethnicity": {
+                  "observedEthnicityId": "bf43941a-1627-45cb-b255-ab6efd26b25d",
+                  "observedEthnicityCode": "O9",
+                  "observedEthnicityDescription": "Any other ethnic group",
+                  "selfDefinedEthnicityId": "90ffba21-501c-4e3b-8b00-e451c97067a6",
+                  "selfDefinedEthnicityCode": "M9",
+                  "selfDefinedEthnicityDescription": "Any other mixed background"
+                },
+                "gender": "MALE",
+                "interpreterLanguageNeeds": "Hakka",
+                "documentationLanguageNeeds": "WELSH",
+                "nationalInsuranceNumber": "JC123456A",
+                "occupation": "lawyer",
+                "occupationCode": "5033",
+                "specificRequirements": "natus",
+                "address": {
+                  "address1": "6376 Merrilee Loop",
+                  "address2": "Suite 304",
+                  "address3": "28301",
+                  "address4": "Cinthiatown",
+                  "address5": "Kyrgyz Republic",
+                  "postcode": "35848-9420"
+                },
+                "contact": {
+                  "home": "(376) 129-7081",
+                  "work": "793.293.0858 x83940",
+                  "mobile": "1-131-191-7418",
+                  "primaryEmail": "francesco.blick@fisher.org",
+                  "secondaryEmail": "hailey.tremblay@weissnat.net",
+                  "fax": "829-539-3102 x61653"
+                }
+              },
+              "bailStatus": {
+                "id": "9567a90f-a82c-42ee-92b4-a6ce3687c8d4",
+                "code": "0hs9ytllu5",
+                "description": "Nobis reiciendis deleniti doloremque.",
+                "custodyTimeLimit": {
+                  "timeLimit": "2021-02-02",
+                  "daysSpent": 37
+                }
+              },
+              "bailConditions": "Molestias quasi assumenda necessitatibus.",
+              "bailReasons": "Nostrum tenetur aspernatur autem.",
+              "perceivedBirthYear": 1984,
+              "driverNumber": "Vitae et quis consequatur.",
+              "driverLicenceCode": "FULL",
+              "driverLicenseIssue": "Dolores placeat veniam reprehenderit.",
+              "vehicleOperatorLicenceNumber": "FQMX65V",
+              "arrestSummonsNumber": "XVITYX8RAIHZ",
+              "employerOrganisation": {
+                "name": "Adams Group",
+                "incorporationNumber": "47-6611239",
+                "registeredCharityNumber": "93-131-3851"
+              },
+              "employerPayrollReference": "X41UERQFM"
+            },
+            "aliases": [
+              {
+                "title": "MS",
+                "firstName": "Wallace",
+                "middleName": "Cummings",
+                "lastName": "McClure",
+                "legalEntityName": "Effertz and Sons"
+              }
+            ],
+            "croNumber": "B0000W4DP6",
+            "pncId": "33629585-8"
+          }
+        ],
+        "caseMarkers": [
+          {
+            "id": "dea23b3e-d4c1-40bd-9b64-8cf8d71aa185",
+            "markerTypeid": "f08a69c8-6a69-4308-9c61-e2bfa2c092f3",
+            "markerTypeCode": "JESDPCOXOB",
+            "markerTypeDescription": "UJOBNCSJUQ"
+          }
+        ]
+      }
+    ],
+    "defenceCounsels": [
+      {
+        "id": "c819785d-d39d-4c44-b1ad-bcca76e88c14",
+        "title": "Pres.",
+        "firstName": "Adrian",
+        "middleName": "Jefferey",
+        "lastName": "Pollich",
+        "status": "Junior counsel",
+        "defendants": [
+          "b17e6c2d-1439-4f02-9179-1ff9935729a7"
+        ],
+        "attendanceDays": [
+          "2019-10-24"
+        ]
+      },
+      {
+        "id": "66b5cc0d-1704-4487-a35c-6d96612b2bc2",
+        "title": "Mr.",
+        "firstName": "Leonard",
+        "middleName": "Rafael",
+        "lastName": "DuBuque",
+        "status": "Junior counsel",
+        "defendants": [
+          "d6900d6a-3d36-4d21-9723-d6bb21a5a6db"
+        ],
+        "attendanceDays": [
+          "2019-10-24"
+        ]
+      }
+    ],
+    "isEffectiveTrial": false,
+    "isBoxHearing": false,
+    "hearingDays": [
+      {
+        "sittingDay": "2019-10-25T10:45:00.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      },
+      {
+        "sittingDay": "2019-10-24T08:30:00.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      },
+      {
+        "sittingDay": "2019-10-23T16:19:15.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      }
+    ]
+  },
+  "sharedTime": "2020-10-30T10:04:27.476+00:00"
+}

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe ProsecutionCase, type: :model do
 
         it { is_expected.to all be_a(Hearing) }
 
+        it 'is_expected to have alias #fetch_details' do
+          expect(prosecution_case.method(:hearings)).to eq(prosecution_case.method(:fetch_details))
+        end
+
         context 'when a hearing has not resulted' do
           let(:hearing_one) { nil }
           let(:hearing_two) { nil }

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -13,19 +13,26 @@ RSpec.describe ProsecutionCase, type: :model do
     end
 
     let(:prosecution_case) { described_class.create(id: prosecution_case_id, body: prosecution_case_result.body['cases'][0]) }
-
     let(:prosecution_case_id) { '31cbe62d-b1ec-4e82-89f7-99dced834900' }
 
-    it { expect(prosecution_case.prosecution_case_reference).to eq('19GD1001816') }
-    it { expect(prosecution_case.defendants).to all be_a(Defendant) }
-    it { expect(prosecution_case.hearing_summaries).to all be_a(HearingSummary) }
-
-    it 'initialises Defendants without details' do
-      expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice.and_call_original
-      prosecution_case.defendants
+    describe '#prosecution_case_reference' do
+      it { expect(prosecution_case.prosecution_case_reference).to eq('19GD1001816') }
     end
 
-    context 'requesting hearing resulted' do
+    describe '#defendants' do
+      it { expect(prosecution_case.defendants).to all be_a(Defendant) }
+
+      it 'initialises Defendants without details' do
+        expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice.and_call_original
+        prosecution_case.defendants
+      end
+    end
+
+    describe '#hearing_summaries' do
+      it { expect(prosecution_case.hearing_summaries).to all be_a(HearingSummary) }
+    end
+
+    context 'when requesting hearing resulted' do
       let(:hearing_ids) { %w[311bb2df-4df5-4abe-bae3-82f144e1e5c5 c6cf04b5-901d-4a89-a9ab-767eb57306e4] }
 
       before do
@@ -70,31 +77,40 @@ RSpec.describe ProsecutionCase, type: :model do
         )
       end
 
-      it { expect(prosecution_case.hearings).to all be_a(Hearing) }
-      it { expect(prosecution_case.hearing_ids).to eq(hearing_ids) }
+      describe '#hearing_ids' do
+        subject { prosecution_case.hearing_ids }
 
-      context 'when a hearing has not resulted' do
-        let(:hearing_one) { nil }
-        let(:hearing_two) { nil }
-
-        it { expect(prosecution_case.hearings).to be_empty }
+        it { is_expected.to eq(hearing_ids) }
       end
 
-      context 'when hearings are loaded' do
-        before { prosecution_case.hearings }
+      describe '#hearings' do
+        subject(:hearings) { prosecution_case.hearings }
 
-        it 'initialises Defendants with detailed fetched from hearing' do
-          expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: an_instance_of(Hash), prosecution_case_id: prosecution_case_id).twice
-          prosecution_case.defendants
+        it { is_expected.to all be_a(Hearing) }
+
+        context 'when a hearing has not resulted' do
+          let(:hearing_one) { nil }
+          let(:hearing_two) { nil }
+
+          it { is_expected.to be_empty }
         end
 
-        context 'with no prosecution_case reference' do
-          let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { 'hearing' => { 'id' => hearing_ids[0] } }) }
-          let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { 'hearing' => { 'id' => hearing_ids[1] } }) }
+        context 'when hearings are loaded' do
+          before { prosecution_case.hearings }
 
-          it 'initialises Defendants without details' do
-            expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice
+          it 'initialises Defendants with detail fetched from hearing' do
+            expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: an_instance_of(Hash), prosecution_case_id: prosecution_case_id).twice
             prosecution_case.defendants
+          end
+
+          context 'with no prosecution_case reference' do
+            let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { 'hearing' => { 'id' => hearing_ids[0] } }) }
+            let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { 'hearing' => { 'id' => hearing_ids[1] } }) }
+
+            it 'initialises Defendants without details' do
+              expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice
+              prosecution_case.defendants
+            end
           end
         end
       end

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
                 schema: {},
                 description: 'Return other data through a has_many relationship </br>e.g. include=offences'
 
+      parameter '$ref' => '#/components/parameters/transaction_id_header'
+
       context 'with success' do
         let(:Authorization) { "Bearer #{token.token}" }
         let(:id) { 'c6cf04b5-901d-4a89-a9ab-767eb57306e4' }
@@ -139,8 +141,6 @@ RSpec.describe 'Api::Internal::V1::Defendants', type: :request, swagger_doc: 'v1
         response('404', 'Not found') do
           let(:Authorization) { "Bearer #{token.token}" }
           let(:id) { 'c6cf04b5' }
-
-          parameter '$ref' => '#/components/parameters/transaction_id_header'
 
           run_test!
         end

--- a/spec/services/defendant_finder_spec.rb
+++ b/spec/services/defendant_finder_spec.rb
@@ -1,33 +1,67 @@
 # frozen_string_literal: true
 
 RSpec.describe DefendantFinder do
+  let(:prosecution_case_id) { '5edd67eb-9d8c-44f2-a57e-c8d026defaa4' }
+  let(:prosecution_case_reference) { '20GD0217100' }
   let(:defendant_id) { '2ecc9feb-9407-482f-b081-d9e5c8ba3ed3' }
   let(:offence_id) { '3f153786-f3cf-4311-bc0c-2d6f48af68a1' }
 
-  subject { described_class.call(defendant_id: defendant_id) }
+  let(:prosecution_cases_json) { file_fixture('prosecution_case_search_result.json').read }
+  let(:prosecution_cases_hash) { JSON.parse(prosecution_cases_json) }
+  let(:prosecution_case) { prosecution_cases_hash['cases'][0] }
 
-  let(:prosecution_case_hash) do
-    JSON.parse(file_fixture('prosecution_case_search_result.json').read)['cases'][0]
+  let(:hearing_json) { file_fixture('full_hearing.json').read }
+
+  before do
+    ProsecutionCase.create!(id: prosecution_case_id, body: prosecution_case)
+    ProsecutionCaseDefendantOffence.create(
+      defendant_id: defendant_id,
+      prosecution_case_id: prosecution_case_id,
+      offence_id: offence_id
+    )
   end
 
-  context 'the defendant does exist' do
-    let!(:prosecution_case) { ProsecutionCase.create!(id: '5edd67eb-9d8c-44f2-a57e-c8d026defaa4', body: prosecution_case_hash) }
-    let!(:case_defendant_offence) { ProsecutionCaseDefendantOffence.create(defendant_id: defendant_id, prosecution_case_id: prosecution_case.id, offence_id: offence_id) }
+  describe '#call', :stub_case_search_with_urn, :stub_hearing_result do
+    subject(:defendant) { described_class.call(defendant_id: defendant_id) }
 
-    it 'returns a Defendant' do
-      expect(subject).to be_a(Defendant)
+    it 'queries body from prosecutionCases endpoint' do
+      defendant
+      expect(a_request(:get, %r{.*/prosecutionCases\?prosecutionCaseReference=#{prosecution_case_reference}})).to have_been_made.once
     end
 
-    it 'returns the requested Defendant' do
-      expect(subject.id).to eq(defendant_id)
+    it 'queries details from hearing results endpoint' do
+      defendant
+      expect(a_request(:get, %r{.*/hearing/results\?hearingId=.*})).to have_been_made.at_least_once
     end
-  end
 
-  context 'the defendant does not exist' do
-    let(:defendant_id) { '2ecc9feb' }
+    context 'when defendant does exist' do
+      it { is_expected.to be_a(Defendant) }
 
-    it 'does not return the requested Defendant' do
-      expect(subject).to be_nil
+      it 'returns the requested Defendant' do
+        expect(defendant.id).to eq(defendant_id)
+      end
+
+      it { is_expected.to respond_to(:offences) }
+
+      it 'includes the expected offence' do
+        expect(defendant.offences.map(&:id)).to include(offence_id)
+      end
+
+      context 'with offence' do
+        it 'includes plea detail' do
+          expect(defendant.offences.map(&:plea)).to include('NOT_GUILTY')
+        end
+
+        it 'includes mode of trial detail' do
+          expect(defendant.offences.map(&:mode_of_trial_reason)).to include('Court directs trial by jury')
+        end
+      end
+    end
+
+    context 'when defendant does not exist' do
+      let(:defendant_id) { '2ecc9feb' }
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/services/prosecution_case_searcher_spec.rb
+++ b/spec/services/prosecution_case_searcher_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe ProsecutionCaseSearcher do
   let(:prosecution_case_reference) { '19GD1001816' }
 
   context 'with an incorrect key' do
-    let(:connection) { CommonPlatformConnection.call }
+    subject(:search) { described_class.call(prosecution_case_reference: prosecution_case_reference, connection: connection) }
 
-    subject { described_class.call(prosecution_case_reference: prosecution_case_reference, connection: connection) }
+    let(:connection) { CommonPlatformConnection.call }
 
     before do
       connection.headers['Ocp-Apim-Subscription-Key'] = 'INCORRECT KEY'
@@ -14,7 +14,7 @@ RSpec.describe ProsecutionCaseSearcher do
 
     it 'returns an unauthorised response' do
       VCR.use_cassette('search_prosecution_case/unauthorised') do
-        expect(subject.status).to eq(401)
+        expect(search.status).to eq(401)
       end
     end
   end
@@ -24,67 +24,67 @@ RSpec.describe ProsecutionCaseSearcher do
 
     it 'returns a successful response' do
       VCR.use_cassette('search_prosecution_case/by_prosecution_case_reference_success') do
-        expect(subject.status).to eq(200)
-        expect(subject.body['cases'][0]['prosecutionCaseReference']).to eq(prosecution_case_reference)
+        expect(search.status).to eq(200)
+        expect(search.body['cases'][0]['prosecutionCaseReference']).to eq(prosecution_case_reference)
         search
       end
     end
   end
 
   context 'searching by National Insurance Number' do
-    let(:national_insurance_number) { 'HB133542A' }
-
     subject(:search) { described_class.call(national_insurance_number: national_insurance_number) }
+
+    let(:national_insurance_number) { 'HB133542A' }
 
     it 'returns a successful response' do
       VCR.use_cassette('search_prosecution_case/by_national_insurance_number_success') do
-        expect(subject.status).to eq(200)
+        expect(search.status).to eq(200)
         search
       end
     end
   end
 
   context 'searching by Arrest Summons Number' do
-    let(:arrest_summons_number) { 'arrest123' }
-
     subject(:search) { described_class.call(arrest_summons_number: arrest_summons_number) }
+
+    let(:arrest_summons_number) { 'arrest123' }
 
     it 'returns a successful response' do
       VCR.use_cassette('search_prosecution_case/by_arrest_summons_number_success') do
-        expect(subject.status).to eq(200)
+        expect(search.status).to eq(200)
         search
       end
     end
   end
 
   context 'searching by name and date of birth' do
-    let(:date_of_birth) { '1980-01-01' }
-
     subject(:search) { described_class.call(name: 'George Walsh', date_of_birth: date_of_birth) }
+
+    let(:date_of_birth) { '1980-01-01' }
 
     it 'returns a successful response' do
       VCR.use_cassette('search_prosecution_case/by_name_and_date_of_birth_success') do
-        expect(subject.status).to eq(200)
+        expect(search.status).to eq(200)
         search
       end
     end
   end
 
   context 'searching by name and date_of_next_hearing' do
-    let(:date_of_next_hearing) { '2020-02-17' }
-
     subject(:search) { described_class.call(name: 'George Walsh', date_of_next_hearing: date_of_next_hearing) }
+
+    let(:date_of_next_hearing) { '2020-02-17' }
 
     it 'returns a successful response' do
       VCR.use_cassette('search_prosecution_case/by_name_and_date_of_next_hearing_success') do
-        expect(subject.status).to eq(200)
+        expect(search.status).to eq(200)
         search
       end
     end
   end
 
   context 'connection' do
-    subject { described_class.call(prosecution_case_reference: prosecution_case_reference, connection: connection) }
+    subject(:search) { described_class.call(prosecution_case_reference: prosecution_case_reference, connection: connection) }
 
     let(:connection) { double('CommonPlatformConnection') }
     let(:url) { 'prosecutionCases' }
@@ -92,7 +92,7 @@ RSpec.describe ProsecutionCaseSearcher do
 
     it 'makes a get request' do
       expect(connection).to receive(:get).with(url, params)
-      subject
+      search
     end
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -2,7 +2,7 @@
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
-  c.hook_into :faraday
+  c.hook_into :webmock
   c.configure_rspec_metadata!
   c.filter_sensitive_data('<COMMON_PLATFORM_URL>') { ENV['COMMON_PLATFORM_URL'] }
   c.filter_sensitive_data('<SHARED_SECRET_KEY>') { ENV['SHARED_SECRET_KEY'] }

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,6 +3,7 @@
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
+  c.debug_logger = File.open('log/vcr.log', 'w') if ENV['VCR_DEBUG']
   c.configure_rspec_metadata!
   c.filter_sensitive_data('<COMMON_PLATFORM_URL>') { ENV['COMMON_PLATFORM_URL'] }
   c.filter_sensitive_data('<SHARED_SECRET_KEY>') { ENV['SHARED_SECRET_KEY'] }

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+RSpec.configure do |config|
+  config.before(:each, stub_case_search_with_urn: true) do
+    stub_request(:get, %r{http.*/apigw.*\.cjscp\.org\.uk/LAA/v1/prosecutionCases\?prosecutionCaseReference=#{prosecution_case_reference}})
+      .to_return(
+        status: 200,
+        body: prosecution_cases_json,
+        headers: { 'Content-Type' => 'application/vnd.unifiedsearch.query.laa.cases+json' }
+      )
+  end
+
+  config.before(:each, stub_hearing_result: true) do
+    uuid_regex = /[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}/
+
+    stub_request(:get, %r{http.*/apigw.*\.cjscp\.org\.uk/LAA/v1/hearing/results\?hearingId=#{uuid_regex}})
+      .to_return(
+        status: 200,
+        body: hearing_json,
+        headers: { 'Content-Type' => 'application/vnd.unifiedsearch.query.laa.cases+json' }
+      )
+  end
+end


### PR DESCRIPTION
## What

[display mode of trial CBO-1575](https://dsdmoj.atlassian.net/browse/CBO-1575)
[display plea and plea date CBO-1588](https://dsdmoj.atlassian.net/browse/CBO-1588)

Modify the DefendantFinder class to query prosecution case from
common platform including fetching the hearing `details`. The
hearing details contain plea and mode of trial reasons which
are needed by case workers during their assessment of a claim.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.