### PR TITLE
Publish Hearing - derive laaOfficeAccount from laaApplnReference object

### DIFF
--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -95,14 +95,14 @@ module Sqs
           [:legalAidStatus, offence.dig(:laaApplnReference, :statusCode)],
           [:legalAidStatusDate, offence.dig(:laaApplnReference, :statusDate)],
           [:legalAidReason, offence.dig(:laaApplnReference, :statusDescription)],
-          [:results, results_map(offence[:judicialResults])],
+          [:results, results_map(offence[:judicialResults], offence.dig(:laaApplnReference, :laaContractNumber))],
           [:plea, offence[:plea]],
           [:verdict, format_verdict(offence[:verdict])],
         ].to_h
       end
     end
 
-    def results_map(results)
+    def results_map(results, laa_contract_number)
       results&.map do |result|
         [
           [:resultCode, result[:cjsCode]],
@@ -111,7 +111,7 @@ module Sqs
           [:resultCodeQualifiers, result[:qualifier]],
           [:nextHearingDate, result.dig(:nextHearing, :listedStartDateTime)&.to_date&.strftime("%Y-%m-%d")],
           [:nextHearingLocation, hearing_location(result.dig(:nextHearing, :courtCentre, :id))],
-          [:laaOfficeAccount, defendant.dig(:defenceOrganisation, :laaAccountNumber)],
+          [:laaOfficeAccount, laa_contract_number],
           [:legalAidWithdrawalDate, defendant.dig(:laaApplnReference, :effectiveEndDate)],
         ].to_h
       end

--- a/app/services/sqs/publish_hearing.rb
+++ b/app/services/sqs/publish_hearing.rb
@@ -95,25 +95,25 @@ module Sqs
           [:legalAidStatus, offence.dig(:laaApplnReference, :statusCode)],
           [:legalAidStatusDate, offence.dig(:laaApplnReference, :statusDate)],
           [:legalAidReason, offence.dig(:laaApplnReference, :statusDescription)],
-          [:results, results_map(offence[:judicialResults], offence.dig(:laaApplnReference, :laaContractNumber))],
+          [:results, results_map(offence)],
           [:plea, offence[:plea]],
           [:verdict, format_verdict(offence[:verdict])],
         ].to_h
       end
     end
 
-    def results_map(results, laa_contract_number)
-      results&.map do |result|
-        [
-          [:resultCode, result[:cjsCode]],
-          [:resultShortTitle, result[:label]],
-          [:resultText, result[:resultText]],
-          [:resultCodeQualifiers, result[:qualifier]],
-          [:nextHearingDate, result.dig(:nextHearing, :listedStartDateTime)&.to_date&.strftime("%Y-%m-%d")],
-          [:nextHearingLocation, hearing_location(result.dig(:nextHearing, :courtCentre, :id))],
-          [:laaOfficeAccount, laa_contract_number],
-          [:legalAidWithdrawalDate, defendant.dig(:laaApplnReference, :effectiveEndDate)],
-        ].to_h
+    def results_map(offence)
+      offence[:judicialResults]&.map do |result|
+        {
+          resultCode: result[:cjsCode],
+          resultShortTitle: result[:label],
+          resultText: result[:resultText],
+          resultCodeQualifiers: result[:qualifier],
+          nextHearingDate: result.dig(:nextHearing, :listedStartDateTime)&.to_date&.strftime("%Y-%m-%d"),
+          nextHearingLocation: hearing_location(result.dig(:nextHearing, :courtCentre, :id)),
+          laaOfficeAccount: offence.dig(:laaApplnReference, :laaContractNumber),
+          legalAidWithdrawalDate: offence.dig(:laaApplnReference, :effectiveEndDate),
+        }
       end
     end
 

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -96,12 +96,10 @@ RSpec.describe Sqs::PublishHearing do
             'statusCode': "AP",
             'statusDescription': "Application Pending",
             'statusDate': "2018-10-24",
+            'laaContractNumber': "0A935R",
           },
         },
       ],
-      'defenceOrganisation': {
-        'laaAccountNumber': "0A935R",
-      },
     }
   end
 
@@ -196,21 +194,6 @@ RSpec.describe Sqs::PublishHearing do
   it "triggers a publish call with the expected sqs payload" do
     expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url)
     publish
-  end
-
-  context "when there are historical hearings" do
-    before do
-      defendant[:offences].each { |offence| offence.delete(:laaApplnReference) }
-    end
-
-    it "triggers a publish call with the sqs payload" do
-      offence_payload[:legalAidStatus] = nil
-      offence_payload[:legalAidStatusDate] = nil
-      offence_payload[:legalAidReason] = nil
-
-      expect(Sqs::MessagePublisher).to receive(:call).with(message: sqs_payload, queue_url: queue_url)
-      publish
-    end
   end
 
   context "when the defendant proceedingsConcluded flag is absent from the incoming hearing defendnt payload" do

--- a/spec/services/sqs/publish_hearing_spec.rb
+++ b/spec/services/sqs/publish_hearing_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe Sqs::PublishHearing do
             'statusDescription': "Application Pending",
             'statusDate': "2018-10-24",
             'laaContractNumber': "0A935R",
+            'effectiveEndDate': "2022-01-01",
           },
         },
       ],
@@ -181,7 +182,7 @@ RSpec.describe Sqs::PublishHearing do
         nextHearingDate: "2018-11-11",
         nextHearingLocation: "B16BG",
         laaOfficeAccount: "0A935R",
-        legalAidWithdrawalDate: nil,
+        legalAidWithdrawalDate: "2022-01-01",
       }],
     }
   end


### PR DESCRIPTION
## What

Publish Hearing was trying to get the values for laaOfficeAccount and legalAidWithdrawalDate from a location that did not match the schema 

This fix takes the value from laaContractNumber found on laaApplnReference as expected, and corrects effectiveEndDate to come from the laaApplnReference on offence, not defendant

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
