### PR TITLE
Remove unneeded MoT attributes on offence

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -29,14 +29,6 @@ class Offence
     body["modeOfTrial"]
   end
 
-  def mode_of_trial_reason
-    allocation_decisions.dig(0, "motReasonDescription")
-  end
-
-  def mode_of_trial_reason_code
-    allocation_decisions.dig(0, "motReasonCode")
-  end
-
   def mode_of_trial_reasons
     allocation_decisions.map do |decision|
       {

--- a/app/serializers/offence_serializer.rb
+++ b/app/serializers/offence_serializer.rb
@@ -9,7 +9,5 @@ class OffenceSerializer
               :legislation,
               :mode_of_trial,
               :mode_of_trial_reasons,
-              :mode_of_trial_reason,
-              :mode_of_trial_reason_code,
               :pleas
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -135,50 +135,6 @@ RSpec.describe Offence, type: :model do
     end
   end
 
-  describe "#mode_of_trial_reason" do
-    subject(:mode_of_trial_reason) { offence.mode_of_trial_reason }
-
-    context "when an allocation decision is not available" do
-      let(:details_array) { [] }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when an allocation decision is available" do
-      let(:details_array) do
-        [{
-          "allocationDecision" => {
-            "motReasonDescription" => "Court directs trial by jury",
-          },
-        }]
-      end
-
-      it { is_expected.to eql "Court directs trial by jury" }
-    end
-  end
-
-  describe "#mode_of_trial_reason_code" do
-    subject(:mode_of_trial_reason) { offence.mode_of_trial_reason_code }
-
-    context "when an allocation decision is not available" do
-      let(:details_array) { [] }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when an allocation decision is available" do
-      let(:details_array) do
-        [{
-          "allocationDecision" => {
-            "motReasonCode" => "5",
-          },
-        }]
-      end
-
-      it { is_expected.to eql "5" }
-    end
-  end
-
   describe "#mode of trial reasons" do
     subject(:mode_of_trial_reasons) { offence.mode_of_trial_reasons }
 

--- a/spec/serializer/offence_serializer_spec.rb
+++ b/spec/serializer/offence_serializer_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe OffenceSerializer do
                     title: "Fail to wear protective clothing",
                     legislation: "Offences against the Person Act 1861 s.24",
                     mode_of_trial: "Indictable-Only Offence",
-                    mode_of_trial_reason: "Court directs trial by jury",
-                    mode_of_trial_reason_code: "5",
-                    mode_of_trial_reasons: ["Court directs trial by jury", "Another reason"],
+                    mode_of_trial_reasons: [{ description: "Court directs trial by jury", code: "5" }],
                     pleas: %w[GUILTY NOT_GUILTY])
   end
 
@@ -25,9 +23,7 @@ RSpec.describe OffenceSerializer do
     it { expect(attribute_hash[:title]).to eq("Fail to wear protective clothing") }
     it { expect(attribute_hash[:legislation]).to eq("Offences against the Person Act 1861 s.24") }
     it { expect(attribute_hash[:mode_of_trial]).to eq("Indictable-Only Offence") }
-    it { expect(attribute_hash[:mode_of_trial_reason]).to eq("Court directs trial by jury") }
-    it { expect(attribute_hash[:mode_of_trial_reason_code]).to eq("5") }
-    it { expect(attribute_hash[:mode_of_trial_reasons]).to eq(["Court directs trial by jury", "Another reason"]) }
+    it { expect(attribute_hash[:mode_of_trial_reasons]).to eq([{ description: "Court directs trial by jury", code: "5" }]) }
     it { expect(attribute_hash[:pleas]).to eq(%w[GUILTY NOT_GUILTY]) }
   end
 end

--- a/spec/services/defendant_finder_spec.rb
+++ b/spec/services/defendant_finder_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DefendantFinder do
         end
 
         it "includes mode of trial detail" do
-          expect(defendant.offences.map(&:mode_of_trial_reason)).to include("Court directs trial by jury")
+          expect(defendant.offences.flat_map(&:mode_of_trial_reasons)).to include({ description: "Court directs trial by jury", code: "5" })
         end
       end
     end


### PR DESCRIPTION
## What
Remove unneeded MoT attributes on offence

[Relates to LASB-443](https://dsdmoj.atlassian.net/browse/LASB-443)

## Why
Following the introduction of a new attribute
, `mode_of_trial_reasons`, to return an array
of reasons with code and description, the old
individual attributes are no longer needed.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.