### PR TITLE
Log HTTP client requests/responses and decrease request rate to CP

### DIFF
--- a/app/services/api/record_laa_reference.rb
+++ b/app/services/api/record_laa_reference.rb
@@ -2,6 +2,8 @@
 
 module Api
   class RecordLaaReference < ApplicationService
+    PAUSE_BETWEEN_REQUESTS_IN_SECONDS = 1
+
     def initialize(prosecution_case_id:,
                    defendant_id:,
                    offence_id:,
@@ -24,6 +26,7 @@ module Api
     def call
       response = connection.post(url, request_body)
       update_database(response)
+      pause_before_next_http_request
       response
     end
 
@@ -44,6 +47,11 @@ module Api
       offence.response_status = response.status
       offence.response_body = response.body
       offence.save!
+    end
+
+    def pause_before_next_http_request
+      Rails.logger.info "Pausing #{PAUSE_BETWEEN_REQUESTS_IN_SECONDS} second(s) before next request to Common Platform ..."
+      sleep PAUSE_BETWEEN_REQUESTS_IN_SECONDS
     end
 
     attr_reader :url, :status_code, :application_reference, :status_date, :connection, :offence_id

--- a/app/services/common_platform_connection.rb
+++ b/app/services/common_platform_connection.rb
@@ -14,6 +14,7 @@ class CommonPlatformConnection < ApplicationService
   def call
     Faraday.new host, options do |connection|
       connection.request :json
+      connection.response :logger, Rails.logger
       connection.response :json, content_type: "application/json"
       connection.response :json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json"
       connection.response :json, content_type: "text/plain"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
+  config.logger = Logger.new(STDOUT)
+  config.log_level = :warn
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/services/common_platform_connection_spec.rb
+++ b/spec/services/common_platform_connection_spec.rb
@@ -57,10 +57,12 @@ RSpec.describe CommonPlatformConnection do
 
     it "initiates a json request" do
       expect(connection).to receive(:request).with(:json)
+      expect(connection).to receive(:response).with(:logger, Rails.logger)
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
       expect(connection).to receive(:response).with(:json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json")
       expect(connection).to receive(:response).with(:json, content_type: "text/plain")
       expect(connection).to receive(:adapter).with(:net_http)
+
       connect_to_common_platform
     end
   end


### PR DESCRIPTION
## What

* Log Faraday HTTP client requests and responses (Faraday [documentation](https://lostisland.github.io/faraday/middleware/logger))
* Add a 1 second `sleep` between HTTP requests to CP to update LAA References. This is an attempted fix for an issue whereby only some defendant offence would get updated on CP, because CDA makes too many calls to CP in a short time.

## Why

We are making rapid fire calls to the common platform endpoint for recording laa references on offences, which seems to cause some offence updates to fail.

This PR makes sure we make calls to that endpoint at a reasonable rate.