### PR TITLE
Add Sentry context for ActiveRecordInvalid errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,20 @@ class ApplicationController < ActionController::API
 
   ERROR_MAPPINGS = {
     ActionController::ParameterMissing => :bad_request,
+    ActiveRecord::RecordInvalid => :bad_request,
   }.freeze
 
   ERROR_MAPPINGS.each do |klass, status|
     rescue_from klass do |error|
       render json: { error: error }, status: status
+
+      Sentry.capture_message(
+        error,
+        tags: {
+          defendant_id: params.dig(:defendant_id),
+          hearing_id: params.dig(:hearing, :id),
+        },
+      )
     end
   end
 

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe "api/internal/v1/laa_references", type: :request, swagger_doc: "v
           run_test!
         end
       end
+
+      context "when we are attempting to create an LaaReference that already exists" do
+        it "includes error message in JSON response" do
+          LaaReference.create!(defendant_id: defendant_id, maat_reference: 1_231_231, user_name: "JaneDoe")
+
+          post api_internal_v1_laa_references_path, params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
+
+          expect(response).to have_http_status :bad_request
+          expect(JSON.parse(response.body)).to eql({ "error" => "Validation failed: Maat reference has already been taken" })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Currently, when a caseworker in VCD tries to link a defendant that is already marked as linked in CDA, the uniqueness constraint on `maat_reference` for linked `LaaReference` records means CDA returns a 500 error with no helpful error message (e.g. [this error](https://sentry.io/organizations/ministryofjustice/issues/2022856720)).

This PR ensures we:

* rescue from `ActiveRecord::RecordInvalid` and return hopefully helpful error messages in the response JSON
* add defendant_id and hearing_id to the extra context data that gets sent to Sentry in order to help with troubleshooting

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
