### PR TITLE
Fix undefined method `deep_transform_keys' for String

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -2,7 +2,7 @@
 
 class HearingsCreator < ApplicationService
   def initialize(hearing_id:)
-    hearing_body = Hearing.find(hearing_id).body.deep_transform_keys(&:to_sym)
+    hearing_body = JSON.parse(Hearing.find(hearing_id).body).deep_symbolize_keys!
     @hearing = hearing_body[:hearing]
     @shared_time = hearing_body[:sharedTime]
   end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe HearingsCreator do
       },
     ]
   end
+
   let(:applications_array) do
     [
       {
@@ -61,6 +62,7 @@ RSpec.describe HearingsCreator do
       },
     ]
   end
+
   let(:hearing_body) do
     {
       "hearing": {
@@ -72,7 +74,7 @@ RSpec.describe HearingsCreator do
         "courtApplications": applications_array,
       },
       "sharedTime": "2018-10-25 11:30:00",
-    }
+    }.to_json
   end
 
   let(:hearing) { Hearing.create!(body: hearing_body) }
@@ -168,7 +170,7 @@ RSpec.describe HearingsCreator do
             "prosecutionCases": prosecution_case_array,
           },
           "sharedTime": "2018-10-25 11:30:00",
-        }
+        }.to_json
       end
 
       it "calls the Sqs::PublishHearing service" do

--- a/spec/workers/hearings_creator_worker_spec.rb
+++ b/spec/workers/hearings_creator_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe HearingsCreatorWorker, type: :worker do
   let(:request_id) { "XYZ" }
 
   before do
-    Hearing.create!(id: hearing_id, body: JSON.parse(file_fixture("valid_hearing.json").read))
+    Hearing.create!(id: hearing_id, body: file_fixture("valid_hearing.json").read)
   end
 
   it "queues the job" do


### PR DESCRIPTION
We are calling deep_transform_keys (a Hash method), on the hearing body
from the database. However, hearing body is stored in Postgres as a JSONB
string, not a hash.

Tests were not picking up on this because our tests were assuming hearing body was
a hash.

https://sentry.io/organizations/ministryofjustice/issues/2093600232/?cursor=0%3A100%3A0&environment=prod&project=5375870

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-550)