### PR TITLE
Revert "Bump shoulda-matchers from 4.4.1 to 4.5.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     ruby-progressbar (1.10.1)
     sentry-raven (3.1.1)
       faraday (>= 1.0)
-    shoulda-matchers (4.5.0)
+    shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)


### PR DESCRIPTION
This reverts commit 549e912c7cfaac3df0b4eea3d0c727daaa3cf4b4.


## What
Revert "Bump shoulda-matchers from 4.4.1 to 4.5.0"

This reverts commit 549e912c7cfaac3df0b4eea3d0c727daaa3cf4b4.
because there seems to be a build problem since adding that commit
albeit it could be a coincidence.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.