### PR TITLE
Clean up and self document dummy maat ref creation

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -12,7 +12,12 @@ module Api
       private
 
         def filtered_params
-          params.require(:filter).permit(:prosecution_case_reference, :arrest_summons_number, :name, :date_of_birth, :date_of_next_hearing, :national_insurance_number)
+          params.require(:filter).permit(:prosecution_case_reference,
+                                         :arrest_summons_number,
+                                         :name,
+                                         :date_of_birth,
+                                         :date_of_next_hearing,
+                                         :national_insurance_number)
         end
 
         def transformed_params

--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LaaReference < ApplicationRecord
+  self.ignored_columns = %w[dummy_maat_reference]
+
   validates :defendant_id, presence: true
   validates :maat_reference, presence: true, uniqueness: { conditions: -> { where(linked: true) } }
   validates :user_name, presence: true
@@ -9,7 +11,7 @@ class LaaReference < ApplicationRecord
     update!(linked: false)
   end
 
-  def is_dummy_maat_reference?
+  def dummy_maat_reference?
     maat_reference.start_with?("A", "Z")
   end
 

--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -4,4 +4,20 @@ class LaaReference < ApplicationRecord
   validates :defendant_id, presence: true
   validates :maat_reference, presence: true, uniqueness: { conditions: -> { where(linked: true) } }
   validates :user_name, presence: true
+
+  def unlink!
+    update!(linked: false)
+  end
+
+  def is_dummy_maat_reference?
+    maat_reference.start_with?("A", "Z")
+  end
+
+  def self.generate_linking_dummy_maat_reference
+    "A#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
+  end
+
+  def self.generate_unlinking_dummy_maat_reference
+    "Z#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
+  end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -4,7 +4,13 @@ class ProsecutionCase < ApplicationRecord
   validates :body, presence: true
 
   def defendants
-    body["defendantSummary"].map { |defendant| Defendant.new(body: defendant, details: defendant_details[defendant["defendantId"]], prosecution_case_id: id) }
+    body["defendantSummary"].map do |defendant|
+      Defendant.new(
+        body: defendant,
+        details: defendant_details[defendant["defendantId"]],
+        prosecution_case_id: id,
+      )
+    end
   end
 
   def defendant_ids

--- a/app/services/laa_reference_creator.rb
+++ b/app/services/laa_reference_creator.rb
@@ -6,7 +6,7 @@ class LaaReferenceCreator < ApplicationService
   def initialize(defendant_id:, user_name: nil, maat_reference: nil)
     @defendant_id = defendant_id
     @user_name = user_name.presence || TEMPORARY_CREATED_USER
-    @maat_reference = maat_reference.presence || dummy_maat_reference
+    @maat_reference = maat_reference.presence || LaaReference.generate_linking_dummy_maat_reference
   end
 
   def call
@@ -20,20 +20,11 @@ private
   def persist_laa_reference!
     @laa_reference = LaaReference.create!(defendant_id: defendant_id,
                                           user_name: user_name,
-                                          maat_reference: maat_reference,
-                                          dummy_maat_reference: dummy_reference?)
+                                          maat_reference: maat_reference)
   end
 
   def create_maat_link
     MaatLinkCreatorWorker.perform_async(Current.request_id, laa_reference.id)
-  end
-
-  def dummy_maat_reference
-    @dummy_maat_reference ||= "A#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
-  end
-
-  def dummy_reference?
-    @dummy_maat_reference.present?
   end
 
   attr_reader :defendant_id, :user_name, :maat_reference, :laa_reference

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -11,7 +11,7 @@ class LaaReferenceUnlinker < ApplicationService
 
   def call
     unlink_maat_reference!
-    push_to_sqs unless laa_reference.is_dummy_maat_reference?
+    push_to_sqs unless laa_reference.dummy_maat_reference?
     update_offences_on_common_platform
   end
 

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -10,15 +10,15 @@ class LaaReferenceUnlinker < ApplicationService
   end
 
   def call
-    unlink_current_maat_reference
-    push_to_sqs unless laa_reference.dummy_maat_reference?
+    unlink_maat_reference!
+    push_to_sqs unless laa_reference.is_dummy_maat_reference?
     call_common_platform_endpoint
   end
 
 private
 
-  def unlink_current_maat_reference
-    laa_reference.update!(linked: false)
+  def unlink_maat_reference!
+    laa_reference.unlink!
   end
 
   def push_to_sqs
@@ -48,7 +48,7 @@ private
   end
 
   def dummy_maat_reference
