### PR TITLE
Ensure only unique mode of trial reasons are returned

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -66,6 +66,6 @@ private
   def allocation_decisions
     return [] if details.blank?
 
-    details.flat_map { |detail| detail["allocationDecision"] }.uniq.compact
+    details.flat_map { |detail| detail["allocationDecision"] }
   end
 end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -30,12 +30,12 @@ class Offence
   end
 
   def mode_of_trial_reasons
-    allocation_decisions.map do |decision|
+    allocation_decisions.map { |decision|
       {
         description: decision["motReasonDescription"],
         code: decision["motReasonCode"],
       }
-    end
+    }.uniq.compact
   end
 
   def maat_reference

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -35,7 +35,7 @@ class Offence
         description: decision["motReasonDescription"],
         code: decision["motReasonCode"],
       }
-    }.uniq.compact
+    }.uniq
   end
 
   def maat_reference
@@ -66,6 +66,6 @@ private
   def allocation_decisions
     return [] if details.blank?
 
-    details.flat_map { |detail| detail["allocationDecision"] }
+    details.flat_map { |detail| detail["allocationDecision"] }.compact
   end
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Offence, type: :model do
         [{
           "allocationDecision" => {
             "motReasonDescription" => "Court directs trial by jury",
-            "motReasonCode" => "3",
+            "motReasonCode" => "05",
           },
         }]
       end
@@ -151,7 +151,7 @@ RSpec.describe Offence, type: :model do
       let(:allocation_decisions_array) do
         [{
           description: "Court directs trial by jury",
-          code: "3",
+          code: "05",
         }]
       end
 
@@ -163,24 +163,24 @@ RSpec.describe Offence, type: :model do
         [{
           "allocationDecision" => {
             "motReasonDescription" => "Court directs trial by jury",
-            "motReasonCode" => "3",
+            "motReasonCode" => "05",
           },
         },
          {
            "allocationDecision" => {
              "motReasonDescription" => "Some other mot desc",
-             "motReasonCode" => "1",
+             "motReasonCode" => "101",
            },
          }]
       end
 
       let(:allocation_decisions_array) do
         [{
-          code: "3",
+          code: "05",
           description: "Court directs trial by jury",
         },
          {
-           code: "1",
+           code: "101",
            description: "Some other mot desc",
          }]
       end
@@ -188,19 +188,19 @@ RSpec.describe Offence, type: :model do
       it { is_expected.to eql allocation_decisions_array }
     end
 
-    context "when multiple non-unique allocation decisions are available" do
+    context "when multiple non-unique allocation decisions available across different hearings" do
       let(:details_array) do
         [{
           "allocationDecision" => {
             "motReasonDescription" => "Court directs trial by jury",
-            "motReasonCode" => "3",
+            "motReasonCode" => "05",
             "originatingHearingId" => "uuid-for-first-hearing",
           },
         },
          {
            "allocationDecision" => {
              "motReasonDescription" => "Court directs trial by jury",
-             "motReasonCode" => "3",
+             "motReasonCode" => "05",
              "originatingHearingId" => "uuid-for-second-hearing",
            },
          }]
@@ -209,7 +209,7 @@ RSpec.describe Offence, type: :model do
       let(:allocation_decisions_array) do
         [{
           description: "Court directs trial by jury",
-          code: "3",
+          code: "05",
         }]
       end
 

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Offence, type: :model do
     end
   end
 
-  describe "#mode of trial reasons" do
+  describe "#mode_of_trial_reasons" do
     subject(:mode_of_trial_reasons) { offence.mode_of_trial_reasons }
 
     context "when one allocation decision is available" do
@@ -194,12 +194,14 @@ RSpec.describe Offence, type: :model do
           "allocationDecision" => {
             "motReasonDescription" => "Court directs trial by jury",
             "motReasonCode" => "3",
+            "originatingHearingId" => "uuid-for-first-hearing",
           },
         },
          {
            "allocationDecision" => {
              "motReasonDescription" => "Court directs trial by jury",
              "motReasonCode" => "3",
+             "originatingHearingId" => "uuid-for-second-hearing",
            },
          }]
       end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Offence, type: :model do
 
       let(:allocation_decisions_array) do
         [{
-          "description": "Court directs trial by jury",
-          "code": "3",
+          description: "Court directs trial by jury",
+          code: "3",
         }]
       end
 
@@ -176,12 +176,12 @@ RSpec.describe Offence, type: :model do
 
       let(:allocation_decisions_array) do
         [{
-          "description": "Court directs trial by jury",
-          "code": "3",
+          code: "3",
+          description: "Court directs trial by jury",
         },
          {
-           "description": "Some other mot desc",
-           "code": "1",
+           code: "1",
+           description: "Some other mot desc",
          }]
       end
 
@@ -206,8 +206,8 @@ RSpec.describe Offence, type: :model do
 
       let(:allocation_decisions_array) do
         [{
-          "description": "Court directs trial by jury",
-          "code": "3",
+          description: "Court directs trial by jury",
+          code: "3",
         }]
       end
 


### PR DESCRIPTION
## What
Ensure only unique mode of trial reasons are returned.

[LASB-505](https://dsdmoj.atlassian.net/browse/LASB-505)
[extension of LASB-443](https://dsdmoj.atlassian.net/browse/LASB-443)


## Why
Ensure only unique mode of trial reasons are returned.

Because `allocationDecisions` appear to be repeating
across hearings for the same offence (unlike on
the  SIT environment). The `originatingHearingId` for the
allocationDecision hash will be unique even if it
is for the same offenceId and the same mode of trial reason;
a chain of `uniq` on the entire allocationDecision will 
therefore not do what is intended.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.

- [x] You should have checked that the commit messages say why the change was made.
