### PR TITLE
LASB-444/include hearings search default

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -20,7 +20,7 @@ module Api
         end
 
         def serialization_options
-          return { include: inclusions, params: { inclusions: inclusions } } if params[:include].present?
+          return { include: inclusions } if inclusions.present?
 
           {}
         end

--- a/app/serializers/prosecution_case_serializer.rb
+++ b/app/serializers/prosecution_case_serializer.rb
@@ -8,5 +8,5 @@ class ProsecutionCaseSerializer
 
   has_many :defendants, record_type: :defendants
   has_many :hearing_summaries, record_type: :hearing_summaries
-  has_many :hearings, record_type: :hearings, if: proc { |_record, params| params[:inclusions].try(:include?, "hearings") }
+  has_many :hearings, record_type: :hearings
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25,6 +25,8 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
@@ -54,7 +56,7 @@ CREATE SEQUENCE public.dummy_maat_reference_seq
 --
 
 CREATE TABLE public.hearing_event_recordings (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     hearing_id uuid,
     hearing_date date,
     body jsonb NOT NULL,
@@ -68,7 +70,7 @@ CREATE TABLE public.hearing_event_recordings (
 --
 
 CREATE TABLE public.hearings (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     body jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -80,7 +82,7 @@ CREATE TABLE public.hearings (
 --
 
 CREATE TABLE public.laa_references (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     defendant_id uuid NOT NULL,
     maat_reference character varying NOT NULL,
     dummy_maat_reference boolean DEFAULT false NOT NULL,
@@ -96,7 +98,7 @@ CREATE TABLE public.laa_references (
 --
 
 CREATE TABLE public.oauth_access_grants (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     resource_owner_id uuid NOT NULL,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -113,7 +115,7 @@ CREATE TABLE public.oauth_access_grants (
 --
 
 CREATE TABLE public.oauth_access_tokens (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     resource_owner_id uuid,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -131,7 +133,7 @@ CREATE TABLE public.oauth_access_tokens (
 --
 
 CREATE TABLE public.oauth_applications (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying NOT NULL,
     uid character varying NOT NULL,
     secret character varying NOT NULL,
@@ -148,7 +150,7 @@ CREATE TABLE public.oauth_applications (
 --
 
 CREATE TABLE public.prosecution_case_defendant_offences (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     prosecution_case_id uuid NOT NULL,
     defendant_id uuid NOT NULL,
     offence_id uuid NOT NULL,
@@ -171,7 +173,7 @@ CREATE TABLE public.prosecution_case_defendant_offences (
 --
 
 CREATE TABLE public.prosecution_cases (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     body jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -192,7 +194,7 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.users (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying,
     auth_token_digest character varying,
     created_at timestamp(6) without time zone NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25,8 +25,6 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
-
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
@@ -56,7 +54,7 @@ CREATE SEQUENCE public.dummy_maat_reference_seq
 --
 
 CREATE TABLE public.hearing_event_recordings (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     hearing_id uuid,
     hearing_date date,
     body jsonb NOT NULL,
@@ -70,7 +68,7 @@ CREATE TABLE public.hearing_event_recordings (
 --
 
 CREATE TABLE public.hearings (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     body jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -82,7 +80,7 @@ CREATE TABLE public.hearings (
 --
 
 CREATE TABLE public.laa_references (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     defendant_id uuid NOT NULL,
     maat_reference character varying NOT NULL,
     dummy_maat_reference boolean DEFAULT false NOT NULL,
@@ -98,7 +96,7 @@ CREATE TABLE public.laa_references (
 --
 
 CREATE TABLE public.oauth_access_grants (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     resource_owner_id uuid NOT NULL,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -115,7 +113,7 @@ CREATE TABLE public.oauth_access_grants (
 --
 
 CREATE TABLE public.oauth_access_tokens (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     resource_owner_id uuid,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -133,7 +131,7 @@ CREATE TABLE public.oauth_access_tokens (
 --
 
 CREATE TABLE public.oauth_applications (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name character varying NOT NULL,
     uid character varying NOT NULL,
     secret character varying NOT NULL,
@@ -150,7 +148,7 @@ CREATE TABLE public.oauth_applications (
 --
 
 CREATE TABLE public.prosecution_case_defendant_offences (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     prosecution_case_id uuid NOT NULL,
     defendant_id uuid NOT NULL,
     offence_id uuid NOT NULL,
@@ -173,7 +171,7 @@ CREATE TABLE public.prosecution_case_defendant_offences (
 --
 
 CREATE TABLE public.prosecution_cases (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     body jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -194,7 +192,7 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.users (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name character varying,
     auth_token_digest character varying,
     created_at timestamp(6) without time zone NOT NULL,

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -152,4 +152,52 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
   recorded_at: Mon, 09 Nov 2020 17:51:54 GMT
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>prosecutionCases?prosecutionCaseReference=19GD1001816"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/vnd.unifiedsearch.query.laa.cases+json
+      Etag:
+      - W/"fb28f6d7c7ea88e334fe228433b66a24"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ca4619fc-5f35-4816-8254-1ba733c1aa18
+      X-Runtime:
+      - '0.021437'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":0,"cases":[]}'
+  recorded_at: Fri, 11 Dec 2020 11:53:19 GMT
 recorded_with: VCR 6.0.0

--- a/spec/requests/api/internal/v1/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v1/prosecution_cases_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "api/internal/v1/prosecution_cases", type: :request, swagger_doc:
   let(:schema) { File.read("swagger/v1/schema.json") }
   let(:include) {}
 
+  before do
+    allow(Api::GetHearingResults).to receive(:call)
+  end
+
   path "/api/internal/v1/prosecution_cases" do
     get("search prosecution_cases") do
       description 'Search prosecution cases. Valid search combinations are: <br/><br/>

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -25,5 +25,4 @@ RSpec.describe ProsecutionCaseSerializer do
     it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
     it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
   end
-  
 end

--- a/spec/serializer/prosecution_case_serializer_spec.rb
+++ b/spec/serializer/prosecution_case_serializer_spec.rb
@@ -23,12 +23,7 @@ RSpec.describe ProsecutionCaseSerializer do
 
     it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
     it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
-    it { expect(relationship_hash[:hearings]).to be_nil }
-
-    context "when hearings are expected in inclusions" do
-      subject { described_class.new(prosecution_case, params: { inclusions: "hearings" }).serializable_hash }
-
-      it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
-    end
+    it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
   end
+  
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-444)

Modifies the prosecution_case endpoint response to show the hearing details as part of the offence object as standard without the need to `include=hearings` in the request