### PR TITLE
Stop ignoring dummy_maat_reference column

### DIFF
--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class LaaReference < ApplicationRecord
-  self.ignored_columns = %w[dummy_maat_reference]
-
   validates :defendant_id, presence: true
   validates :maat_reference, presence: true, uniqueness: { conditions: -> { where(linked: true) } }
   validates :user_name, presence: true


### PR DESCRIPTION
Now that we've successfully dropped the `dummy_maat_reference` column from the laa_references table in https://github.com/ministryofjustice/laa-court-data-adaptor/pull/443, we can safely remove the temporary `ignored_columns` method.

Docs: https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns
