### PR TITLE
Modify offence model to expose multiple mode of trial reasons

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -37,6 +37,15 @@ class Offence
     allocation_decisions.dig(0, "motReasonCode")
   end
 
+  def mode_of_trial_reasons
+    allocation_decisions.map do |decision|
+      {
+        description: decision["motReasonDescription"],
+        code: decision["motReasonDescriptionCode"],
+      }
+    end
+  end
+
   def maat_reference
     laa_reference["applicationReference"] if laa_reference.present?
   end
@@ -75,6 +84,6 @@ private
   def allocation_decisions
     return [] if details.blank?
 
-    details.flat_map { |detail| detail["allocationDecision"] }
+    details.flat_map { |detail| detail["allocationDecision"] }.uniq.compact
   end
 end

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -8,6 +8,7 @@ class OffenceSerializer
               :title,
               :legislation,
               :mode_of_trial,
+              :mode_of_trial_reasons,
               :mode_of_trial_reason,
               :mode_of_trial_reason_code,
               :pleas,

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -208,4 +208,90 @@ RSpec.describe Offence, type: :model do
       it { is_expected.to eql "5" }
     end
   end
+
+  describe "#mode of trial reasons" do
+    subject(:mode_of_trial_reasons) { offence.mode_of_trial_reasons }
+
+    context "when one allocation decision is available" do
+      let(:details_array) do
+        [{
+          "allocationDecision" => {
+            "motReasonDescription" => "Court directs trial by jury",
+            "motReasonDescriptionCode" => "3",
+          },
+        }]
+      end
+
+      let(:allocation_decisions_array) do
+        [{
+          "description": "Court directs trial by jury",
+          "code": "3",
+        }]
+      end
+
+      it { is_expected.to eql allocation_decisions_array }
+    end
+
+    context "when multiple unique allocation decisions are available" do
+      let(:details_array) do
+        [{
+          "allocationDecision" => {
+            "motReasonDescription" => "Court directs trial by jury",
+            "motReasonDescriptionCode" => "3",
+          },
+        },
+         {
+           "allocationDecision" => {
+             "motReasonDescription" => "Some other mot desc",
+             "motReasonDescriptionCode" => "1",
+           },
+         }]
+      end
+
+      let(:allocation_decisions_array) do
+        [{
+          "description": "Court directs trial by jury",
+          "code": "3",
+        },
+         {
+           "description": "Some other mot desc",
+           "code": "1",
+         }]
+      end
+
+      it { is_expected.to eql allocation_decisions_array }
+    end
+
+    context "when multiple non-unique allocation decisions are available" do
+      let(:details_array) do
+        [{
+          "allocationDecision" => {
+            "motReasonDescription" => "Court directs trial by jury",
+            "motReasonDescriptionCode" => "3",
+          },
+        },
+         {
+           "allocationDecision" => {
+             "motReasonDescription" => "Court directs trial by jury",
+             "motReasonDescriptionCode" => "3",
+           },
+         }]
+      end
+
+      let(:allocation_decisions_array) do
+        [{
+          "description": "Court directs trial by jury",
+          "code": "3",
+        }]
+      end
+
+      it { is_expected.to eql allocation_decisions_array }
+    end
+
+    context "with no allocation decisions" do
+      let(:details_array) { [{ "some_other_detail" => "" }] }
+
+      it { expect(offence.mode_of_trial_reasons).to be_an(Array).and be_empty }
+    end
+  end
 end

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe OffenceSerializer do
                     mode_of_trial: "Indictable-Only Offence",
                     mode_of_trial_reason: "Court directs trial by jury",
                     mode_of_trial_reason_code: "5",
+                    mode_of_trial_reasons: ["Court directs trial by jury", "Another reason"],
                     pleas: %w[GUILTY NOT_GUILTY],
                     plea: "GUILTY",
                     plea_date: "2020-01-01")
@@ -28,6 +29,7 @@ RSpec.describe OffenceSerializer do
     it { expect(attribute_hash[:mode_of_trial]).to eq("Indictable-Only Offence") }
     it { expect(attribute_hash[:mode_of_trial_reason]).to eq("Court directs trial by jury") }
     it { expect(attribute_hash[:mode_of_trial_reason_code]).to eq("5") }
+    it { expect(attribute_hash[:mode_of_trial_reasons]).to eq(["Court directs trial by jury", "Another reason"]) }
     it { expect(attribute_hash[:pleas]).to eq(%w[GUILTY NOT_GUILTY]) }
     it { expect(attribute_hash[:plea]).to eq("GUILTY") }
     it { expect(attribute_hash[:plea_date]).to eq("2020-01-01") }


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=454&projectKey=LASB&modal=detail&selectedIssue=LASB-443

Expose all the allocation decisions (mode of trial reasons and mode of trial reason codes) available against a single offence. Although it is expected that only one decision will be available, this accounts for the possibility that multiple decisions could be.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
