### PR TITLE
Expose cracked ineffective trial payload

### DIFF
--- a/app/models/cracked_ineffective_trial.rb
+++ b/app/models/cracked_ineffective_trial.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CrackedIneffectiveTrial
+  include ActiveModel::Model
+
+  attr_accessor :body
+
+  def id
+    body["id"]
+  end
+
+  def code
+    body["code"]
+  end
+
+  def description
+    body["description"]
+  end
+
+  def type
+    body["type"]&.downcase
+  end
+end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -55,6 +55,16 @@ class Hearing < ApplicationRecord
     hearing_body["defenceCounsels"]&.map { |defence_counsel| defence_counsel["id"] }
   end
 
+  def cracked_ineffective_trial
+    return if cp_cracked_ineffective_trial.blank?
+
+    CrackedIneffectiveTrial.new(body: cp_cracked_ineffective_trial)
+  end
+
+  def cracked_ineffective_trial_id
+    cp_cracked_ineffective_trial&.fetch("id", nil)
+  end
+
 private
 
   def hearing_body
@@ -81,5 +91,9 @@ private
 
   def court_centre
     @court_centre ||= HmctsCommonPlatform::Reference::CourtCentre.find(hearing_body["courtCentre"]["id"])
+  end
+
+  def cp_cracked_ineffective_trial
+    hearing_body["crackedIneffectiveTrial"]
   end
 end

--- a/app/serializers/cracked_ineffective_trial_serializer.rb
+++ b/app/serializers/cracked_ineffective_trial_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CrackedIneffectiveTrialSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :cracked_ineffective_trial
+
+  attributes :id, :code, :type, :description
+end

--- a/app/serializers/hearing_serializer.rb
+++ b/app/serializers/hearing_serializer.rb
@@ -14,4 +14,5 @@ class HearingSerializer
 
   has_many :hearing_events, record_type: :hearing_events
   has_many :providers, record_type: :providers
+  has_one :cracked_ineffective_trial, record_type: :cracked_ineffective_trial
 end

