### PR TITLE
Include prosecution concluded flag in payload

### DIFF
--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -52,6 +52,7 @@ module Sqs
         caseCreationDate: shared_time.to_date.strftime("%Y-%m-%d"),
         cjsLocation: cjs_location,
         docLanguage: "EN",
+        proceedingsConcluded: defendant.dig(:proceedingsConcluded),
         inActive: inactive?,
         defendant: defendant_hash,
         session: session_hash,

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Sqs::PublishHearing do
   let(:defendant) do
     {
       'id': "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+      'proceedingsConcluded': true,
       'personDefendant': {
         'personDetails': {
           "firstName": "Lavon",
@@ -103,6 +104,7 @@ RSpec.describe Sqs::PublishHearing do
       caseCreationDate: "2018-10-25",
       cjsLocation: "B16BG",
       docLanguage: "EN",
+      proceedingsConcluded: true,
       inActive: "Y",
       defendant: {
         forename: "Lavon",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-531)

This PR makes sure CDA parses the prosecution concluded flag that is present on the defendant objects under a hearing and includes it as part of the payload that is posted to the queue for MAAT API to consume and process.

## Why

Posting the prosecution concluded flag allows MAAT API to process the case conclusion and determine the crown court outcome.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
