### PR TITLE
Fix undefined method 'split' for nil:NilClass

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -31,7 +31,7 @@ module Api
         end
 
         def inclusions
-          params[:include].split(",")
+          params[:include]&.split(",")
         end
       end
     end


### PR DESCRIPTION
The `include` query param is not always present. The `&` safe operator makes sure we don't run into a null pointer exception when that's the case.

Fix issue https://github.com/ministryofjustice/laa-court-data-adaptor/issues/455.