--- a/spec/cassettes/hearing_result_fetcher/success_hearing_cracked_trial.yml
+++ b/spec/cassettes/hearing_result_fetcher/success_hearing_cracked_trial.yml
@@ -1,0 +1,348 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/hearing/results?hearingId=da124701-048f-408c-85b4-81138316ddce"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/plain; charset=utf-8
+      Request-Context:
+      - appId=cid-v1:fa402f79-a77a-4ded-8114-1ca5377aa0ab
+      Date:
+      - Fri, 18 Dec 2020 14:34:51 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "hearing": {
+            "id": "da124701-048f-408c-85b4-81138316ddce",
+            "jurisdictionType": "CROWN",
+            "courtCentre": {
+              "address": {
+                "address1": "QEII Law Courts",
+                "address2": "Derby Square",
+                "address3": "Liverpool",
+                "address4": "",
+                "address5": "",
+                "postcode": "L2 1XA"
+              },
+              "code": "C05LV00",
+              "id": "9b583616-049b-30f9-a14f-028a53b7cfe8",
+              "lja": {
+                "ljaCode": "1810",
+                "ljaName": "Merseyside Magistrates' Court"
+              },
+              "name": "Liverpool Crown Court",
+              "roomId": "7cb09222-49e1-3622-a5a6-ad253d2b3c39",
+              "roomName": "Crown Court 3-1"
+            },
+            "hearingDays": [
+              {
+                "listedDurationMinutes": 120,
+                "listingSequence": 1,
+                "sittingDay": "2020-08-28T08:00:00.000Z"
+              }
+            ],
+            "type": {
+              "description": "Trial",
+              "id": "bf8155e1-90b9-4080-b133-bfbad895d6e4"
+            },
+            "hearingLanguage": "ENGLISH",
+            "prosecutionCases": [
+              {
+                "id": "46115836-02c6-4547-844b-0db38d5d8447",
+                "prosecutionCaseIdentifier": {
+                  "majorCreditorCode": "PF45",
+                  "prosecutionAuthorityCode": "SURRPF",
+                  "prosecutionAuthorityId": "764bff92-a135-34cb-b858-8bb6b4b66301",
+                  "prosecutionAuthorityName": "Surrey Police",
+                  "prosecutionAuthorityOUCode": "0450000",
+                  "caseURN": "90GD9163LAA"
+                },
+                "initiationCode": "C",
+                "defendants": [
+                  {
+                    "id": "5f1d74c0-a2c3-425f-9447-68050e569a15",
+                    "prosecutionCaseId": "46115836-02c6-4547-844b-0db38d5d8447",
+                    "offences": [
+                      {
+                        "id": "933c2585-4d1c-4e51-8f78-5ed148db7d5c",
+                        "offenceDefinitionId": "a927ec2f-8a15-47e1-8a89-1d08d90b5091",
+                        "offenceCode": "AA06006",
+                        "offenceTitle": "Furnish false / misleading information - Animals and Animal Products (Import and Export) Regulations 2006",
+                        "wording": "Has a violent past and fear that he will commit further offences and\n                interfere with witnesse",
+                        "startDate": "2020-02-09",
+                        "offenceLegislation": "Contrary to regulations 32(c) and 34(4) of the Animals and Animal Products (Import and Export)(England) Regulations 2006.",
+                        "modeOfTrial": "Either Way",
+                        "arrestDate": "2020-02-09",
+                        "chargeDate": "2020-02-09",
+                        "orderIndex": 1,
+                        "count": 0,
+                        "plea": {
+                          "offenceId": "933c2585-4d1c-4e51-8f78-5ed148db7d5c",
+                          "originatingHearingId": "75865225-3608-4715-a800-c8b001a7f6d2",
+                          "pleaDate": "2020-08-27",
+                          "pleaValue": "NOT_GUILTY"
+                        },
+                        "aquittalDate": "2020-08-28",
+                        "judicialResults": [
+                          {
+                            "alwaysPublished": false,
+                            "category": "FINAL",
+                            "cjsCode": "2050",
+                            "courtClerk": {
+                              "firstName": "Erica",
+                              "lastName": "Wilson",
+                              "userId": "31ec3a16-8721-498c-8da5-f099390ee254"
+                            },
+                            "d20": false,
+                            "excludedFromResults": false,
+                            "isAdjournmentResult": false,
+                            "isAvailableForCourtExtract": true,
+                            "isConvictedResult": false,
+                            "isDeleted": false,
+                            "isFinancialResult": false,
+                            "isUnscheduled": false,
+                            "judicialResultId": "3cf9fd4b-ade4-427f-8f80-bef8a8e67f51",
+                            "judicialResultTypeId": "88fd00c6-d63c-4f4e-9a86-4628856a9557",
+                            "label": "No evidence offered - verdict of not guilty by order of Judge",
+                            "lastSharedDateTime": "2020-08-26",
+                            "lifeDuration": false,
+                            "orderedDate": "2020-08-28",
+                            "orderedHearingId": "da124701-048f-408c-85b4-81138316ddce",
+                            "postHearingCustodyStatus": "A",
+                            "publishedAsAPrompt": false,
+                            "publishedForNows": false,
+                            "rank": 18500,
+                            "resultText": "No evidence offered - verdict of not guilty by order of Judge\n",
+                            "rollUpPrompts": true,
+                            "terminatesOffenceProceedings": true,
+                            "urgent": false,
+                            "usergroups": []
+                          }
+                        ],
+                        "allocationDecision": {
+                          "originatingHearingId": "75865225-3608-4715-a800-c8b001a7f6d2",
+                          "offenceId": "933c2585-4d1c-4e51-8f78-5ed148db7d5c",
+                          "allocationDecisionDate": "2020-08-26",
+                          "motReasonId": "f8eb278a-8bce-373e-b365-b45e939da38a",
+                          "sequenceNumber": 30,
+                          "motReasonDescription": "Defendant elects trial by jury",
+                          "motReasonCode": "04"
+                        },
+                        "laaApplnReference": {
+                          "applicationReference": "6007982",
+                          "effectiveEndDate": "2020-08-26",
+                          "effectiveStartDate": "2020-08-26",
+                          "laaContractNumber": "0R022D",
+                          "offenceLevelStatus": "Granted",
+                          "statusCode": "GR",
+                          "statusDate": "2020-08-26",
+                          "statusDescription": "Granted (One Advocate)",
+                          "statusId": "98e86937-9652-32a3-a9fb-dbd01eda86a5"
+                        },
+                        "proceedingsConcluded": false
+                      },
+                      {
+                        "id": "a588aefd-006a-41d9-a42d-3beb450cbc0f",
+                        "offenceDefinitionId": "9c225a5d-e7e1-447f-bb1b-62c265b662ed",
+                        "offenceCode": "AA06007",
+                        "offenceTitle": "Operate an unapproved quarantine centre / facility for captive birds",
+                        "wording": "Has a violent past and fear that he will commit further offences and\n                interfere with witnesse",
+                        "startDate": "2020-02-09",
+                        "offenceLegislation": "Contrary to regulations 19(1) & 34(4) of the Animals and Animal Products (Import and Export) (England) Regulations 2006",
+                        "modeOfTrial": "Either Way",
+                        "arrestDate": "2020-02-09",
+                        "chargeDate": "2020-02-09",
+                        "orderIndex": 2,
+                        "count": 0,
+                        "plea": {
+                          "offenceId": "a588aefd-006a-41d9-a42d-3beb450cbc0f",
+                          "originatingHearingId": "75865225-3608-4715-a800-c8b001a7f6d2",
+                          "pleaDate": "2020-08-27",
+                          "pleaValue": "NOT_GUILTY"
+                        },
+                        "aquittalDate": "2020-08-28",
+                        "judicialResults": [
+                          {
+                            "alwaysPublished": false,
+                            "category": "FINAL",
+                            "cjsCode": "2050",
+                            "courtClerk": {
+                              "firstName": "Erica",
+                              "lastName": "Wilson",
+                              "userId": "31ec3a16-8721-498c-8da5-f099390ee254"
+                            },
+                            "d20": false,
+                            "excludedFromResults": false,
+                            "isAdjournmentResult": false,
+                            "isAvailableForCourtExtract": true,
+                            "isConvictedResult": false,
+                            "isDeleted": false,
+                            "isFinancialResult": false,
+                            "isUnscheduled": false,
+                            "judicialResultId": "fee32fcc-cb0f-4c12-ace3-f122cb0eff73",
+                            "judicialResultTypeId": "88fd00c6-d63c-4f4e-9a86-4628856a9557",
+                            "label": "No evidence offered - verdict of not guilty by order of Judge",
+                            "lastSharedDateTime": "2020-08-26",
+                            "lifeDuration": false,
+                            "orderedDate": "2020-08-28",
+                            "orderedHearingId": "da124701-048f-408c-85b4-81138316ddce",
+                            "postHearingCustodyStatus": "A",
+                            "publishedAsAPrompt": false,
+                            "publishedForNows": false,
+                            "rank": 18500,
+                            "resultText": "No evidence offered - verdict of not guilty by order of Judge\n",
+                            "rollUpPrompts": true,
+                            "terminatesOffenceProceedings": true,
+                            "urgent": false,
+                            "usergroups": []
+                          }
+                        ],
+                        "allocationDecision": {
+                          "originatingHearingId": "75865225-3608-4715-a800-c8b001a7f6d2",
+                          "offenceId": "a588aefd-006a-41d9-a42d-3beb450cbc0f",
+                          "allocationDecisionDate": "2020-08-26",
+                          "motReasonId": "f8eb278a-8bce-373e-b365-b45e939da38a",
+                          "sequenceNumber": 30,
+                          "motReasonDescription": "Defendant elects trial by jury",
+                          "motReasonCode": "04"
+                        },
+                        "laaApplnReference": {
+                          "applicationReference": "6007982",
+                          "effectiveEndDate": "2020-08-26",
+                          "effectiveStartDate": "2020-08-26",
+                          "laaContractNumber": "0R022D",
+                          "offenceLevelStatus": "Granted",
+                          "statusCode": "GR",
+                          "statusDate": "2020-08-26",
+                          "statusDescription": "Granted (One Advocate)",
+                          "statusId": "98e86937-9652-32a3-a9fb-dbd01eda86a5"
+                        },
+                        "proceedingsConcluded": false
+                      }
+                    ],
+                    "prosecutionAuthorityReference": "TFL",
+                    "personDefendant": {
+                      "arrestSummonsNumber": "TFL",
+                      "bailConditions": "",
+                      "bailStatus": {
+                        "code": "A",
+                        "description": "Not applicable",
+                        "id": "86009c70-759d-3308-8de4-194886ff9a77"
+                      },
+                      "personDetails": {
+                        "address": {
+                          "address1": "1234",
+                          "address2": "StreetDescription",
+                          "address3": "Locality2O"
+                        },
+                        "dateOfBirth": "1990-01-01",
+                        "documentationLanguageNeeds": "ENGLISH",
+                        "firstName": "Yessenia",
+                        "gender": "MALE",
+                        "lastName": "Kutch",
+                        "title": "Mr"
+                      }
+                    }
+                  }
+                ],
+                "originatingOrganisation": "0450000"
+              }
+            ],
+            "hasSharedResults": true,
+            "judiciary": [
+              {
+                "firstName": "Andrew Gwyn",
+                "judicialId": "f033ab37-c302-31f7-bf14-2449d037028d",
+                "judicialRoleType": {
+                  "judicialRoleTypeId": "f033ab37-c302-31f7-bf14-2449d037028d",
+                  "judiciaryType": "Senior Circuit Judge"
+                },
+                "lastName": "Menary",
+                "title": ""
+              }
+            ],
+            "prosecutionCounsels": [
+              {
+                "attendanceDays": [
+                  "2020-08-28"
+                ],
+                "firstName": "JO",
+                "id": "1877c1d9-f0b8-41c2-86d2-a601e4f3c540",
+                "lastName": "BOX",
+                "middleName": "",
+                "prosecutionCases": [
+                  "46115836-02c6-4547-844b-0db38d5d8447"
+                ],
+                "status": "JUNIOR",
+                "title": ""
+              }
+            ],
+            "defenceCounsels": [
+              {
+                "attendanceDays": [
+                  "2020-08-28"
+                ],
+                "defendants": [
+                  "f135658a-9d9f-49a2-b172-4935c4a2abf2"
+                ],
+                "firstName": "SIMON",
+                "id": "b0b28f12-df9a-447d-89fa-18b21ecb77f6",
+                "lastName": "BOLTON",
+                "middleName": "",
+                "status": "JUNIOR",
+                "title": ""
+              }
+            ],
+            "defendantAttendance": [
+              {
+                "attendanceDays": [
+                  {
+                    "attendanceType": "IN_PERSON",
+                    "day": "2020-08-28"
+                  }
+                ],
+                "defendantId": "5f1d74c0-a2c3-425f-9447-68050e569a15"
+              },
+              {
+                "attendanceDays": [
+                  {
+                    "attendanceType": "IN_PERSON",
+                    "day": "2020-08-28"
+                  }
+                ],
+                "defendantId": "f135658a-9d9f-49a2-b172-4935c4a2abf2"
+              }
+            ],
+            "crackedIneffectiveTrial": {
+              "code": "A",
+              "description": "On the date of trial the defendant, for the first time, enters a guilty plea which the prosecution accepts.",
+              "id": "c4ca4238-a0b9-3382-8dcc-509a6f75849b",
+              "type": "Cracked"
+            }
+          },
+          "sharedTime": "2020-08-26T13:32:10.717Z"
+        }
+  recorded_at: Fri, 18 Dec 2020 14:34:51 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/files/cracked_ineffective_trial.json
+++ b/spec/fixtures/files/cracked_ineffective_trial.json
@@ -1,0 +1,6 @@
+{
+  "code": "A",
+  "description": "On the date of trial the defendant, for the first time, enters a guilty plea which the prosecution accepts.",
+  "id": "c4ca4238-a0b9-3382-8dcc-509a6f75849b",
+  "type": "Cracked"
+}