-    @dummy_maat_reference ||= "Z#{ActiveRecord::Base.connection.execute("SELECT nextval('dummy_maat_reference_seq')")[0]['nextval']}"
+    @dummy_maat_reference ||= LaaReference.generate_unlinking_dummy_maat_reference
   end
 
   attr_reader :defendant_id, :laa_reference, :user_name, :unlink_reason_code, :unlink_other_reason_text

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -12,7 +12,7 @@ class LaaReferenceUnlinker < ApplicationService
   def call
     unlink_maat_reference!
     push_to_sqs unless laa_reference.is_dummy_maat_reference?
-    call_common_platform_endpoint
+    update_offences_on_common_platform
   end
 
 private
@@ -30,17 +30,19 @@ private
     )
   end
 
-  def call_common_platform_endpoint
-    offences.each do |offence|
-      Api::RecordLaaReference.call(
-        prosecution_case_id: offence.prosecution_case_id,
-        defendant_id: offence.defendant_id,
-        offence_id: offence.offence_id,
-        status_code: "AP",
-        application_reference: dummy_maat_reference,
-        status_date: Time.zone.today.strftime("%Y-%m-%d"),
-      )
-    end
+  def update_offences_on_common_platform
+    offences.each { |offence| update_offence_on_common_platform(offence) }
+  end
+
+  def update_offence_on_common_platform(offence)
+    Api::RecordLaaReference.call(
+      prosecution_case_id: offence.prosecution_case_id,
+      defendant_id: offence.defendant_id,
+      offence_id: offence.offence_id,
+      status_code: "AP",
+      application_reference: dummy_maat_reference,
+      status_date: Time.zone.today.strftime("%Y-%m-%d"),
+    )
   end
 
   def offences

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -6,7 +6,7 @@ class MaatLinkCreator < ApplicationService
   end
 
   def call
-    publish_laa_reference_to_queue unless laa_reference.is_dummy_maat_reference?
+    publish_laa_reference_to_queue unless laa_reference.dummy_maat_reference?
     post_laa_references_to_common_platform
     fetch_past_hearings
   end

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -6,7 +6,7 @@ class MaatLinkCreator < ApplicationService
   end
 
   def call
-    publish_laa_reference_to_queue unless laa_reference.dummy_maat_reference?
+    publish_laa_reference_to_queue unless laa_reference.is_dummy_maat_reference?
     post_laa_references_to_common_platform
     fetch_past_hearings
   end

--- a/app/services/prosecution_case_recorder.rb
+++ b/app/services/prosecution_case_recorder.rb
@@ -11,7 +11,11 @@ class ProsecutionCaseRecorder < ApplicationService
 
     prosecution_case.defendants.each do |defendant|
       defendant.offences.each do |offence|
-        ProsecutionCaseDefendantOffence.find_or_create_by!(prosecution_case_id: prosecution_case.id, defendant_id: defendant.id, offence_id: offence.id)
+        ProsecutionCaseDefendantOffence.find_or_create_by!(
+          prosecution_case_id: prosecution_case.id,
+          defendant_id: defendant.id,
+          offence_id: offence.id,
+        )
       end
     end
 

--- a/app/workers/unlink_laa_reference_worker.rb
+++ b/app/workers/unlink_laa_reference_worker.rb
@@ -5,7 +5,12 @@ class UnlinkLaaReferenceWorker
 
   def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text)
     Current.set(request_id: request_id) do
-      LaaReferenceUnlinker.call(defendant_id: defendant_id, user_name: user_name, unlink_reason_code: unlink_reason_code, unlink_other_reason_text: unlink_other_reason_text)
+      LaaReferenceUnlinker.call(
+        defendant_id: defendant_id,
+        user_name: user_name,
+        unlink_reason_code: unlink_reason_code,
+        unlink_other_reason_text: unlink_other_reason_text,
+      )
     end
   end
 end

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -21,4 +21,28 @@ RSpec.describe LaaReference, type: :model do
 
     it { is_expected.to be_valid }
   end
+
+  describe ".generate_linking_dummy_maat_reference" do
+    it "starts with an A" do
+      dummy_maat_reference = described_class.generate_linking_dummy_maat_reference
+      expect(dummy_maat_reference).to start_with("A")
+    end
+  end
+
+  describe ".generate_unlinking_dummy_maat_reference" do
+    it "starts with an Z" do
+      dummy_maat_reference = described_class.generate_unlinking_dummy_maat_reference
+      expect(dummy_maat_reference).to start_with("Z")
+    end
+  end
+
+  describe "#is_dummy_maat_reference?" do
+    it "returns true when MAAT reference is a linking dummy maat reference" do
+      expect(described_class.new(maat_reference: "A123")).to be_is_dummy_maat_reference
+    end
+
+    it "returns true when MAAT reference is a unlinking dummy maat reference" do
+      expect(described_class.new(maat_reference: "Z123")).to be_is_dummy_maat_reference
+    end
+  end
 end

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe LaaReference, type: :model do
     end
   end
 
