### PR TITLE
Handle HearingEventRecording with blank body

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -86,7 +86,7 @@ private
   end
 
   def hearing_day_events
-    hearing_event_recordings.flat_map { |recording| recording.body["events"] }
+    hearing_event_recordings.flat_map { |recording| recording.body["events"] }.compact
   end
 
   def court_centre

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Hearing, type: :model do
 
           it { expect(hearing.hearing_events).to all be_a(HearingEvent) }
         end
+
+        context "with a missing events key from hearing log response" do
+          let(:hearing_events) { [HearingEventRecording.new(body: {})] }
+
+          it { expect(hearing.hearing_events).to be_empty }
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes and edge case where a hearing log request to Common Platform returns `{}` in the response body, even though the schema forbids it.

This fix is put in place until Common Platform make a fix to their API response.