--- a/spec/models/cracked_ineffective_trial_spec.rb
+++ b/spec/models/cracked_ineffective_trial_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe CrackedIneffectiveTrial, type: :model do
+  subject(:cracked_ineffective_trial) { described_class.new(body: cracked_ineffective_trial_hash) }
+
+  let(:cracked_ineffective_trial_hash) do
+    JSON.parse(file_fixture("cracked_ineffective_trial.json").read)
+  end
+
+  describe "#id" do
+    subject { cracked_ineffective_trial.id }
+
+    it { is_expected.to eql("c4ca4238-a0b9-3382-8dcc-509a6f75849b") }
+  end
+
+  describe "#type" do
+    subject(:type) { cracked_ineffective_trial.type }
+
+    it "is expected to downcase the type" do
+      expect(type).to eql("cracked")
+    end
+  end
+
+  describe "#code" do
+    subject { cracked_ineffective_trial.code }
+
+    it { is_expected.to eql("A") }
+  end
+
+  describe "#description" do
+    subject { cracked_ineffective_trial.description }
+
+    it { is_expected.to eql("On the date of trial the defendant, for the first time, enters a guilty plea which the prosecution accepts.") }
+  end
+end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -82,5 +82,27 @@ RSpec.describe Hearing, type: :model do
         it { expect(hearing.defence_advocate_names).to be_nil }
       end
     end
