### PR TITLE
Fix Sentry reporting for HearingRecorder

### DIFF
--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe HearingRecorder do
 
     it "does not publish hearing to the queue" do
       expect(HearingsCreatorWorker).not_to receive(:perform_async)
+      record_hearing
     end
   end
 


### PR DESCRIPTION
## What

Fix [this Sentry error](https://sentry.io/organizations/ministryofjustice/issues/2278772804/?environment=prod&project=5375870&query=is%3Aunresolved) by stopping using `extras`, and use `capture_exception` instead of `capture_message`.