-  describe "#is_dummy_maat_reference?" do
+  describe "#dummy_maat_reference?" do
     it "returns true when MAAT reference is a linking dummy maat reference" do
-      expect(described_class.new(maat_reference: "A123")).to be_is_dummy_maat_reference
+      expect(described_class.new(maat_reference: "A123")).to be_dummy_maat_reference
     end
 
     it "returns true when MAAT reference is a unlinking dummy maat reference" do
-      expect(described_class.new(maat_reference: "Z123")).to be_is_dummy_maat_reference
+      expect(described_class.new(maat_reference: "Z123")).to be_dummy_maat_reference
     end
   end
 end

--- a/spec/models/prosecution_case_defendant_offence_spec.rb
+++ b/spec/models/prosecution_case_defendant_offence_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ProsecutionCaseDefendantOffence, type: :model do
   let(:defendant_id) { SecureRandom.uuid }
   let(:offence_id) { SecureRandom.uuid }
   let(:maat_reference) { "A00000001" }
-  let(:dummy_maat_reference) { true }
   let(:rep_order_status) { "AP" }
   let(:response_status) { 200 }
   let(:response_body) { { response: "response" }.to_json }

--- a/spec/services/laa_reference_creator_spec.rb
+++ b/spec/services/laa_reference_creator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe LaaReferenceCreator do
     laa_reference = LaaReference.last
     expect(laa_reference.defendant_id).to eq(defendant_id)
     expect(laa_reference.maat_reference).to eq("12345678")
-    expect(laa_reference.dummy_maat_reference).to be_falsey
+    expect(laa_reference).not_to be_dummy_maat_reference
   end
 
   it "returns the LaaReference" do
@@ -86,7 +86,7 @@ RSpec.describe LaaReferenceCreator do
 
       expect(laa_reference.defendant_id).to eq(defendant_id)
       expect(laa_reference.maat_reference).to eq("A10000000")
-      expect(laa_reference).to be_is_dummy_maat_reference
+      expect(laa_reference).to be_dummy_maat_reference
     end
   end
 end

--- a/spec/services/laa_reference_creator_spec.rb
+++ b/spec/services/laa_reference_creator_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe LaaReferenceCreator do
     it "creates a dummy_maat_reference" do
       create_reference
       laa_reference = LaaReference.last
+
       expect(laa_reference.defendant_id).to eq(defendant_id)
       expect(laa_reference.maat_reference).to eq("A10000000")
-      expect(laa_reference.dummy_maat_reference).to be_truthy
+      expect(laa_reference).to be_is_dummy_maat_reference
     end
   end
 end

--- a/spec/services/laa_reference_unlinker_spec.rb
+++ b/spec/services/laa_reference_unlinker_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe LaaReferenceUnlinker do
 
   context "when the maat_reference is a dummy" do
     before do
-      linked_laa_reference.update!(dummy_maat_reference: true)
+      linked_laa_reference.update!(maat_reference: "Z10000000")
     end
 
     it "does not call the Sqs::PublishUnlinkLaaReference service" do

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe MaatLinkCreator do
   end
 
   context "with a dummy_maat_reference" do
-    let(:maat_reference) { "A10000000" }
-    let(:laa_reference) { LaaReference.create!(defendant_id: defendant_id, user_name: "caseWorker", maat_reference: maat_reference, dummy_maat_reference: true) }
+    let(:laa_reference) { LaaReference.create!(defendant_id: defendant_id, user_name: "caseWorker", maat_reference: "A10000000") }
 
     it "does not call the Sqs::PublishLaaReference service" do
       expect(Sqs::PublishLaaReference).not_to receive(:call)


### PR DESCRIPTION
## What 

### Stop relying on little-used `dummy_maat_reference` boolean database column

This will remove the possibility of ending up with an inconsistent state between the maat reference field and and the `dummy_maat_reference`. Indeed, each one of these fields can be updated independently.

We should only ever determine whether a MAAT reference is a dummy or not by looking at the _actual_ maat reference.

### Refactorings

* move all dummy reference logic to the `LaaReference` model
* use more intention-revealing method names

## Note

There is a PR to drop the `dummy_reference` boolean column from `laa_references` table, branched off of the present one: https://github.com/ministryofjustice/laa-court-data-adaptor/pull/443.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