+
+    context "with cracked ineffective trial data available" do
+      let(:hearing_id) { "da124701-048f-408c-85b4-81138316ddce" }
+      let(:hearing) do
+        VCR.use_cassette("hearing_result_fetcher/success_hearing_cracked_trial") do
+          Api::GetHearingResults.call(hearing_id: hearing_id)
+        end
+      end
+
+      describe "#cracked_ineffective_trial_id" do
+        subject { hearing.cracked_ineffective_trial_id }
+
+        it { is_expected.to eql("c4ca4238-a0b9-3382-8dcc-509a6f75849b") }
+      end
+
+      describe "#cracked_ineffective_trial" do
+        subject { hearing.cracked_ineffective_trial }
+
+        it { is_expected.to be_a(CrackedIneffectiveTrial) }
+        it { is_expected.to respond_to(:id, :code, :description, :type) }
+      end
+    end
   end
 end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -5,55 +5,60 @@ RSpec.describe Hearing, type: :model do
 
   let(:hearing) { described_class.new(body: "{}") }
 
-  describe "validations" do
-    it { is_expected.to validate_presence_of(:body) }
-  end
+  it { is_expected.to validate_presence_of(:body) }
 
-  describe "Common Platform search" do
+  context "when searching common platform" do
     before do
       allow(HearingsCreatorWorker).to receive(:perform_async)
     end
 
