### PR TITLE
Return unique pleas per offence

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -69,7 +69,7 @@ private
   def pleas_array
     return [] if details.blank?
 
-    details.flat_map { |detail| detail["plea"] }.compact
+    details.flat_map { |detail| detail["plea"] }.uniq.compact
   end
 
   def allocation_decisions

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -50,12 +50,12 @@ class Offence
     end
   end
 
-  # TODO: derprecate/remove
+  # TODO: deprecate/remove
   def plea
     pleas_array.dig(0, "pleaValue")
   end
 
-  # TODO: derprecate/remove
+  # TODO: deprecate/remove
   def plea_date
     pleas_array.dig(0, "pleaDate")
   end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Offence, type: :model do
       it { is_expected.to eq plea_array }
     end
 
-    context "with multiple pleas" do
+    context "with multiple unique pleas" do
       let(:details_array) do
         [{
           "plea" => {
@@ -127,6 +127,32 @@ RSpec.describe Offence, type: :model do
            "code": "GUILTY",
            "pleaded_at": "2020-12-24",
          }]
+      end
+
+      it { is_expected.to eq plea_array }
+    end
+
+    context "with multiple non-unique pleas" do
+      let(:details_array) do
+        [{
+          "plea" => {
+            "pleaDate" => "2020-04-24",
+            "pleaValue" => "NOT_GUILTY",
+          },
+        },
+         {
+           "plea" => {
+             "pleaDate" => "2020-04-24",
+             "pleaValue" => "NOT_GUILTY",
+           },
+         }]
+      end
+
+      let(:plea_array) do
+        [{
+          "code": "NOT_GUILTY",
+          "pleaded_at": "2020-04-24",
+        }]
       end
 
       it { is_expected.to eq plea_array }

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -51,75 +51,91 @@ RSpec.describe Offence, type: :model do
     it { expect(offence.maat_reference).to eq("AB746921") }
   end
 
-  context "when plea details are available" do
+  describe "#plea" do
     let(:details_array) do
       [{
         "plea" => {
-          "pleaDate" => "2020-04-24",
           "pleaValue" => "GUILTY",
         },
       }]
     end
 
-    describe "#plea" do
-      subject { offence.plea }
+    subject { offence.plea }
 
-      it { is_expected.to eq("GUILTY") }
+    it { is_expected.to eq("GUILTY") }
+  end
+
+  describe "#plea_date" do
+    let(:details_array) do
+      [{
+        "plea" => {
+          "pleaDate" => "2020-04-24",
+        },
+      }]
     end
 
-    describe "#plea_date" do
-      subject { offence.plea_date }
+    subject { offence.plea_date }
 
-      it { is_expected.to eq("2020-04-24") }
-    end
+    it { is_expected.to eq("2020-04-24") }
+  end
 
-    context "#pleas" do
-      subject { offence.pleas }
+  context "#pleas" do
+    subject { offence.pleas }
+
+    context "with one plea" do
+      let(:details_array) do
+        [{
+          "plea" => {
+            "pleaDate" => "2020-04-25",
+            "pleaValue" => "NOT_GUILTY",
+          },
+        }]
+      end
 
       let(:plea_array) do
         [{
-          "code": "GUILTY",
-          "pleaded_at": "2020-04-24",
+          "code": "NOT_GUILTY",
+          "pleaded_at": "2020-04-25",
         }]
       end
 
       it { is_expected.to eq plea_array }
+    end
 
-      context "with multiple pleas" do
-        let(:details_array) do
-          [{
-            "plea" => {
-              "pleaDate" => "2020-04-24",
-              "pleaValue" => "NOT_GUILTY",
-            },
+    context "with multiple pleas" do
+      let(:details_array) do
+        [{
+          "plea" => {
+            "pleaDate" => "2020-04-24",
+            "pleaValue" => "NOT_GUILTY",
           },
-           {
-             "plea" => {
-               "pleaDate" => "2020-12-24",
-               "pleaValue" => "GUILTY",
-             },
-           }]
-        end
-
-        let(:plea_array) do
-          [{
-            "code": "NOT_GUILTY",
-            "pleaded_at": "2020-04-24",
-          },
-           {
-             "code": "GUILTY",
-             "pleaded_at": "2020-12-24",
-           }]
-        end
-
-        it { is_expected.to eq plea_array }
+        },
+         {
+           "plea" => {
+             "pleaDate" => "2020-12-24",
+             "pleaValue" => "GUILTY",
+           },
+         }]
       end
 
-      context "with no pleas" do
-        let(:details_array) { [{ "some_other_detail" => "" }] }
-
-        it { expect(offence.pleas).to be_an(Array).and be_empty }
+      let(:plea_array) do
+        [{
+          "code": "NOT_GUILTY",
+          "pleaded_at": "2020-04-24",
+        },
+         {
+           "code": "GUILTY",
+           "pleaded_at": "2020-12-24",
+         }]
       end
+
+      it { is_expected.to eq plea_array }
+    end
+
+    context "with no pleas" do
+      let(:details_array) { [{ "some_other_detail" => "" }] }
+
+      it { expect(offence.pleas).to be_an(Array).and be_empty }
     end
   end
 


### PR DESCRIPTION
## What
Prevent non-unique pleas being returned

[Link to story LASB-442](https://dsdmoj.atlassian.net/browse/LASB-442)

## Why

Pleas are repeated per hearing, defendant, offence on the hearing endpoint
of common platoform API. We therefore need to filter out non-unique plea
details.

This will enable consumers (VCD) to easily present Changes of plea without
pointless repetition.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.