### PR TITLE
Capture exception rather than message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::API
     rescue_from klass do |error|
       render json: { error: error }, status: status
 
-      Sentry.capture_message(
+      Sentry.capture_exception(
         error,
         tags: {
           request_id: Current.request_id,


### PR DESCRIPTION
## What

Sentry needs to be sent a string with `Sentry.capture_message(message)` or an exception with `Sentry.capture_exception(exception)`.

The current code is passing an exception to `Sentry.capture_message(message)`, which causes one more error than we need :)

This PR implements `Sentry.capture_exception(exception)`.