### PR TITLE
Configure Faraday to retry for 429 Too Many Requests HTTP responses

### DIFF
--- a/app/services/common_platform_connection.rb
+++ b/app/services/common_platform_connection.rb
@@ -13,6 +13,7 @@ class CommonPlatformConnection < ApplicationService
 
   def call
     Faraday.new host, options do |connection|
+      connection.request :retry, retry_options
       connection.request :json
       connection.response :logger, Rails.logger
       connection.response :json, content_type: "application/json"
@@ -38,6 +39,13 @@ private
         client_key: OpenSSL::PKey::RSA.new(client_key),
         ca_file: Rails.root.join("lib/ssl/ca.crt").to_s,
       },
+    }
+  end
+
+  def retry_options
+    {
+      retry_statuses: [429],
+      methods: %i[delete get head options put post],
     }
   end
 

--- a/spec/services/common_platform_connection_spec.rb
+++ b/spec/services/common_platform_connection_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe CommonPlatformConnection do
     end
 
     it "initiates a json request" do
+      retry_options = {
+        methods: %i[delete get head options put post],
+        retry_statuses: [429],
+      }
+
+      expect(connection).to receive(:request).with(:retry, retry_options)
       expect(connection).to receive(:request).with(:json)
       expect(connection).to receive(:response).with(:logger, Rails.logger)
       expect(connection).to receive(:response).with(:json, content_type: "application/json")


### PR DESCRIPTION
Common Platform currently enforces a 10 requests per minute rate limit. To make sure no request gets lost, this PR configures the Faraday HTTP client to automatically retry after the amount of time specified in the `Retry-After` response header.

Faraday documentation: https://github.com/lostisland/faraday/blob/master/docs/middleware/request/retry.md#automatically-handle-the-retry-after-header