### PR TITLE
Remove unneeded singular plea data attributes

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -59,16 +59,6 @@ class Offence
     end
   end
 
-  # TODO: deprecate/remove
-  def plea
-    pleas_array.dig(0, "pleaValue")
-  end
-
-  # TODO: deprecate/remove
-  def plea_date
-    pleas_array.dig(0, "pleaDate")
-  end
-
 private
 
   def laa_reference

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -11,7 +11,5 @@ class OffenceSerializer
               :mode_of_trial_reasons,
               :mode_of_trial_reason,
               :mode_of_trial_reason_code,
-              :pleas,
-              :plea,
-              :plea_date
+              :pleas
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Offence, type: :model do
   it { expect(offence.legislation).to eq("Offences against the Person Act 1861 s.24") }
   it { expect(offence.mode_of_trial).to eq("Indictable-Only Offence") }
   it { expect(offence.maat_reference).to be_nil }
-  it { expect(offence.plea).to be_nil }
-  it { expect(offence.plea_date).to be_nil }
   it { expect(offence.pleas).to be_an(Array).and be_empty }
 
   context "when an LAA reference are available" do
@@ -49,34 +47,6 @@ RSpec.describe Offence, type: :model do
     end
 
     it { expect(offence.maat_reference).to eq("AB746921") }
-  end
-
-  describe "#plea" do
-    let(:details_array) do
-      [{
-        "plea" => {
-          "pleaValue" => "GUILTY",
-        },
-      }]
-    end
-
-    subject { offence.plea }
-
-    it { is_expected.to eq("GUILTY") }
-  end
-
-  describe "#plea_date" do
-    let(:details_array) do
-      [{
-        "plea" => {
-          "pleaDate" => "2020-04-24",
-        },
-      }]
-    end
-
-    subject { offence.plea_date }
-
-    it { is_expected.to eq("2020-04-24") }
   end
 
   context "#pleas" do

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe OffenceSerializer do
                     mode_of_trial_reason: "Court directs trial by jury",
                     mode_of_trial_reason_code: "5",
                     mode_of_trial_reasons: ["Court directs trial by jury", "Another reason"],
-                    pleas: %w[GUILTY NOT_GUILTY],
-                    plea: "GUILTY",
-                    plea_date: "2020-01-01")
+                    pleas: %w[GUILTY NOT_GUILTY])
   end
 
   subject { described_class.new(offence).serializable_hash }
@@ -31,7 +29,5 @@ RSpec.describe OffenceSerializer do
     it { expect(attribute_hash[:mode_of_trial_reason_code]).to eq("5") }
     it { expect(attribute_hash[:mode_of_trial_reasons]).to eq(["Court directs trial by jury", "Another reason"]) }
     it { expect(attribute_hash[:pleas]).to eq(%w[GUILTY NOT_GUILTY]) }
-    it { expect(attribute_hash[:plea]).to eq("GUILTY") }
-    it { expect(attribute_hash[:plea_date]).to eq("2020-01-01") }
   end
 end

--- a/spec/services/defendant_finder_spec.rb
+++ b/spec/services/defendant_finder_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DefendantFinder do
 
       context "with offence" do
         it "includes plea detail" do
-          expect(defendant.offences.map(&:plea)).to include("NOT_GUILTY")
+          expect(defendant.offences.flat_map(&:pleas)).to include({ code: "NOT_GUILTY", pleaded_at: "2020-04-12" })
         end
 
         it "includes mode of trial detail" do


### PR DESCRIPTION
## What
Remove unneeded singular plea data attributes

[LASB-442](https://dsdmoj.atlassian.net/browse/LASB-442)

Offence can have multiple pleas. VCD now expects
an array of pleas so the older single plea mechanism
is no longer required by it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.