### PR TITLE
Reorder the --trusted flag

### DIFF
--- a/docs/git-crypt.md
+++ b/docs/git-crypt.md
@@ -14,7 +14,7 @@
     - type `quit` to exit the gpg prompt
 * add user to git-crypt:
 
-        git-crypt add-gpg-user <email> --trusted
+        git-crypt add-gpg-user --trusted <email>
 
     This will create a commit with the appropriate changes
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-496)

Update the docs to correctly refer to the `--trusted` flag.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
