### PR TITLE
Revert "temporary patch to process failing delayed jobs"

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -2,22 +2,9 @@
 
 class HearingsCreator < ApplicationService
   def initialize(hearing_id:)
-    @hearing_id = hearing_id
+    hearing_body = Hearing.find(hearing_id).body.deep_transform_keys(&:to_sym)
     @hearing = hearing_body[:hearing]
     @shared_time = hearing_body[:sharedTime]
-  end
-
-  # This is temp to process failing delayed jobs. To be reverted. See PR
-  def hearing_body
-    body = Hearing.find(@hearing_id).body
-
-    if body.is_a?(Hash)
-      return body.deep_symbolize_keys
-    end
-
-    if body.is_a?(String)
-      JSON.parse(body).deep_symbolize_keys
-    end
   end
 
   def call

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -214,29 +214,4 @@ RSpec.describe HearingsCreator do
       end
     end
   end
-
-  context "when hearing body is a string" do
-    let(:hearing_body) do
-      {
-        "hearing": {
-          "jurisdictionType": "MAGISTRATES",
-          "courtCentre": {
-            "id": "dd22b110-7fbc-3036-a076-e4bb40d0a519",
-          },
-          "prosecutionCases": prosecution_case_array,
-          "courtApplications": nil,
-        },
-        "sharedTime": "2018-10-25 11:30:00",
-      }.to_json
-    end
-
-    it "calls the Sqs::PublishHearing service once" do
-      expect(Sqs::PublishHearing).to receive(:call).once.with(hash_including(shared_time: "2018-10-25 11:30:00",
-                                                                             jurisdiction_type: "MAGISTRATES",
-                                                                             case_urn: "12345",
-                                                                             defendant: defendant_one,
-                                                                             court_centre_id: "dd22b110-7fbc-3036-a076-e4bb40d0a519"))
-      create_hearings
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit 6e03f40597beeaf15adf82e48c1cd381e9bc19f6.

## What

Reverts temporary patch to process failing delayed jobs

The patch only needs to be in place until all these failing jobs have been retried and processed successfully. Our assumption is that we can safely revert to this commit for all new incoming jobs. 

*DO NOT MERGE UNTIL ALL FAILING `HearingsCreatorWorker` JOBS HAVE BEEN RETRIED AND PASSED*

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x You should have checked that the commit messages say why the change was made.
