### PR TITLE
Bump aws-ecr orb 4.0.1 --> 6.15.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@4.0.1
+  aws-ecr: circleci/aws-ecr@6.15.2
   aws-eks: circleci/aws-eks@0.2.1
   kubernetes: circleci/kubernetes@0.7.0
   helm: circleci/helm@1.1.2
@@ -174,14 +174,14 @@ workflows:
             branches:
               only:
                 - master
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           requires:
-            - test
+          - test
           repo: laa-crime-apps-team/laa-court-data-adaptor
           tag: "${CIRCLE_SHA1}"
       - install_on_dev:
           requires:
-          - aws-ecr/build_and_push_image
+          - aws-ecr/build-and-push-image
       - hold_install_on_test:
           type: approval
           requires:
@@ -227,7 +227,7 @@ workflows:
             branches:
               ignore:
                 - master
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           requires:
             - branch-build-approval
           repo: laa-crime-apps-team/laa-court-data-adaptor
@@ -235,28 +235,28 @@ workflows:
       - hold_install_on_dev:
           type: approval
           requires:
-          - aws-ecr/build_and_push_image
+          - aws-ecr/build-and-push-image
       - install_on_dev:
           requires:
           - hold_install_on_dev
       - hold_install_on_test:
           type: approval
           requires:
-          - aws-ecr/build_and_push_image
+          - aws-ecr/build-and-push-image
       - install_on_test:
           requires:
           - hold_install_on_test
       - hold_install_on_uat:
           type: approval
           requires:
-          - aws-ecr/build_and_push_image
+          - aws-ecr/build-and-push-image
       - install_on_uat:
           requires:
           - hold_install_on_uat
       - hold_install_on_stage:
           type: approval
           requires:
-          - aws-ecr/build_and_push_image
+          - aws-ecr/build-and-push-image
       - install_on_stage:
           requires:
           - hold_install_on_stage


### PR DESCRIPTION
## What
Bump circleci orb used to build and push docker images
to ECR.

see [aws-ecr-orb](https://github.com/CircleCI-Public/aws-ecr-orb)

## Testing
I have tested the circleci build and push works on [another branch](
https://app.circleci.com/pipelines/github/ministryofjustice/laa-court-data-adaptor/1256/workflows/e35b50dd-8e1c-43c8-8b3e-571a2ff44919/jobs/2576)


## Why
We are pretty out of date on this orb and am thinking to use it
to set some docker build args.

[relates to](https://dsdmoj.atlassian.net/browse/CBO-1668)

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.