### PR TITLE
Upgrade helm orb to 1.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@4.0.1
   aws-eks: circleci/aws-eks@0.2.1
   kubernetes: circleci/kubernetes@0.7.0
-  helm: circleci/helm@1.0.0
+  helm: circleci/helm@1.1.2
 
 commands:
   checkout_and_decrypt:


### PR DESCRIPTION
## What
Upgrade helm orb to 1.1.2, as the helm charts at https://kubernetes-charts.storage.googleapis.com are no longer publicly available. This is causing the build pipeline to break at the installing helm chart step.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
