### PR TITLE
Default proceedingsConcluded flag to false

### DIFF
--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -28,7 +28,7 @@ module Sqs
         caseCreationDate: shared_time.to_date.strftime("%Y-%m-%d"),
         cjsLocation: cjs_location,
         docLanguage: "EN",
-        proceedingsConcluded: defendant.dig(:proceedingsConcluded),
+        proceedingsConcluded: defendant.dig(:proceedingsConcluded) || false,
         inActive: inactive?,
         defendant: defendant_hash,
         session: session_hash,

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -213,6 +213,18 @@ RSpec.describe Sqs::PublishHearing do
     end
   end
 
+  context "when the defendant proceedingsConcluded flag is absent from the incoming hearing defendnt payload" do
+    before do
+      defendant.delete(:proceedingsConcluded)
+      sqs_payload[:proceedingsConcluded] = false
+    end
+
+    it "defaults the value to false" do
+      expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url)
+      publish
+    end
+  end
+
   context "when there are crown court outcomes" do
     context "when there is verdict data" do
       it "creates a crown court outcome hash" do


### PR DESCRIPTION
MAAT API expects the `proceedingsConcluded` flag to be a boolean, so this PR makes sure we default the value to `false` if the `proceedingsConcluded` flag is absent from the incoming payload.
