### PR TITLE
Remove extraneous whitespace from defendant.name attribute

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -10,7 +10,7 @@ class Defendant
   end
 
   def name
-    [first_name, middle_name, last_name].compact.join(" ")
+    [first_name, middle_name, last_name].join(" ").squish
   end
 
   def first_name

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Defendant, type: :model do
   let(:prosecution_case_id) { nil }
   let(:details_array) { nil }
 
-  it { expect(defendant.name).to eq("George Andrew Walsh") }
   it { expect(defendant.first_name).to eq("George") }
   it { expect(defendant.middle_name).to eq("Andrew") }
   it { expect(defendant.last_name).to eq("Walsh") }
@@ -24,10 +23,32 @@ RSpec.describe Defendant, type: :model do
   it { expect(defendant.prosecution_case).to be_nil }
   it { expect(defendant.post_hearing_custody_statuses).to eq([]) }
 
-  context "when defendant does not have a middle name" do
-    before { defendant.body.delete("defendantMiddleName") }
+  describe "#name" do
+    subject { defendant.name }
 
-    it { expect(defendant.name).to eq("George Walsh") }
+    it { is_expected.to eq("George Andrew Walsh") }
+
+    context "with no middle name attribute" do
+      before { defendant.body.delete("defendantMiddleName") }
+
+      it { is_expected.to eq("George Walsh") }
+    end
+
+    context "with empty string for middle name" do
+      before { defendant.body["defendantMiddleName"] = "" }
+
+      it { is_expected.to eq("George Walsh") }
+    end
+
+    context "with extra whitespace in name parts" do
+      before do
+        defendant.body["defendantFirstName"] = "   Fred   "
+        defendant.body["defendantMiddleName"] = " "
+        defendant.body["defendantLastName"] = " Bloggs   "
+      end
+
+      it { is_expected.to eq("Fred Bloggs") }
+    end
   end
 
   context "with prosecution case information" do


### PR DESCRIPTION
## What
Remove extraneous whitespace from defendant.name attribute

## Why
Extra whitespace is added for empty middle names
resulting in search failure from VCD as the
name search is currently an extact case-insensitive
match. Whitespace is not currently handled.

This relates to the [issue 395](https://github.com/ministryofjustice/laa-court-data-adaptor/issues/395) that I have raised:

VCD is also providing a [belt and braces fix](https://github.com/ministryofjustice/laa-court-data-ui/pull/456):

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.