### PR TITLE
Migrate to sentry-ruby from sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "prmd"
 gem "prometheus-client"
 gem "rswag-api"
 gem "rswag-ui"
-gem "sentry-raven"
+gem "sentry-ruby"
 gem "sidekiq"
 gem "versionist"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,8 +305,13 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
-    sentry-raven (3.1.1)
+    sentry-ruby (4.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.2.2)
+    sentry-ruby-core (4.2.2)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     sidekiq (6.1.3)
@@ -381,7 +386,7 @@ DEPENDENCIES
   rswag-ui
   rubocop-govuk
   rubocop-performance
-  sentry-raven
+  sentry-ruby
   shoulda-matchers
   sidekiq
   simplecov


### PR DESCRIPTION
## What

[sentry-raven](https://github.com/getsentry/sentry-ruby/tree/master/sentry-raven) has entered maintenance mode, which means it won't receive any new feature supports or aggressive bug fixes.

This PR replaces it with [sentry-ruby](https://github.com/getsentry/sentry-ruby/tree/master/sentry-ruby).

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
