### PR TITLE
Serialize hearings with no prosecution cases

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -12,7 +12,7 @@ class Hearing < ApplicationRecord
   end
 
   def hearing_days
-    hearing_body["hearingDays"].map { |hearing_day| hearing_day["sittingDay"] }
+    Array(hearing_body["hearingDays"]).map { |hearing_day| hearing_day["sittingDay"] }
   end
 
   def defendant_names
@@ -30,19 +30,19 @@ class Hearing < ApplicationRecord
   end
 
   def judge_names
-    hearing_body["judiciary"]&.map do |judge|
+    Array(hearing_body["judiciary"]).map do |judge|
       [judge["title"], judge["firstName"], judge["lastName"]].reject(&:blank?).join(" ")
     end
   end
 
   def prosecution_advocate_names
-    hearing_body["prosecutionCounsels"]&.map do |prosecution_counsel|
+    Array(hearing_body["prosecutionCounsels"]).map do |prosecution_counsel|
       "#{prosecution_counsel['firstName']} #{prosecution_counsel['lastName']}"
     end
   end
 
   def defence_advocate_names
-    hearing_body["defenceCounsels"]&.map do |defence_counsel|
+    Array(hearing_body["defenceCounsels"]).map do |defence_counsel|
       "#{defence_counsel['firstName']} #{defence_counsel['lastName']}"
     end
   end
@@ -76,11 +76,11 @@ private
   end
 
   def defendants
-    prosecution_cases.flat_map { |prosecution_case| prosecution_case["defendants"] }
+    Array(prosecution_cases).flat_map { |prosecution_case| prosecution_case["defendants"] }
   end
 
   def hearing_event_recordings
-    @hearing_event_recordings ||= hearing_body["hearingDays"].flat_map { |hearing_day|
+    @hearing_event_recordings ||= Array(hearing_body["hearingDays"]).flat_map { |hearing_day|
       Api::GetHearingEvents.call(hearing_id: id, hearing_date: hearing_day["sittingDay"].to_date)
     }.compact
   end

--- a/spec/fixtures/files/hearing/required_fields.json
+++ b/spec/fixtures/files/hearing/required_fields.json
@@ -1,0 +1,16 @@
+{
+  "hearing": {
+    "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+    "jurisdictionType": "CROWN",
+    "courtCentre": {
+      "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "name": "Warrington CCU (Decom)",
+      "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "roomName": "Warrington CCU (Decom)"
+    },
+    "type": {
+      "id": "63003e58-d753-46e2-a2c8-47fd15341592",
+      "description": "Mention - Defendant to Attend (MDA)"
+    }
+  }
+}

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe Hearing, type: :model do
       context "when prosecutionCounsels are not provided" do
         before { hearing.body["hearing"].delete("prosecutionCounsels") }
 
-        it { expect(hearing.prosecution_advocate_names).to be_nil }
+        it { expect(hearing.prosecution_advocate_names).to eql([]) }
       end
 
       context "when defenceCounsels are not provided" do
         before { hearing.body["hearing"].delete("defenceCounsels") }
 
-        it { expect(hearing.defence_advocate_names).to be_nil }
+        it { expect(hearing.defence_advocate_names).to eql([]) }
       end
     end
 

--- a/spec/serializer/hearing_serializer_spec.rb
+++ b/spec/serializer/hearing_serializer_spec.rb
@@ -36,4 +36,18 @@ RSpec.describe HearingSerializer do
     it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_events }]) }
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :providers }]) }
   end
+
+  context "with required fields only" do
+    let(:hearing_data) { JSON.parse(file_fixture("hearing/required_fields.json").read).deep_symbolize_keys }
+    let(:hearing) { Hearing.new(body: hearing_data) }
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:court_name]).to eq("Warrington CCU (Decom)") }
+    it { expect(attribute_hash[:hearing_type]).to eql("Mention - Defendant to Attend (MDA)") }
+    it { expect(attribute_hash[:defendant_names]).to eq([]) }
+    it { expect(attribute_hash[:judge_names]).to eq([]) }
+    it { expect(attribute_hash[:prosecution_advocate_names]).to eq([]) }
+    it { expect(attribute_hash[:defence_advocate_names]).to eq([]) }
+    it { expect(attribute_hash[:hearing_days]).to eq([]) }
+  end
 end


### PR DESCRIPTION
The current `HearingSerializer` errors with `undefined method `flat_map' for nil:NilClass` because some hearings can have no prosecution cases. It's an optional field as per HMCTS schema. This currently causes a 500 server error on VCD.

This PR:

* makes sure we are able to serialize a hearing object with no associated prosecution cases,
* serializes empty collections as `[]` rather than `null` by casting `nil` into `[]` with `Array(nil)`.

Fixes issue https://github.com/ministryofjustice/laa-court-data-adaptor/issues/480.