-    let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
-
-    let(:hearing) do
-      VCR.use_cassette("hearing_result_fetcher/success") do
-        Api::GetHearingResults.call(hearing_id: hearing_id)
-      end
-    end
-
-    it { expect(hearing.court_name).to eq("Lavender Hill Magistrates' Court") }
-    it { expect(hearing.hearing_type).to eq("First hearing") }
-    it { expect(hearing.defendant_names).to eq(["Kole Jaskolski"]) }
-    it { expect(hearing.providers).to be_blank }
-    it { expect(hearing.provider_ids).to be_blank }
-    it { expect(hearing.judge_names).to be_blank }
-
-    context "with hearing events" do
-      let(:hearing_day) { "2020-08-17" }
-
-      let(:hearing_event_recording) do
-        VCR.use_cassette("hearing_logs_fetcher/success") do
-          Api::GetHearingEvents.call(hearing_id: hearing_id, hearing_date: hearing_day)
+    context "with basic hearing data available" do
+      let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
+      let(:hearing) do
+        VCR.use_cassette("hearing_result_fetcher/success") do
+          Api::GetHearingResults.call(hearing_id: hearing_id)
         end
       end
 
-      let(:hearing_events) { [hearing_event_recording] }
+      it { expect(hearing.id).to eq("4d01840d-5959-4539-a450-d39f57171036") }
+      it { expect(hearing.court_name).to eq("Lavender Hill Magistrates' Court") }
+      it { expect(hearing.hearing_type).to eq("First hearing") }
+      it { expect(hearing.judge_names).to be_blank }
+      it { expect(hearing.defendant_names).to eq(["Kole Jaskolski"]) }
+      it { expect(hearing.prosecution_advocate_names).to be_blank }
+      it { expect(hearing.defence_advocate_names).to be_blank }
+      it { expect(hearing.providers).to be_blank }
+      it { expect(hearing.provider_ids).to be_blank }
+      it { expect(hearing.hearing_days).to eq(["2020-08-17T09:01:01.001Z"]) }
+      it { expect(hearing.cracked_ineffective_trial).to be_nil }
+      it { expect(hearing.cracked_ineffective_trial_id).to be_nil }
 
-      before do
-        allow(Api::GetHearingEvents).to receive(:call).and_return(hearing_events)
-      end
+      context "with hearing events" do
+        let(:hearing_day) { "2020-08-17" }
 
