### PR TITLE
Don't raise error when MAAT refs are mix of dummy and actual

### DIFF
--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -146,6 +146,16 @@ RSpec.describe Defendant, type: :model do
 
         it { expect { defendant.maat_reference }.to raise_error StandardError, "Too many maat references" }
       end
+
+      context "with a mix of dummy and actual maat references" do
+        let(:offences) do
+          [instance_double("Offence", maat_reference: "Z123123"),
+           instance_double("Offence", maat_reference: nil),
+           instance_double("Offence", maat_reference: "321321")]
+        end
+
+        it { expect { defendant.maat_reference }.not_to raise_error }
+      end
     end
 
     context "when an offence has an unlinked maat reference" do


### PR DESCRIPTION
## What

Don't raise error when MAAT refs are mix of dummy and actual

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
