### PR TITLE
Fix Prometheus "Instance Down" alert

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/network-policy.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/network-policy.yaml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-netpol
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: monitoring


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB-512)

This alert keeps occurring:

```
Alert

Details:

alertname: Instance-Down
clusterName: live-1
namespace: laa-court-data-adaptor-prod
prometheus: monitoring/prometheus-operator-prometheus
severity: Crime-Apps-Team
```

Very similar to what happened with the Apply for Legal Aid Team here: 

* [JIRA story](https://dsdmoj.atlassian.net/browse/AP-1870)
* [Github pull request](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/2103)

## Solution

This PR creates a `NetworkPolicy` that allows ingress for monitoring systems we have in place in Prometheus.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
