### PR TITLE
Create RESTful route for unlinking

### DIFF
--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -5,29 +5,42 @@ module Api
     module V1
       class LaaReferencesController < ApplicationController
         def create
-          enforce_contract!
-          create_laa_reference
+          contract = NewLaaReferenceContract.new.call(**transformed_params)
+          enforce_contract!(contract)
+
+          LaaReferenceCreator.call(defendant_id: transformed_params[:defendant_id],
+                                   user_name: transformed_params[:user_name],
+                                   maat_reference: transformed_params[:maat_reference])
+
+          render status: :accepted
+        end
+
+        def destroy
+          contract = UnlinkDefendantContract.new.call(**transformed_params)
+          enforce_contract!(contract)
+
+          UnlinkLaaReferenceWorker.perform_async(
+            Current.request_id,
+            transformed_params[:defendant_id],
+            transformed_params[:user_name],
+            transformed_params[:unlink_reason_code],
+            transformed_params[:unlink_other_reason_text],
+          )
 
           render status: :accepted
         end
 
       private
 
-        def enforce_contract!
+        def enforce_contract!(contract)
           unless contract.success?
-            message = "LaaReference contract failed with: #{contract.errors.to_hash}"
+            message = "Contract failed with: #{contract.errors.to_hash}"
             raise Errors::ContractError, message
           end
         end
 
-        def contract
-          @contract ||= NewLaaReferenceContract.new.call(**transformed_params)
-        end
-
-        def create_laa_reference
-          LaaReferenceCreator.call(defendant_id: transformed_params[:defendant_id],
-                                   user_name: transformed_params[:user_name],
-                                   maat_reference: transformed_params[:maat_reference])
+        def transformed_params
+          create_params.slice(*allowed_params).to_hash.symbolize_keys.compact
         end
 
         def create_params
@@ -35,11 +48,13 @@ module Api
         end
 
         def allowed_params
-          %i[maat_reference defendant_id user_name]
-        end
-
-        def transformed_params
-          create_params.slice(*allowed_params).to_hash.transform_keys(&:to_sym).compact
+          %i[
+            maat_reference
+            defendant_id
+            user_name
+            unlink_reason_code
+            unlink_other_reason_text
+          ]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     namespace :internal do
       api_version(module: "V1", path: { value: "v1" }, default: true) do
         resources :prosecution_cases, only: [:index]
-        resources :laa_references, only: [:create]
+        resources :laa_references, only: %i[create destroy], param: :defendant_id
         resources :defendants, only: %i[update show]
         resources :representation_orders, only: [:create]
         resources :hearings, only: [:show]

--- a/swagger/v1/laa_reference.json
+++ b/swagger/v1/laa_reference.json
@@ -53,6 +53,29 @@
         }
       }
     },
+    "resource_to_destroy": {
+      "description": "object representing a single laa_reference to be destroyed",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "user_name": {
+              "$ref": "#/definitions/user_name"
+            },
+            "unlink_reason_code": {
+              "$ref": "#/definitions/unlink_reason_code"
+            },
+            "unlink_other_reason_text": {
+              "$ref": "#/definitions/unlink_other_reason_text"
+            }
+          }
+        }
+      }
+    },
     "attributes": {
       "type": "object",
       "properties": {
@@ -112,6 +135,26 @@
         "Content-Type": "application/vnd.api+json",
         "Authorization": "Bearer <TOKEN>"
       }
+    },
+    {
+      "description": "Destroy a defendant's LaaReference.",
+      "href": "/laa_references/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "DELETE",
+      "rel": "empty",
+      "title": "Destroy",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/resource_to_destroy"
+          }
+        }
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+
     }
   ],
   "properties": {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -159,6 +159,40 @@ paths:
           application/json:
             schema:
               "$ref": laa_reference.json#/definitions/new_resource
+  "/api/internal/v1/laa_references/{defendant_id}":
+    delete:
+      summary: delete a defendant's LAA Reference
+      description: Delete an LAA reference from Common Platform case
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: defendant_id
+        in: path
+        required: true
+        type: uuid
+        schema:
+          "$ref": defendant.json#/definitions/id
+        description: The unique identifier of the defendant
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '202':
+          description: Accepted
+          content: {}
+        '400':
+          description: Bad Request
+          content: {}
+        '401':
+          description: Unauthorized
+          content: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": laa_reference.json#/definitions/resource_to_unlink
   "/api/internal/v1/prosecution_cases":
     get:
       summary: search prosecution_cases


### PR DESCRIPTION
## What

The ability to "unlink" via a destroy action on the `laa_references` controller.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-568)

Addresses https://github.com/ministryofjustice/laa-court-data-adaptor/issues/188.

## Why

VCD has duplicated logic for linking via the `laa_reference` create endpoint and unlinking via the defendant update endpoint.

This PR makes it less surprising/more conventional by making linking and unlinking RESTful actions on the same endpoint.
