### PR TITLE
remove historical hearings test from publish hearing spec

### DIFF
--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -198,21 +198,6 @@ RSpec.describe Sqs::PublishHearing do
     publish
   end
 
-  context "when there are historical hearings" do
-    before do
-      defendant[:offences].each { |offence| offence.delete(:laaApplnReference) }
-    end
-
-    it "triggers a publish call with the sqs payload" do
-      offence_payload[:legalAidStatus] = nil
-      offence_payload[:legalAidStatusDate] = nil
-      offence_payload[:legalAidReason] = nil
-
-      expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url)
-      publish
-    end
-  end
-
   context "when the defendant proceedingsConcluded flag is absent from the incoming hearing defendnt payload" do
     before do
       defendant.delete(:proceedingsConcluded)


### PR DESCRIPTION
## What

Removes reference to historical hearings from publish hearing spec.

A so-called 'historical hearing' is a hearing with no LAA application reference, i.e. one that took place prior to any LAA involvement.

However, HMCTS sends to CDA only hearings for cases that do have an LAA Reference.
As a result, no historical hearing will ever be sent to CDA to be processed.
We can therefore delete the test for historical hearings from publish hearing spec.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