-      it { expect(hearing.hearing_events).to all be_a(HearingEvent) }
+        let(:hearing_event_recording) do
+          VCR.use_cassette("hearing_logs_fetcher/success") do
+            Api::GetHearingEvents.call(hearing_id: hearing_id, hearing_date: hearing_day)
+          end
+        end
 
-      context "with blank hearing events" do
-        let(:hearing_events) { [hearing_event_recording, nil] }
+        let(:hearing_events) { [hearing_event_recording] }
+
+        before do
+          allow(Api::GetHearingEvents).to receive(:call).and_return(hearing_events)
+        end
 
         it { expect(hearing.hearing_events).to all be_a(HearingEvent) }
+
+        context "with blank hearing events" do
+          let(:hearing_events) { [hearing_event_recording, nil] }
+
+          it { expect(hearing.hearing_events).to all be_a(HearingEvent) }
+        end
       end
     end
 
-    context "with hearings information" do
+    context "with most hearing data available" do
       let(:hearing_id) { "29b73d8f-7683-4e27-9069-f7a031672c35" }
       let(:hearing) do
         VCR.use_cassette("hearing_result_fetcher/success_hearing_attendees") do
@@ -61,13 +66,15 @@ RSpec.describe Hearing, type: :model do
         end
       end
 
+      it { expect(hearing.id).to eq("29b73d8f-7683-4e27-9069-f7a031672c35") }
+      it { expect(hearing.hearing_type).to eq("Committal for Sentence") }
+      it { expect(hearing.court_name).to eq("Liverpool Crown Court") }
       it { expect(hearing.judge_names).to eq(["Andrew Gwyn Menary"]) }
+      it { expect(hearing.defendant_names).to eq(["Trever Glover"]) }
       it { expect(hearing.prosecution_advocate_names).to eq(["andrew smith"]) }
       it { expect(hearing.defence_advocate_names).to eq(["joe bloggs"]) }
       it { expect(hearing.providers).to all be_a(Provider) }
       it { expect(hearing.provider_ids).to eq(%w[536abfd5-8671-4672-bf33-aa54de5d6a24]) }
-      it { expect(hearing.id).to eq("29b73d8f-7683-4e27-9069-f7a031672c35") }
-      it { expect(hearing.hearing_type).to eq("Committal for Sentence") }
       it { expect(hearing.hearing_days).to eq(["2020-08-18T09:00:00.000Z"]) }
 
       context "when prosecutionCounsels are not provided" do

--- a/spec/serializer/cracked_ineffective_trial_serializer_spec.rb
+++ b/spec/serializer/cracked_ineffective_trial_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe CrackedIneffectiveTrialSerializer do
+  subject { described_class.new(cracked_ineffective_trial).serializable_hash }
+
+  let(:cracked_ineffective_trial) do
+    instance_double("CrackedIneffectiveTrial",
+                    id: "a-uuid",
+                    code: "A",
+                    type: "cracked",
+                    description: "A reason for the cracked trail goes here")
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:id]).to eq("a-uuid") }
+    it { expect(attribute_hash[:code]).to eq("A") }
+    it { expect(attribute_hash[:type]).to eq("cracked") }
+    it { expect(attribute_hash[:description]).to eq("A reason for the cracked trail goes here") }
+  end
+end

--- a/spec/serializer/hearing_serializer_spec.rb
+++ b/spec/serializer/hearing_serializer_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe HearingSerializer do
                     judge_names: ["Mr Recorder J Patterson"],
                     prosecution_advocate_names: ["John Rob"],
                     defence_advocate_names: ["Neil Griffiths"],
-                    provider_ids: %w[PROVIDER_UUID])
+                    provider_ids: %w[PROVIDER_UUID],
+                    cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
 
   context "with attributes" do


### PR DESCRIPTION
## What
Expose cracked inneffective trial payload

Add `cracked_ineffective_trial` payloads to the
hearing and prosecution case endpoints.

## Ticket

[CBO-1605](https://dsdmoj.atlassian.net/browse/CBO-1605)

## Why
These are required by VCD to inform case workers if a trial
has cracked (or been vacated in a manner that would
constitute a cracked trial - TBC). This in turn affects claimable
fees and the amounts.

## TODO

 - [ ] check with crimeapps teams if this is the best way
 - [ ] check with crimeapps teams we need to generate any JSON for the new pseudo-model
 - [ ] check with crimeapps teams if we need more specs or swagger doc changes
 - [x]  rebase/tidy commits

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.