### PR TITLE
LAA Court Data Adapator API version 2

### DIFF
--- a/app/controllers/api/external/v2/hearings_controller.rb
+++ b/app/controllers/api/external/v2/hearings_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  module External
+    module V2
+      class HearingsController < ApplicationController
+        def create
+          enforce_contract!
+
+          HearingRecorder.call(
+            hearing_id: params[:hearing][:id],
+            body: transformed_params,
+            publish_to_queue: true,
+          )
+
+          head :accepted
+        end
+
+      private
+
+        def enforce_contract!
+          unless contract.success?
+            message = "Hearing contract failed with: #{contract.errors.to_hash}"
+            raise Errors::ContractError, message
+          end
+        end
+
+        def contract
+          HearingContract.new.call(**transformed_params)
+        end
+
+        # Only allow a trusted parameter "white list" through.
+        def hearing_params
+          params.require(%i[sharedTime hearing])
+          params.permit(:sharedTime, hearing: {})
+        end
+
+        def transformed_params
+          hearing_params.to_hash.deep_symbolize_keys.compact
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/defendants_controller.rb
+++ b/app/controllers/api/internal/v2/defendants_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class DefendantsController < ApplicationController
+        def update
+          contract = UnlinkDefendantContract.new.call(**transformed_params)
+          if contract.success?
+            enqueue_unlink
+            render status: :accepted
+          else
+            render json: contract.errors.to_hash, status: :bad_request
+          end
+        end
+
+        def show
+          defendant = DefendantFinder.call(defendant_id: params[:id])
+
+          if defendant.present?
+            render json: DefendantSerializer.new(defendant, serialization_options)
+          else
+            render status: :not_found
+          end
+        end
+
+      private
+
+        def enqueue_unlink
+          UnlinkLaaReferenceWorker.perform_async(
+            Current.request_id,
+            transformed_params[:defendant_id],
+            transformed_params[:user_name],
+            transformed_params[:unlink_reason_code],
+            transformed_params[:unlink_other_reason_text],
+          )
+        end
+
+        def unlink_params
+          params.from_jsonapi.require(:defendant).permit(allowed_params)
+        end
+
+        def allowed_params
+          %i[user_name unlink_reason_code unlink_other_reason_text]
+        end
+
+        def transformed_params
+          @transformed_params ||= unlink_params.slice(*allowed_params).to_hash.transform_keys(&:to_sym).merge(defendant_id: params[:id])
+        end
+
+        def serialization_options
+          return { include: inclusions } if params[:include].present?
+
+          {}
+        end
+
+        def inclusions
+          params[:include].split(",")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/hearings_controller.rb
+++ b/app/controllers/api/internal/v2/hearings_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class HearingsController < ApplicationController
+        def show
+          @hearing = Api::GetHearingResults.call(hearing_id: params[:id])
+          render json: HearingSerializer.new(@hearing, serialization_options)
+        end
+
+      private
+
+        def serialization_options
+          return { include: inclusions } if inclusions.present?
+
+          {}
+        end
+
+        def inclusions
+          params[:include]&.split(",")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/laa_references_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class LaaReferencesController < ApplicationController
+        def create
+          contract = NewLaaReferenceContract.new.call(**transformed_params)
+          enforce_contract!(contract)
+
+          LaaReferenceCreator.call(defendant_id: transformed_params[:defendant_id],
+                                   user_name: transformed_params[:user_name],
+                                   maat_reference: transformed_params[:maat_reference])
+
+          render status: :accepted
+        end
+
+        def destroy
+          contract = UnlinkDefendantContract.new.call(**transformed_params)
+          enforce_contract!(contract)
+
+          UnlinkLaaReferenceWorker.perform_async(
+            Current.request_id,
+            transformed_params[:defendant_id],
+            transformed_params[:user_name],
+            transformed_params[:unlink_reason_code],
+            transformed_params[:unlink_other_reason_text],
+          )
+
+          render status: :accepted
+        end
+
+      private
+
+        def enforce_contract!(contract)
+          unless contract.success?
+            message = "Contract failed with: #{contract.errors.to_hash}"
+            raise Errors::ContractError, message
+          end
+        end
+
+        def transformed_params
+          create_params.slice(*allowed_params).to_hash.symbolize_keys.compact
+        end
+
+        def create_params
+          params.from_jsonapi.require(:laa_reference).permit(allowed_params)
+        end
+
+        def allowed_params
+          %i[
+            maat_reference
+            defendant_id
+            user_name
+            unlink_reason_code
+            unlink_other_reason_text
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_cases_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class ProsecutionCasesController < ApplicationController
+        def index
+          @prosecution_cases = Api::SearchProsecutionCase.call(transformed_params)
+          render json: ProsecutionCaseSerializer.new(@prosecution_cases, serialization_options)
+        end
+
+      private
+
+        def filtered_params
+          params.require(:filter).permit(:prosecution_case_reference,
+                                         :arrest_summons_number,
+                                         :name,
+                                         :date_of_birth,
+                                         :date_of_next_hearing,
+                                         :national_insurance_number)
+        end
+
+        def transformed_params
+          filtered_params.to_hash.transform_keys(&:to_sym)
+        end
+
+        def serialization_options
+          return { include: inclusions } if inclusions.present?
+
+          {}
+        end
+
+        def inclusions
+          params[:include]&.split(",")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/representation_orders_controller.rb
+++ b/app/controllers/api/internal/v2/representation_orders_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class RepresentationOrdersController < ApplicationController
+        def create
+          enforce_contract!
+          enqueue_representation_order
+
+          render status: :accepted
+        end
+
+      private
+
+        def enforce_contract!
+          unless contract.success?
+            message = "Representation Order contract failed with: #{contract.errors.to_hash}"
+            raise Errors::ContractError, message
+          end
+        end
+
+        def contract
+          NewRepresentationOrderContract.new.call(**transformed_params)
+        end
+
+        def create_params
+          params.from_jsonapi.require(:representation_order).permit!
+        end
+
+        def transformed_params
+          @transformed_params ||= create_params.to_hash.transform_keys(&:to_sym).compact
+        end
+
+        def enqueue_representation_order
+          RepresentationOrderCreatorWorker.perform_async(
+            Current.request_id,
+            transformed_params[:defendant_id],
+            transformed_params[:offences],
+            transformed_params[:maat_reference],
+            transformed_params[:defence_organisation],
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/v2/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/v2/doorkeeper/authorizations_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module V2
+  module Doorkeeper
+    class AuthorizationsController < ::Doorkeeper::AuthorizationsController
+    end
+  end
+end

--- a/app/controllers/v2/doorkeeper/token_info_controller.rb
+++ b/app/controllers/v2/doorkeeper/token_info_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module V2
+  module Doorkeeper
+    class TokenInfoController < ::Doorkeeper::TokenInfoController
+    end
+  end
+end

--- a/app/controllers/v2/doorkeeper/tokens_controller.rb
+++ b/app/controllers/v2/doorkeeper/tokens_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module V2
+  module Doorkeeper
+    class TokensController < ::Doorkeeper::TokensController
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/cracked_ineffective_trial_serializer.rb
+++ b/app/serializers/api/internal/v2/cracked_ineffective_trial_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class CrackedIneffectiveTrialSerializer
+        include JSONAPI::Serializer
+        set_type :cracked_ineffective_trial
+
+        attributes :id, :code, :type, :description
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/defence_organisation_serializer.rb
+++ b/app/serializers/api/internal/v2/defence_organisation_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class DefenceOrganisationSerializer
+        include JSONAPI::Serializer
+        set_type :defence_organisation
+
+        attributes :name, :address1, :address2, :address3, :address4, :address5, :postcode
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/defendant_serializer.rb
+++ b/app/serializers/api/internal/v2/defendant_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class DefendantSerializer
+        include JSONAPI::Serializer
+        set_type :defendants
+
+        attributes :name, :date_of_birth, :national_insurance_number, :arrest_summons_number, :maat_reference, :representation_order_date, :prosecution_case_id, :post_hearing_custody_statuses
+
+        has_many :offences, record_type: :offences
+        has_one :defence_organisation, record_type: :defence_organisations
+        has_one :prosecution_case, record_type: :prosecution_case
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/hearing_event_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_event_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class HearingEventSerializer
+        include JSONAPI::Serializer
+        set_type :hearing_events
+
+        attributes :description
+        attributes :occurred_at
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/hearing_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_serializer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class HearingSerializer
+        include JSONAPI::Serializer
+        set_type :hearings
+
+        attributes :court_name,
+                   :hearing_type,
+                   :hearing_days,
+                   :defendant_names,
+                   :judge_names,
+                   :prosecution_advocate_names,
+                   :defence_advocate_names
+
+        has_many :hearing_events, record_type: :hearing_events
+        has_many :providers, record_type: :providers
+        has_one :cracked_ineffective_trial, record_type: :cracked_ineffective_trial
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/hearing_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_serializer.rb
@@ -15,7 +15,6 @@ module Api
                    :prosecution_advocate_names,
                    :defence_advocate_names
 
-        has_many :hearing_events, record_type: :hearing_events
         has_many :providers, record_type: :providers
         has_one :cracked_ineffective_trial, record_type: :cracked_ineffective_trial
       end

--- a/app/serializers/api/internal/v2/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_summary_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class HearingSummarySerializer
+        include JSONAPI::Serializer
+        set_type :hearing_summaries
+
+        attributes :hearing_type, :hearing_days
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/offence_serializer.rb
+++ b/app/serializers/api/internal/v2/offence_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class OffenceSerializer
+        include JSONAPI::Serializer
+        set_type :offences
+        attributes :code,
+                   :order_index,
+                   :title,
+                   :legislation,
+                   :mode_of_trial,
+                   :mode_of_trial_reasons,
+                   :pleas
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/prosecution_case_serializer.rb
+++ b/app/serializers/api/internal/v2/prosecution_case_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class ProsecutionCaseSerializer
+        include JSONAPI::Serializer
+        set_type :prosecution_cases
+
+        attributes :prosecution_case_reference
+
+        has_many :defendants, record_type: :defendants
+        has_many :hearing_summaries, record_type: :hearing_summaries
+        has_many :hearings, record_type: :hearings
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/prosecution_case_serializer.rb
+++ b/app/serializers/api/internal/v2/prosecution_case_serializer.rb
@@ -11,7 +11,6 @@ module Api
 
         has_many :defendants, record_type: :defendants
         has_many :hearing_summaries, record_type: :hearing_summaries
-        has_many :hearings, record_type: :hearings
       end
     end
   end

--- a/app/serializers/api/internal/v2/provider_serializer.rb
+++ b/app/serializers/api/internal/v2/provider_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class ProviderSerializer
+        include JSONAPI::Serializer
+        set_type :providers
+
+        attributes :name, :role
+      end
+    end
+  end
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -8,4 +8,5 @@ Rswag::Ui.configure do |c|
   # then the list below should correspond to the relative paths for those endpoints
 
   c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+  c.swagger_endpoint "/api-docs/v2/swagger.yaml", "API V2 Docs"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,10 @@ Rails.application.routes.draw do
       api_version(module: "V1", path: { value: "v1" }, default: true) do
         resources :hearings, only: [:create]
       end
+
+      api_version(module: "V2", path: { value: "v2" }) do
+        resources :hearings, only: [:create]
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,16 @@ Rails.application.routes.draw do
         resources :representation_orders, only: [:create]
         resources :hearings, only: [:show]
       end
+
+      api_version(module: "V2", path: { value: "v2" }) do
+        resources :prosecution_cases, only: [:index]
+        resources :laa_references, only: %i[create destroy], param: :defendant_id
+        resources :defendants, only: %i[update show]
+        resources :representation_orders, only: [:create]
+        resources :hearings, only: [:show]
+      end
     end
+
     namespace :external do
       api_version(module: "V1", path: { value: "v1" }, default: true) do
         resources :hearings, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     use_doorkeeper
   end
 
+  api_version(module: "V2", path: { value: "v2" }) do
+    use_doorkeeper
+  end
+
   namespace :api do
     namespace :internal do
       api_version(module: "V1", path: { value: "v1" }, default: true) do

--- a/spec/controllers/api/external/v2/hearings_controller_spec.rb
+++ b/spec/controllers/api/external/v2/hearings_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::External::V2::HearingsController, type: :controller do
+  include AuthorisedRequestHelper
+
+  before { authorise_requests! }
+
+  let(:valid_attributes) { JSON.parse(file_fixture("hearing/valid.json").read) }
+  let(:invalid_attributes) { JSON.parse(file_fixture("hearing/invalid.json").read) }
+  let(:unprocessable_attributes) { JSON.parse(file_fixture("hearing/unprocessable.json").read) }
+
+  describe "POST #create" do
+    context "with valid params" do
+      it "creates a new Hearing" do
+        expect {
+          post :create, params: valid_attributes, as: :json
+        }.to change(Hearing, :count).by(1)
+      end
+
+      it "renders a JSON response with an empty response" do
+        post :create, params: valid_attributes, as: :json
+        expect(response.body).to be_empty
+        expect(response).to have_http_status(:accepted)
+      end
+    end
+
+    context "with an invalid hearing" do
+      it "renders a JSON response with an unprocessable_entity error" do
+        allow(HearingRecorder).to receive(:call).and_return(Hearing.new)
+        post :create, params: unprocessable_attributes, as: :json
+        expect(response.body).to include("must be an integer")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "with invalid params" do
+      it "renders a JSON response with errors for the new hearing" do
+        post :create, params: invalid_attributes, as: :json
+        expect(response.body).to include("param is missing or the value is empty")
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/requests/api/external/v2/hearings_request_spec.rb
+++ b/spec/requests/api/external/v2/hearings_request_spec.rb
@@ -3,7 +3,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "api/external/v2/hearings", type: :request do
+RSpec.describe "api/external/v2/hearings", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }

--- a/spec/requests/api/external/v2/hearings_spec.rb
+++ b/spec/requests/api/external/v2/hearings_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/external/v2/hearings", type: :request do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+
+  path "/api/external/v2/hearings" do
+    post("post hearing") do
+      description "Post Common Platform hearing data to CDA"
+      consumes "application/json"
+      tags "External - available to Common Platform"
+      security [{ oAuth: [] }]
+
+      response(202, "Accepted") do
+        parameter name: :hearing, in: :body, required: false, type: :object,
+                  schema: {
+                    '$ref': "hearing_resulted.json#/definitions/new_resource",
+                  },
+                  description: "The minimal Hearing Resulted payload"
+
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:hearing) { JSON.parse(file_fixture("hearing/valid.json").read) }
+
+        before do
+          expect(HearingsCreatorWorker).to receive(:perform_async)
+        end
+
+        run_test!
+      end
+
+      context "when entity is unprocessable" do
+        response("422", "Unprocessable Entity") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:hearing) { JSON.parse(file_fixture("hearing/unprocessable.json").read) }
+
+          run_test!
+        end
+      end
+
+      context "when data is invalid" do
+        response("400", "Bad Request") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:hearing) { JSON.parse(file_fixture("hearing/invalid.json").read) }
+
+          run_test!
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          let(:Authorization) { nil }
+
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/external/v2/hearings_spec.rb
+++ b/spec/requests/api/external/v2/hearings_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 
@@ -59,3 +60,4 @@ RSpec.describe "api/external/v2/hearings", type: :request do
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 require "sidekiq/testing"
@@ -160,3 +161,4 @@ RSpec.describe "Api::Internal::V1::Defendants", type: :request, swagger_doc: "v1
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v2/defendants_request_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 require "sidekiq/testing"
@@ -160,3 +161,4 @@ RSpec.describe "Api::Internal::V2::Defendants", type: :request, swagger_doc: "v1
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v2/defendants_request_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+require "sidekiq/testing"
+
+RSpec.describe "Api::Internal::V2::Defendants", type: :request, swagger_doc: "v1/swagger.yaml" do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:id) { "23d7f10a-067a-476e-bba6-bb855674e23b" }
+  let(:include) {}
+  let(:defendant) do
+    {
+      data: {
+        type: "defendants",
+        attributes: {
+          user_name: "johnDoe",
+          unlink_reason_code: 1,
+          unlink_other_reason_text: "",
+        },
+      },
+    }
+  end
+
+  around do |example|
+    Sidekiq::Testing.fake! do
+      example.run
+    end
+  end
+
+  path "/api/internal/v2/defendants/{id}" do
+    patch("patch defendant relationships") do
+      description "Delete an LAA reference from Common Platform case"
+      consumes "application/json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      response(202, "Accepted") do
+        parameter name: :id, in: :path, required: true, type: :uuid,
+                  schema: {
+                    '$ref': "defendant.json#/definitions/id",
+                  },
+                  description: "The unique identifier of the defendant"
+
+        parameter name: :defendant, in: :body, required: true, type: :object,
+                  schema: {
+                    '$ref': "defendant.json#/definitions/resource_to_unlink",
+                  },
+                  description: "Object containing the user_name, unlink_reason_code and unlink_other_reason_text"
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        let(:Authorization) { "Bearer #{token.token}" }
+
+        before do
+          expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with(String, id, "johnDoe", 1, "").and_call_original
+        end
+
+        run_test!
+      end
+
+      context "when data is bad" do
+        response("400", "Bad Request") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:id) { "X" }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+          end
+
+          run_test!
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          let(:Authorization) { nil }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+          end
+
+          run_test!
+        end
+      end
+    end
+
+    get("fetch a defendant by ID") do
+      description "find a defendant where it exists within Court Data Adaptor"
+      consumes "application/json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      parameter name: :id, in: :path, required: true, type: :uuid,
+                schema: {
+                  '$ref': "defendant.json#/definitions/id",
+                },
+                description: "The uuid of the defendant"
+
+      parameter name: "include", in: :query, required: false, type: :string,
+                schema: {},
+                description: "Return other data through a has_many relationship </br>e.g. include=offences"
+
+      parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+      context "with success" do
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:id) { "c6cf04b5-901d-4a89-a9ab-767eb57306e4" }
+
+        before do
+          # This call creates the ProsecutionCase and ProsecutionCaseDefendantOffence
+          # in the CDA DB, which are currently required to query the defendant by id
+          # on this api endpoint.
+          # It implies that defendants are not queryable unless their case has been searched
+          # for beforehand, which seems risky (albeit that VCD should always have queried the
+          # case first via its searchinng options).
+          #
+          Api::SearchProsecutionCase.call(prosecution_case_reference: "19GD1001816")
+        end
+
+        around do |example|
+          VCR.use_cassette("search_prosecution_case/by_prosecution_case_reference_success", record: :new_episodes) do
+            example.run
+          end
+        end
+
+        context "with no inclusions" do
+          let(:include) {}
+
+          response(200, "Success") do
+            run_test!
+          end
+        end
+
+        context "with offences included" do
+          let(:include) { "offences" }
+
+          response(200, "Success") do
+            run_test! do |response|
+              hashed = JSON.parse(response.body, symbolize_names: true)
+              included_types = hashed[:included].pluck(:type)
+              expect(included_types).to all(eql("offences"))
+            end
+          end
+        end
+      end
+
+      context "when not found" do
+        response("404", "Not found") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:id) { "c6cf04b5" }
+
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v2/defendants_request_spec.rb
@@ -4,7 +4,7 @@
 require "swagger_helper"
 require "sidekiq/testing"
 
-RSpec.describe "Api::Internal::V2::Defendants", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "api/internal/v2/defendants", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }

--- a/spec/requests/api/internal/v2/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearings_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Api::Internal::V2::Hearings", type: :request do
 
       parameter name: "include", in: :query, required: false, type: :string,
                 schema: {},
-                description: "Return other data through a has_many relationship </br>e.g. include=hearing_events"
+                description: "Return other data through a has_many relationship </br>e.g. include=providers"
 
       parameter "$ref" => "#/components/parameters/transaction_id_header"
 
@@ -46,18 +46,6 @@ RSpec.describe "Api::Internal::V2::Hearings", type: :request do
 
           response(200, "Success") do
             run_test!
-          end
-        end
-
-        context "with hearing_events included" do
-          let(:include) { "hearing_events" }
-
-          response(200, "Success") do
-            run_test! do |response|
-              hashed = JSON.parse(response.body, symbolize_names: true)
-              included_types = hashed[:included].pluck(:type)
-              expect(included_types).to all(eql("hearing_events"))
-            end
           end
         end
       end

--- a/spec/requests/api/internal/v2/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearings_request_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 
@@ -79,3 +80,4 @@ RSpec.describe "Api::Internal::V2::Hearings", type: :request do
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearings_request_spec.rb
@@ -3,7 +3,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "Api::Internal::V2::Hearings", type: :request do
+RSpec.describe "api/internal/v2/hearings", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }

--- a/spec/requests/api/internal/v2/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearings_request_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Api::Internal::V2::Hearings", type: :request do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:include) {}
+  let(:id) { "4d01840d-5959-4539-a450-d39f57171036" }
+
+  path "/api/internal/v2/hearings/{id}" do
+    get("get hearing") do
+      description "GET Common Platform hearing data"
+      consumes "application/json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      parameter name: :id, in: :path, required: true, type: :uuid,
+                schema: {
+                  '$ref': "hearing.json#/definitions/id",
+                },
+                description: "The uuid of the hearing"
+
+      parameter name: "include", in: :query, required: false, type: :string,
+                schema: {},
+                description: "Return other data through a has_many relationship </br>e.g. include=hearing_events"
+
+      parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+      context "with success" do
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:shared_time) { JSON.parse(file_fixture("hearing/valid.json").read) }
+
+        around do |example|
+          VCR.use_cassette("hearing_result_fetcher/success") do
+            VCR.use_cassette("hearing_logs_fetcher/success") do
+              example.run
+            end
+          end
+        end
+
+        context "with no inclusions" do
+          let(:include) {}
+
+          response(200, "Success") do
+            run_test!
+          end
+        end
+
+        context "with hearing_events included" do
+          let(:include) { "hearing_events" }
+
+          response(200, "Success") do
+            run_test! do |response|
+              hashed = JSON.parse(response.body, symbolize_names: true)
+              included_types = hashed[:included].pluck(:type)
+              expect(included_types).to all(eql("hearing_events"))
+            end
+          end
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          around do |example|
+            VCR.use_cassette("hearing_result_fetcher/unauthorised") do
+              example.run
+            end
+          end
+
+          let(:Authorization) { nil }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/laa_references_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+require "sidekiq/testing"
+
+RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v1/swagger.yaml" do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:defendant_id) { SecureRandom.uuid }
+  let(:laa_reference) do
+    {
+      data: {
+        type: "laa_references",
+        attributes: {
+          maat_reference: 1_231_231,
+          user_name: "JaneDoe",
+          unlink_reason_code: 1,
+          unlink_other_reason_text: "",
+        },
+        relationships: {
+          defendant: {
+            data: {
+              type: "defendants",
+              id: defendant_id,
+            },
+          },
+        },
+      },
+    }
+  end
+
+  before do
+    allow(LinkValidator).to receive(:call).and_return(true)
+  end
+
+  around do |example|
+    VCR.use_cassette("maat_api/maat_reference_success") do
+      Sidekiq::Testing.fake! do
+        example.run
+      end
+    end
+  end
+
+  path "/api/internal/v2/laa_references" do
+    post("post laa_reference") do
+      description "Post an LAA reference to CDA to link a MAAT case to a Common Platform case"
+      consumes "application/json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      response(202, "Accepted") do
+        around do |example|
+          Sidekiq::Testing.fake!
+          VCR.use_cassette("laa_reference_recorder/update") do
+            example.run
+          end
+        end
+
+        parameter name: :laa_reference, in: :body, required: false, type: :object,
+                  schema: {
+                    '$ref': "laa_reference.json#/definitions/new_resource",
+                  },
+                  description: "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings"
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        let(:Authorization) { "Bearer #{token.token}" }
+
+        before do
+          expect(LaaReferenceCreator).to receive(:call).with(defendant_id: defendant_id, user_name: "JaneDoe", maat_reference: 1_231_231).and_call_original
+        end
+
+        run_test!
+      end
+
+      context "with a blank maat_reference" do
+        response(202, "Accepted") do
+          let(:Authorization) { "Bearer #{token.token}" }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            laa_reference[:data][:attributes].delete(:maat_reference)
+            expect(LaaReferenceCreator).to receive(:call).with(defendant_id: defendant_id, user_name: "JaneDoe", maat_reference: nil).and_call_original
+          end
+
+          run_test!
+        end
+      end
+
+      context "with a blank user_name" do
+        response("422", "Unprocessable entity") do
+          let(:Authorization) { "Bearer #{token.token}" }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            laa_reference[:data][:attributes].delete(:user_name)
+            expect(LaaReferenceCreator).not_to receive(:call)
+          end
+
+          run_test!
+        end
+      end
+
+      context "with an invalid maat_reference" do
+        response("422", "Unprocessable entity") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          before { laa_reference[:data][:attributes][:maat_reference] = "ABC123123" }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(LaaReferenceCreator).not_to receive(:call)
+          end
+
+          run_test!
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          let(:Authorization) { nil }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(LaaReferenceCreator).not_to receive(:call)
+          end
+
+          run_test!
+        end
+      end
+
+      context "when we are attempting to create an LaaReference that already exists" do
+        it "includes error message in JSON response" do
+          LaaReference.create!(defendant_id: defendant_id, maat_reference: 1_231_231, user_name: "JaneDoe")
+
+          post "/api/internal/v2/laa_references", params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
+
+          expect(response).to have_http_status :bad_request
+          expect(JSON.parse(response.body)).to eql({ "error" => "Validation failed: Maat reference has already been taken" })
+        end
+      end
+
+      context "with a failing LAA Reference contract" do
+        before { laa_reference[:data][:relationships][:defendant][:data][:id] = "foo" }
+
+        it "renders a JSON response with an unprocessable_entity error" do
+          post "/api/internal/v2/laa_references", params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
+
+          expect(response.body).to include("is not a valid uuid")
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+
+  path "/api/internal/v2/laa_references/{defendant_id}" do
+    delete("laa_reference") do
+      description "Delete an LAA reference from Common Platform case"
+      consumes "application/json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      response(202, "Accepted") do
+        parameter name: :defendant_id, in: :path, required: true, type: :uuid,
+                  schema: {
+                    '$ref': "defendant.json#/definitions/id",
+                  },
+                  description: "The unique identifier of the defendant"
+
+        parameter name: :laa_reference, in: :body, required: true, type: :object,
+                  schema: {
+                    '$ref': "laa_reference.json#/definitions/resource_to_destroy",
+                  },
+                  description: "Object containing the user_name, unlink_reason_code and unlink_other_reason_text"
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        let(:Authorization) { "Bearer #{token.token}" }
+
+        before do
+          expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with(String, defendant_id, "JaneDoe", 1, "")
+        end
+
+        run_test!
+      end
+
+      response("422", "Unprocessable Entity") do
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:defendant_id) { "X" }
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        before do
+          expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+        end
+
+        run_test!
+      end
+
+      response("401", "Unauthorized") do
+        let(:Authorization) { nil }
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        before do
+          expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/laa_references_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 require "sidekiq/testing"
@@ -215,3 +216,4 @@ RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/laa_references_spec.rb
@@ -4,7 +4,7 @@
 require "swagger_helper"
 require "sidekiq/testing"
 
-RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }
@@ -159,7 +159,7 @@ RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v
   end
 
   path "/api/internal/v2/laa_references/{defendant_id}" do
-    delete("laa_reference") do
+    delete("delete laa_reference") do
       description "Delete an LAA reference from Common Platform case"
       consumes "application/json"
       tags "Internal - available to other LAA applications"
@@ -174,7 +174,7 @@ RSpec.describe "api/internal/v2/laa_references", type: :request, swagger_doc: "v
 
         parameter name: :laa_reference, in: :body, required: true, type: :object,
                   schema: {
-                    '$ref': "laa_reference.json#/definitions/resource_to_destroy",
+                    '$ref': "laa_reference.json#/definitions/unlink",
                   },
                   description: "Object containing the user_name, unlink_reason_code and unlink_other_reason_text"
 

--- a/spec/requests/api/internal/v2/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v2/prosecution_cases_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 
@@ -174,3 +175,4 @@ RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc:
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v2/prosecution_cases_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc:
           parameter name: "include", in: :query, required: false, type: :string,
                     schema: {},
                     description: 'Return defendant and offence data through a has_many relationship </br>
-                                  eg include=defendants,defendants.offences,defendants.defence_organisation,hearings.providers'
+                                  eg include=defendants,defendants.offences,defendants.defence_organisation'
 
           parameter "$ref" => "#/components/parameters/transaction_id_header"
 
@@ -51,7 +51,7 @@ RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc:
 
           let(:Authorization) { "Bearer #{token.token}" }
           let(:'filter[prosecution_case_reference]') { "19GD1001816" }
-          let(:include) { "defendants,defendants.offences,defendants.defence_organisation,hearings.providers" }
+          let(:include) { "defendants,defendants.offences,defendants.defence_organisation" }
 
           run_test!
         end

--- a/spec/requests/api/internal/v2/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v2/prosecution_cases_spec.rb
@@ -3,7 +3,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }

--- a/spec/requests/api/internal/v2/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v2/prosecution_cases_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/internal/v2/prosecution_cases", type: :request, swagger_doc: "v1/swagger.yaml" do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:include) {}
+
+  before do
+    allow(Api::GetHearingResults).to receive(:call)
+  end
+
+  path "/api/internal/v2/prosecution_cases" do
+    get("search prosecution_cases") do
+      description 'Search prosecution cases. Valid search combinations are: <br/><br/>
+                    1) prosecution_case_reference <br/>
+                    2) arrest_summons_number <br/>
+                    3) national_insurance_number <br/>
+                    4) name and date_of_birth <br/>
+                    5) name and date_of_next_hearing'
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      context "when searching by prosecution_case_reference" do
+        response(200, "Success") do
+          around do |example|
+            VCR.use_cassette("search_prosecution_case/by_prosecution_case_reference_success") do
+              example.run
+            end
+          end
+
+          produces "application/vnd.api+json"
+
+          parameter name: "filter[prosecution_case_reference]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "prosecution_case.json#/definitions/prosecution_case_reference",
+                    },
+                    description: "Searches prosecution cases by prosecution case reference"
+
+          parameter name: "include", in: :query, required: false, type: :string,
+                    schema: {},
+                    description: 'Return defendant and offence data through a has_many relationship </br>
+                                  eg include=defendants,defendants.offences,defendants.defence_organisation,hearings.providers'
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          schema "$ref" => "prosecution_case.json#/definitions/resource_collection"
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[prosecution_case_reference]') { "19GD1001816" }
+          let(:include) { "defendants,defendants.offences,defendants.defence_organisation,hearings.providers" }
+
+          run_test!
+        end
+      end
+
+      context "when searching by arrest_summons_number" do
+        response(200, "Success") do
+          around do |example|
+            VCR.use_cassette("search_prosecution_case/by_arrest_summons_number_success") do
+              example.run
+            end
+          end
+
+          parameter name: "filter[arrest_summons_number]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "prosecution_case.json#/definitions/arrest_summons_number",
+                    },
+                    description: "Searches prosecution cases by arrest summons number"
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[arrest_summons_number]') { "arrest123" }
+
+          run_test!
+        end
+      end
+
+      context "when searching by national_insurance_number" do
+        response(200, "Success") do
+          around do |example|
+            VCR.use_cassette("search_prosecution_case/by_national_insurance_number_success") do
+              example.run
+            end
+          end
+
+          parameter name: "filter[national_insurance_number]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "defendant.json#/definitions/nino",
+                    },
+                    description: "Searches prosecution cases by national_insurance_number"
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[national_insurance_number]') { "HB133542A" }
+
+          run_test!
+        end
+      end
+
+      context "when searching by name and date of birth" do
+        response(200, "Success") do
+          around do |example|
+            VCR.use_cassette("search_prosecution_case/by_name_and_date_of_birth_success") do
+              example.run
+            end
+          end
+
+          parameter name: "filter[name]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "defendant.json#/definitions/name",
+                    },
+                    description: "Searches prosecution cases by name"
+
+          parameter name: "filter[date_of_birth]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "defendant.json#/definitions/date_of_birth",
+                    },
+                    description: "Searches prosecution cases by date_of_birth"
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[name]') { "George Walsh" }
+          let(:'filter[date_of_birth]') { "1980-01-01" }
+
+          run_test!
+        end
+      end
+
+      context "when searching by name and date of next hearing" do
+        response(200, "Success") do
+          around do |example|
+            VCR.use_cassette("search_prosecution_case/by_name_and_date_of_next_hearing_success") do
+              example.run
+            end
+          end
+
+          parameter name: "filter[name]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "defendant.json#/definitions/name",
+                    },
+                    description: "Searches prosecution cases by name"
+
+          parameter name: "filter[date_of_next_hearing]", in: :query, required: false, type: :string,
+                    schema: {
+                      '$ref': "prosecution_case.json#/definitions/date_of_next_hearing",
+                    },
+                    description: "Searches prosecution cases by date_of_next_hearing"
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          let(:Authorization) { "Bearer #{token.token}" }
+          let(:'filter[name]') { "George Walsh" }
+          let(:'filter[date_of_next_hearing]') { "2020-02-17" }
+
+          run_test!
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          let(:Authorization) { nil }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v2/representation_orders_request_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+require "sidekiq/testing"
+
+RSpec.describe "api/internal/v2/representation_orders", type: :request, swagger_doc: "v1/swagger.yaml" do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:defendant_id) { SecureRandom.uuid }
+
+  let(:offence_array) do
+    [
+      {
+        offence_id: SecureRandom.uuid,
+        status_code: "GR",
+        status_date: "2020-02-12",
+        effective_start_date: "2020-02-20",
+        effective_end_date: "2020-02-25",
+      },
+    ]
+  end
+
+  let(:defence_organisation) do
+    {
+      laa_contract_number: "CONTRACT REFERENCE",
+      sra_number: "SRA NUMBER",
+      bar_council_membership_number: "BAR COUNCIL NUMBER",
+      incorporation_number: "AAA",
+      registered_charity_number: "BBB",
+      organisation: {
+        name: "SOME ORGANISATION",
+        address: {
+          address1: "102",
+          address2: "Petty France",
+          address3: "Floor 5",
+          address4: "St James",
+          address5: "Westminster",
+          postcode: "EC4A 2AH",
+        },
+        contact: {
+          home: "+99999",
+          work: "CALL ME 888",
+          mobile: "+99999",
+          primary_email: "a@example.com",
+          secondary_email: "a@example.com",
+          fax: "ABC123123",
+        },
+      },
+    }
+  end
+
+  let(:representation_order) do
+    {
+      data: {
+        type: "representation_orders",
+        attributes: {
+          maat_reference: 1_231_231,
+          defence_organisation: defence_organisation,
+          offences: offence_array,
+        },
+        relationships: {
+          defendant: {
+            data: {
+              type: "defendants",
+              id: defendant_id,
+            },
+          },
+        },
+      },
+    }
+  end
+
+  around do |example|
+    Sidekiq::Testing.fake! do
+      example.run
+    end
+  end
+
+  path "/api/internal/v2/representation_orders" do
+    post("post representation_order") do
+      description "Post a Representation Order to CDA to update the status on a MAAT case to a Common Platform case"
+      consumes "application/vnd.api+json"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+
+      response(202, "Accepted") do
+        around do |example|
+          VCR.use_cassette("representation_order_recorder/update") do
+            example.run
+          end
+        end
+
+        parameter name: :representation_order, in: :body, required: true, type: :object,
+                  schema: {
+                    '$ref': "representation_order.json#/definitions/new_resource",
+                  },
+                  description: "The Representation Order for an offence"
+
+        parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+        let(:Authorization) { "Bearer #{token.token}" }
+
+        before do
+          expect(RepresentationOrderCreatorWorker).to receive(:perform_async).with(
+            String,
+            defendant_id,
+            offence_array.map { |o| o.deep_transform_keys(&:to_s) },
+            1_231_231,
+            defence_organisation.deep_transform_keys(&:to_s),
+          ).and_call_original
+        end
+
+        run_test!
+      end
+
+      context "with an invalid maat_reference" do
+        response("422", "Unprocessable entity") do
+          let(:Authorization) { "Bearer #{token.token}" }
+          before { representation_order[:data][:attributes][:maat_reference] = "ABC123123" }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+          end
+
+          run_test!
+        end
+      end
+
+      context "when request is unauthorized" do
+        response("401", "Unauthorized") do
+          let(:Authorization) { nil }
+
+          parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+          before do
+            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+          end
+
+          run_test!
+        end
+      end
+
+      context "with a failing contract" do
+        before { representation_order[:data][:relationships][:defendant][:data][:id] = "foo" }
+
+        it "renders a JSON response with an unprocessable_entity error" do
+          post "/api/internal/v2/representation_orders", params: representation_order, headers: { "Authorization" => "Bearer #{token.token}" }
+
+          expect(response.body).to include("is not a valid uuid")
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v2/representation_orders_request_spec.rb
@@ -4,7 +4,7 @@
 require "swagger_helper"
 require "sidekiq/testing"
 
-RSpec.describe "api/internal/v2/representation_orders", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "api/internal/v2/representation_orders", type: :request, swagger_doc: "v2/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }

--- a/spec/requests/api/internal/v2/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v2/representation_orders_request_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 require "sidekiq/testing"
@@ -156,3 +157,4 @@ RSpec.describe "api/internal/v2/representation_orders", type: :request, swagger_
     end
   end
 end
+# rubocop:enable all

--- a/spec/routing/api/external/v2/hearings_routing_spec.rb
+++ b/spec/routing/api/external/v2/hearings_routing_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::External::V2::HearingsController, type: :routing do
+  describe "routing" do
+    it "routes to #create" do
+      expect(post: "/api/external/v2/hearings").to route_to("api/external/v2/hearings#create")
+    end
+
+    context "when no API version is specified" do
+      it "routes to #create" do
+        expect(post: "/api/external/hearings").to route_to("api/external/v1/hearings#create")
+      end
+    end
+  end
+end

--- a/spec/routing/v2/doorkeeper/authorize_routing_spec.rb
+++ b/spec/routing/v2/doorkeeper/authorize_routing_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe "routing", type: :routing do
+  it "routes to #new" do
+    expect(get: "/v2/oauth/authorize").to route_to("v2/doorkeeper/authorizations#new")
+  end
+
+  it "routes to #show" do
+    expect(get: "/v2/oauth/authorize/native").to route_to("v2/doorkeeper/authorizations#show")
+  end
+
+  it "routes to #destroy" do
+    expect(delete: "/v2/oauth/authorize").to route_to("v2/doorkeeper/authorizations#destroy")
+  end
+
+  it "routes to #create" do
+    expect(post: "/v2/oauth/authorize").to route_to("v2/doorkeeper/authorizations#create")
+  end
+
+  context "when no API version is specified" do
+    it "routes to #show" do
+      expect(get: "/oauth/authorize/native").to route_to("v1/doorkeeper/authorizations#show")
+    end
+
+    it "routes to #new" do
+      expect(get: "/oauth/authorize").to route_to("v1/doorkeeper/authorizations#new")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/oauth/authorize").to route_to("v1/doorkeeper/authorizations#destroy")
+    end
+
+    it "routes to #create" do
+      expect(post: "/oauth/authorize").to route_to("v1/doorkeeper/authorizations#create")
+    end
+  end
+end

--- a/spec/routing/v2/doorkeeper/token_info_routing_spec.rb
+++ b/spec/routing/v2/doorkeeper/token_info_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe "routing", type: :routing do
+  it "routes to #show" do
+    expect(get: "/v2/oauth/token/info").to route_to("v2/doorkeeper/token_info#show")
+  end
+
+  context "when no API version is specified" do
+    it "routes to #show" do
+      expect(get: "/oauth/token/info").to route_to("v1/doorkeeper/token_info#show")
+    end
+  end
+end

--- a/spec/routing/v2/doorkeeper/token_routing_spec.rb
+++ b/spec/routing/v2/doorkeeper/token_routing_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "routing", type: :routing do
+  it "routes to #create" do
+    expect(post: "/v2/oauth/token").to route_to("v2/doorkeeper/tokens#create")
+  end
+
+  it "routes to #revoke" do
+    expect(post: "/v2/oauth/revoke").to route_to("v2/doorkeeper/tokens#revoke")
+  end
+
+  it "routes to #introspect" do
+    expect(post: "/v2/oauth/introspect").to route_to("v2/doorkeeper/tokens#introspect")
+  end
+
+  context "when no API version is specified" do
+    it "routes to #revoke" do
+      expect(post: "/oauth/revoke").to route_to("v1/doorkeeper/tokens#revoke")
+    end
+
+    it "routes to #introspect" do
+      expect(post: "/oauth/introspect").to route_to("v1/doorkeeper/tokens#introspect")
+    end
+
+    it "routes to #create" do
+      expect(post: "/oauth/token").to route_to("v1/doorkeeper/tokens#create")
+    end
+  end
+end

--- a/spec/serializers/api/internal/v2/cracked_ineffective_trial_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/cracked_ineffective_trial_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::CrackedIneffectiveTrialSerializer do
+  subject { described_class.new(cracked_ineffective_trial).serializable_hash }
+
+  let(:cracked_ineffective_trial) do
+    instance_double("CrackedIneffectiveTrial",
+                    id: "a-uuid",
+                    code: "A",
+                    type: "cracked",
+                    description: "A reason for the cracked trail goes here")
+  end
+
+  let(:attributes) { subject[:data][:attributes] }
+
+  it { expect(attributes[:id]).to eq("a-uuid") }
+  it { expect(attributes[:code]).to eq("A") }
+  it { expect(attributes[:type]).to eq("cracked") }
+  it { expect(attributes[:description]).to eq("A reason for the cracked trail goes here") }
+end

--- a/spec/serializers/api/internal/v2/defence_organisation_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defence_organisation_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::DefenceOrganisationSerializer do
+  subject { described_class.new(defence_organisation).serializable_hash }
+
+  let(:defence_organisation) do
+    instance_double("DefenceOrganisation",
+                    id: "UUID",
+                    name: "The Johnson Partnership",
+                    address1: "104",
+                    address2: "Fleet Street",
+                    address3: "Westminster",
+                    address4: "London",
+                    address5: "GB",
+                    postcode: "EC4A 2AH")
+  end
+
+  let(:attributes) { subject[:data][:attributes] }
+
+  it { expect(attributes[:name]).to eq("The Johnson Partnership") }
+  it { expect(attributes[:address1]).to eq("104") }
+  it { expect(attributes[:address2]).to eq("Fleet Street") }
+  it { expect(attributes[:address3]).to eq("Westminster") }
+  it { expect(attributes[:address4]).to eq("London") }
+  it { expect(attributes[:address5]).to eq("GB") }
+  it { expect(attributes[:postcode]).to eq("EC4A 2AH") }
+end

--- a/spec/serializers/api/internal/v2/defendant_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defendant_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::DefendantSerializer do
+  subject { described_class.new(defendant).serializable_hash }
+
+  let(:defendant) do
+    instance_double("Defendant",
+                    id: "UUID",
+                    name: "John Doe",
+                    date_of_birth: "2012-12-12",
+                    national_insurance_number: "XW858621B",
+                    arrest_summons_number: "MG25A11223344",
+                    maat_reference: "123123",
+                    representation_order_date: "2020-12-12",
+                    offence_ids: %w[55555],
+                    defence_organisation_id: "88888",
+                    prosecution_case_id: "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+                    post_hearing_custody_statuses: %w[A])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:name]).to eq("John Doe") }
+    it { expect(attribute_hash[:date_of_birth]).to eq("2012-12-12") }
+    it { expect(attribute_hash[:national_insurance_number]).to eq("XW858621B") }
+    it { expect(attribute_hash[:arrest_summons_number]).to eq("MG25A11223344") }
+    it { expect(attribute_hash[:maat_reference]).to eq("123123") }
+    it { expect(attribute_hash[:representation_order_date]).to eq("2020-12-12") }
+    it { expect(attribute_hash[:prosecution_case_id]).to eq("5edd67eb-9d8c-44f2-a57e-c8d026defaa4") }
+    it { expect(attribute_hash[:post_hearing_custody_statuses]).to eq(%w[A]) }
+  end
+
+  context "with relationships" do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:offences][:data]).to eq([{ id: "55555", type: :offences }]) }
+    it { expect(relationship_hash[:defence_organisation][:data]).to eq({ id: "88888", type: :defence_organisations }) }
+    it { expect(relationship_hash[:prosecution_case][:data]).to eq({ id: "5edd67eb-9d8c-44f2-a57e-c8d026defaa4", type: :prosecution_case }) }
+  end
+end

--- a/spec/serializers/api/internal/v2/hearing_event_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_event_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::HearingEventSerializer do
+  subject(:serializable_hash) { described_class.new(hearing_event).serializable_hash }
+
+  let(:hearing_event) do
+    instance_double("HearingEvent",
+                    id: "UUID",
+                    description: "Hearing type changed to Plea",
+                    occurred_at: "2020-04-30T16:17:58.610Z")
+  end
+
+  context "with data" do
+    subject(:data) { serializable_hash[:data] }
+
+    it { is_expected.to include(id: "UUID") }
+    it { is_expected.to include(type: :hearing_events) }
+    it { is_expected.to have_key(:attributes) }
+  end
+
+  context "with data attributes" do
+    subject(:data_attributes) { serializable_hash[:data][:attributes] }
+
+    it { expect(data_attributes[:description]).to eq("Hearing type changed to Plea") }
+    it { expect(data_attributes[:occurred_at]).to eq("2020-04-30T16:17:58.610Z") }
+  end
+end

--- a/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::HearingSerializer do
+  subject { described_class.new(hearing).serializable_hash }
+
+  let(:hearing) do
+    instance_double("Hearing",
+                    id: "UUID",
+                    court_name: "Bexley Court",
+                    hearing_type: "Committal for Sentencing",
+                    hearing_days: %w[2020-02-01],
+                    defendant_names: ["Treutel", "Alfredine Parker"],
+                    hearing_event_ids: %w[HEARING_EVENT_UUID],
+                    judge_names: ["Mr Recorder J Patterson"],
+                    prosecution_advocate_names: ["John Rob"],
+                    defence_advocate_names: ["Neil Griffiths"],
+                    provider_ids: %w[PROVIDER_UUID],
+                    cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:court_name]).to eq("Bexley Court") }
+    it { expect(attribute_hash[:hearing_type]).to eq("Committal for Sentencing") }
+    it { expect(attribute_hash[:defendant_names]).to eq(["Treutel", "Alfredine Parker"]) }
+    it { expect(attribute_hash[:judge_names]).to eq(["Mr Recorder J Patterson"]) }
+    it { expect(attribute_hash[:prosecution_advocate_names]).to eq(["John Rob"]) }
+    it { expect(attribute_hash[:defence_advocate_names]).to eq(["Neil Griffiths"]) }
+    it { expect(attribute_hash[:hearing_days]).to eq(%w[2020-02-01]) }
+  end
+
+  context "with relationships" do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_events }]) }
+    it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :providers }]) }
+  end
+
+  context "with required fields only" do
+    let(:hearing_data) { JSON.parse(file_fixture("hearing/required_fields.json").read).deep_symbolize_keys }
+    let(:hearing) { Hearing.new(body: hearing_data) }
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:court_name]).to eq("Warrington CCU (Decom)") }
+    it { expect(attribute_hash[:hearing_type]).to eql("Mention - Defendant to Attend (MDA)") }
+    it { expect(attribute_hash[:defendant_names]).to eq([]) }
+    it { expect(attribute_hash[:judge_names]).to eq([]) }
+    it { expect(attribute_hash[:prosecution_advocate_names]).to eq([]) }
+    it { expect(attribute_hash[:defence_advocate_names]).to eq([]) }
+    it { expect(attribute_hash[:hearing_days]).to eq([]) }
+  end
+end

--- a/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
   context "with relationships" do
     let(:relationship_hash) { subject[:data][:relationships] }
 
-    it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_events }]) }
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :providers }]) }
   end
 

--- a/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::HearingSummarySerializer do
+  subject { described_class.new(hearing_summary).serializable_hash }
+
+  let(:hearing_summary) do
+    instance_double("HearingSummary",
+                    id: "UUID",
+                    hearing_type: "Committal for Sentencing",
+                    hearing_days: %w[2020-02-01])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:hearing_type]).to eq("Committal for Sentencing") }
+    it { expect(attribute_hash[:hearing_days]).to eq(%w[2020-02-01]) }
+  end
+end

--- a/spec/serializers/api/internal/v2/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/offence_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::OffenceSerializer do
+  subject { described_class.new(offence).serializable_hash }
+
+  let(:offence) do
+    instance_double("Offence",
+                    id: "UUID",
+                    code: "AA06001",
+                    order_index: "0",
+                    title: "Fail to wear protective clothing",
+                    legislation: "Offences against the Person Act 1861 s.24",
+                    mode_of_trial: "Indictable-Only Offence",
+                    mode_of_trial_reasons: [{ description: "Court directs trial by jury", code: "5" }],
+                    pleas: %w[GUILTY NOT_GUILTY])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:code]).to eq("AA06001") }
+    it { expect(attribute_hash[:order_index]).to eq("0") }
+    it { expect(attribute_hash[:title]).to eq("Fail to wear protective clothing") }
+    it { expect(attribute_hash[:legislation]).to eq("Offences against the Person Act 1861 s.24") }
+    it { expect(attribute_hash[:mode_of_trial]).to eq("Indictable-Only Offence") }
+    it { expect(attribute_hash[:mode_of_trial_reasons]).to eq([{ description: "Court directs trial by jury", code: "5" }]) }
+    it { expect(attribute_hash[:pleas]).to eq(%w[GUILTY NOT_GUILTY]) }
+  end
+end

--- a/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::ProsecutionCaseSerializer do
+  subject { described_class.new(prosecution_case).serializable_hash }
+
+  let(:prosecution_case) do
+    instance_double("ProsecutionCase",
+                    id: "UUID",
+                    prosecution_case_reference: "AAA",
+                    defendant_ids: %w[DEFENDANT-UUID],
+                    hearing_ids: %w[HEARING-UUID],
+                    hearing_summary_ids: %w[HEARING-UUID])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:prosecution_case_reference]).to eq("AAA") }
+  end
+
+  context "with relationships" do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
+    it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
+    it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
+  end
+end

--- a/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
@@ -23,6 +23,5 @@ RSpec.describe Api::Internal::V2::ProsecutionCaseSerializer do
 
     it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
     it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
-    it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
   end
 end

--- a/spec/serializers/api/internal/v2/provider_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/provider_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::ProviderSerializer do
+  subject(:serializable_hash) { described_class.new(provider).serializable_hash }
+
+  let(:provider) do
+    instance_double("Provider",
+                    id: "PROVIDER_UUID",
+                    name: "Neil Griffiths",
+                    role: "Junior counsel")
+  end
+
+  context "with data" do
+    subject(:data) { serializable_hash[:data] }
+
+    it { is_expected.to include(id: "PROVIDER_UUID") }
+    it { is_expected.to include(type: :providers) }
+    it { is_expected.to have_key(:attributes) }
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { serializable_hash[:data][:attributes] }
+
+    it { expect(attribute_hash[:name]).to eq("Neil Griffiths") }
+    it { expect(attribute_hash[:role]).to eq("Junior counsel") }
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -48,6 +48,41 @@ RSpec.configure do |config|
         },
       },
     },
+    "v2/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "Court Data Adaptor",
+        description: "CDA exposes API endpoints to the LAA's View Court Data and
+                      MAAT/MLRA applications and the HMCTS Common Platform in order to
+                      exchange criminal court data between the two organisations.",
+        version: "v1",
+      },
+      paths: {},
+      components: {
+        securitySchemes: {
+          oAuth: {
+            in: :header,
+            type: :oauth2,
+            description: "OAuth2 client credentials flow",
+            flows: {
+              clientCredentials: {
+                scopes: [],
+                tokenUrl: "/oauth/token",
+              },
+            },
+          },
+        },
+        parameters: {
+          transaction_id_header: {
+            type: :uuid,
+            name: "Laa-Transaction-Id",
+            in: :header,
+            required: false,
+            description: "A unique identifier for an individual request that can be traced across multiple systems",
+          },
+        },
+      },
+    },
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/swagger/v2/defence_organisation.json
+++ b/swagger/v2/defence_organisation.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "DefenceOrganisations",
+  "description": "DefenceOrganisations",
+  "id": "defence_organisation",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defence_organisation known internally as laa_contract_number",
+      "type": "string"
+    },
+    "type": {
+      "description": "The defence_organisations type",
+      "enum": [
+        "defence_organisations"
+      ],
+      "example": "defence_organisations",
+      "type": "string"
+    },
+    "name": {
+      "readOnly": true,
+      "example": "The Johnson Partnership",
+      "type": "string"
+    },
+    "address1": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "address2": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "address3": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "address4": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "address5": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "postcode": {
+      "readOnly": true,
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "defence_organisation.json#/definitions/id"
+    },
+    "resource": {
+      "description": "object representing a single defence_organisation",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "address1": {
+          "$ref": "#/definitions/address1"
+        },
+        "address2": {
+          "$ref": "#/definitions/address2"
+        },
+        "address3": {
+          "$ref": "#/definitions/address3"
+        },
+        "address4": {
+          "$ref": "#/definitions/address4"
+        },
+        "address5": {
+          "$ref": "#/definitions/address5"
+        },
+        "postcode": {
+          "$ref": "#/definitions/postcode"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing defence_organisation.",
+      "href": "/defence_organisations/{(defence_organisation.json%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "name": {
+      "$ref": "defence_organisation.json#/definitions/name"
+    },
+    "address1": {
+      "$ref": "defence_organisation.json#/definitions/address1"
+    },
+    "address2": {
+      "$ref": "defence_organisation.json#/definitions/address2"
+    },
+    "address3": {
+      "$ref": "defence_organisation.json#/definitions/address3"
+    },
+    "address4": {
+      "$ref": "defence_organisation.json#/definitions/address4"
+    },
+    "address5": {
+      "$ref": "defence_organisation.json#/definitions/address5"
+    },
+    "postcode": {
+      "$ref": "defence_organisation.json#/definitions/postcode"
+    }
+  }
+}

--- a/swagger/v2/defendant.json
+++ b/swagger/v2/defendant.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defendants",
+  "description": "Defendants",
+  "id": "defendant",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defendant",
+      "example": "61b1f98c-f58e-46ab-bde8-f09ad92df927",
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The defendants type",
+      "enum": [
+        "defendants"
+      ],
+      "example": "defendants",
+      "type": "string"
+    },
+    "name": {
+      "readOnly": true,
+      "example": "Alfredine",
+      "description": "The full name when the defendant is a person",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "date_of_birth": {
+      "readOnly": true,
+      "example": "1971-05-12",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "The person date of birth when the defendant is a person",
+          "example": "1954-02-23",
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      ]
+    },
+    "nino": {
+      "readOnly": true,
+      "example": "BN102966C",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "National Insurance Number for a person",
+          "type": "string",
+          "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
+        }
+      ]
+    },
+    "maat_reference": {
+      "example": 314159265,
+      "description": "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings",
+      "anyOf":[
+        {
+          "$ref": "laa_reference.json#/definitions/maat_reference"
+        },{
+          "type": "null"
+        }
+      ]
+    },
+    "user_name": {
+      "example": "example-username",
+      "description": "The user_name of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
+    "unlink_reason_code": {
+      "example": 1,
+      "description": "Id of the reason for unlinking the case",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 7
+    },
+    "unlink_other_reason_text": {
+      "example": "Linked to incorrect case",
+      "description": "Text describing a reason for unlinking the case when code is 7/other",
+      "type": "string"
+    },
+    "representation_order_date": {
+      "readOnly": true,
+      "example": "1971-05-12",
+      "type": "date"
+    },
+    "resource": {
+      "description": "object representing a single defendant",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "date_of_birth": {
+          "$ref": "#/definitions/date_of_birth"
+        },
+        "national_insurance_number": {
+          "$ref": "#/definitions/nino"
+        },
+        "maat_reference": {
+          "$ref": "#/definitions/maat_reference"
+        },
+        "arrest_summons_number": {
+          "$ref": "prosecution_case.json#/definitions/arrest_summons_number"
+        },
+        "representation_order_date": {
+          "$ref": "#/definitions/representation_order_date"
+        }
+      }
+    },
+    "resource_to_unlink": {
+      "description": "object representing a single laa_reference to be unlinked",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "user_name": {
+              "$ref": "#/definitions/user_name"
+            },
+            "unlink_reason_code": {
+              "$ref": "#/definitions/unlink_reason_code"
+            },
+            "unlink_other_reason_text": {
+              "$ref": "#/definitions/unlink_other_reason_text"
+            }
+          }
+        }
+      }
+    }
+  },
+  "relationships": {
+    "type": "object",
+    "properties": {
+      "offences": {
+        "$ref": "#/definitions/offence_relationship"
+      },
+      "defence_organisation": {
+        "$ref": "#/definitions/defence_organisation_relationship"
+      }
+    }
+  },
+  "offence_relationship": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "items": {
+          "$ref": "#/definitions/offence"
+        },
+        "type": "array"
+      }
+    }
+  },
+  "offence": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "offence.json#/definitions/id"
+      },
+      "type": {
+        "$ref": "offence.json#/definitions/type"
+      }
+    }
+  },
+  "defence_organisation_relationship": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "defence_organisation.json#/definitions/id"
+      },
+      "type": {
+        "$ref": "defence_organisation.json#/definitions/type"
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing defendant.",
+      "href": "/defendants/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "#/definitions/resource"
+      }
+    },
+    {
+      "description": "Unlink a defendant's LaaReference.",
+      "href": "/defendants/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "PATCH",
+      "rel": "empty",
+      "title": "Patch",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/resource_to_unlink"
+          }
+        }
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+
+    }
+  ],
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/name"
+    },
+    "date_of_birth": {
+      "$ref": "#/definitions/date_of_birth"
+    },
+    "national_insurance_number": {
+      "$ref": "#/definitions/nino"
+    },
+    "maat_reference": {
+      "$ref": "#/definitions/maat_reference"
+    },
+    "arrest_summons_number": {
+      "$ref": "prosecution_case.json#/definitions/arrest_summons_number"
+    }
+  }
+}

--- a/swagger/v2/hearing.json
+++ b/swagger/v2/hearing.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Hearing",
+  "description": "Hearing",
+  "id": "hearing",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of a hearing",
+      "example": "04180ff1-99b0-40b7-9929-ca05bdc767d8",
+      "format": "uuid",
+      "type": "string"
+    },
+    "jurisdictionType": {
+      "description": "The court type",
+      "enum": [
+        "MAGISTRATES",
+        "CROWN"
+      ],
+      "example": "MAGISTRATES",
+      "type": "string"
+    },
+    "courtCentre": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique id of the court",
+          "example": "dd9bf969-f55e-43f1-a08a-7b475a9aa914",
+          "format": "uuid",
+          "type": "string"
+        }
+      }
+    },
+    "type": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique id of the hearing type",
+          "example": "141c74ad-b87e-4756-8908-1642b1771ab5",
+          "format": "uuid",
+          "type": "string"
+          },
+        "description": {
+          "description": "Description of the hearing type",
+          "example": "First hearing",
+          "type": "string"
+          },
+        "code": {
+          "description": "Code for the hearing type",
+          "example": "FHG",
+          "type": "string"
+        }
+      }
+    },
+    "hearingDay": {
+      "type": "object",
+      "properties": {
+        "sittingDay": {
+          "description": "The date and time the hearing was held",
+          "example": "2018-10-24 10:00:00",
+          "format": "date-time",
+          "type": "string"
+        },
+        "listingSequence": {
+          "description": "Sequence number for the hearing",
+          "example": 1,
+          "type": "number"
+        },
+        "listedDurationMinutes": {
+          "description": "Duration of the hearing in minutes",
+          "example": 120,
+          "type": "number"
+        }
+      }
+    }
+  },
+  "required": [
+    "id",
+    "jurisdictionType",
+    "courtCentre",
+    "type",
+    "hearingDays"
+  ]
+}

--- a/swagger/v2/hearing_resulted.json
+++ b/swagger/v2/hearing_resulted.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "HearingResulted",
+  "description": "HearingResulted",
+  "id": "hearing-resulted",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "sharedTime": {
+      "description": "The date and time the hearing result was shared with the LAA",
+      "example": "2018-10-25 11:30:00",
+      "format": "date-time",
+      "type": "string"
+    },
+    "hearing": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "hearing.json#/definitions/id"
+        },
+        "jurisdictionType": {
+          "$ref": "hearing.json#/definitions/jurisdictionType"
+        },
+        "courtCentre": {
+          "$ref": "hearing.json#/definitions/courtCentre"
+        },
+        "type": {
+          "$ref": "hearing.json#/definitions/type"
+        },
+        "hearingDays": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "hearing.json#/definitions/hearingDay"
+          }
+        }
+      }
+    },
+    "new_resource": {
+      "description": "object representing a single hearing_resulted",
+      "type": "object",
+      "properties": {
+        "hearing": {
+          "$ref": "#/definitions/hearing"
+        },
+        "sharedTime": {
+          "$ref": "#/definitions/sharedTime"
+        }
+      }
+    }
+  },
+  "required": [
+    "hearing",
+    "sharedTime"
+  ]
+}

--- a/swagger/v2/hearing_summary.json
+++ b/swagger/v2/hearing_summary.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Hearing Summary",
+  "description": "Hearing Summary",
+  "id": "hearing_summary",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of hearing_summary",
+      "example": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The hearing_summaries type",
+      "enum": [
+        "hearing_summaries"
+      ],
+      "example": "hearing_summaries",
+      "type": "string"
+    },
+    "hearing_type": {
+      "readOnly": true,
+      "example": "First hearing",
+      "description": "A description of the hearing type",
+      "type": "string"
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "hearing_days": {
+      "readOnly": true,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/hearing_day"
+      }
+    },
+    "hearing_day": {
+      "example": "2020-04-07T09:00:00Z",
+      "description": "The sitting day of the hearing",
+      "type": "string"
+    },
+    "resource": {
+      "description": "object representing a single hearing_summary",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "hearing_type": {
+          "$ref": "#/definitions/hearing_type"
+        },
+        "hearing_days": {
+          "$ref": "#/definitions/hearing_days"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing hearing_summary.",
+      "href": "/hearing_summaries/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "hearing_type": {
+      "$ref": "#/definitions/hearing_type"
+    },
+    "hearing_days": {
+      "$ref": "#/definitions/hearing_days"
+    }
+  }
+}

--- a/swagger/v2/laa_reference.json
+++ b/swagger/v2/laa_reference.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "LaaReferences",
+  "description": "LaaReferences",
+  "id": "laa_reference",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of laa_reference",
+      "readOnly": true,
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The laa_references type",
+      "enum": [
+        "laa_references"
+      ],
+      "example": "laa_references",
+      "type": "string"
+    },
+    "user_name": {
+      "example": "example-username",
+      "description": "The user_name of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
+    "maat_reference": {
+      "example": 314159265,
+      "description": "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 999999999
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "new_resource": {
+      "description": "object representing a single laa_reference",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationships"
+        }
+      }
+    },
+    "user_name": {
+      "example": "example-username",
+      "description": "The user_name of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
+    "unlink_reason_code": {
+      "example": 1,
+      "description": "Id of the reason for unlinking the case",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 7
+    },
+    "unlink_other_reason_text": {
+      "example": "Linked to incorrect case",
+      "description": "Text describing a reason for unlinking the case when code is 7/other",
+      "type": "string"
+    },
+    "unlink": {
+      "description": "object representing unlinking data",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "user_name": {
+              "$ref": "#/definitions/user_name"
+            },
+            "unlink_reason_code": {
+              "$ref": "#/definitions/unlink_reason_code"
+            },
+            "unlink_other_reason_text": {
+              "$ref": "#/definitions/unlink_other_reason_text"
+            }
+          }
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "maat_reference": {
+          "$ref": "#/definitions/maat_reference"
+        },
+        "user_name": {
+          "$ref": "#/definitions/user_name"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defendant": {
+          "$ref": "#/definitions/defendant_relationship"
+        }
+      }
+    },
+    "defendant_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/defendant",
+          "type": "object"
+        }
+      }
+    },
+    "defendant": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defendant.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defendant.json#/definitions/type"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Create a new LaaReference.",
+      "href": "laa_reference.json",
+      "method": "POST",
+      "rel": "empty",
+      "title": "Create",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/new_resource"
+          }
+        }
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+    },
+    {
+      "description": "Destroy a defendant's LaaReference.",
+      "href": "/laa_references/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "DELETE",
+      "rel": "empty",
+      "title": "Destroy",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/unlink"
+          }
+        }
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+
+    }
+  ],
+  "properties": {
+    "maat_reference": {
+      "$ref": "#/definitions/maat_reference"
+    },
+    "user_name": {
+      "$ref": "#/definitions/user_name"
+    }
+  }
+}

--- a/swagger/v2/oauth.json
+++ b/swagger/v2/oauth.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "title": "OAuth endpoints",
+  "description": "Endpoints for authentication via OAuth",
+  "id": "oauth",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "auth_success_response": {
+      "description": "Successful Response",
+      "type": "object",
+      "properties": {
+        "access_token": {
+          "example": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+          "description": "Token that can be used to make authenticated requests",
+          "type": "string"
+        },
+        "token_type": {
+          "example": "Bearer",
+          "enum": [
+            "Bearer"
+          ],
+          "description": "Type of token",
+          "type": "string"
+        },
+        "expires_in": {
+          "example": 7200,
+          "description": "Duration of the token validity",
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "when the token was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Request a new access token.",
+      "href": "/oauth/token",
+      "method": "POST",
+      "rel": "create",
+      "schema": {
+        "description": "Params to request a new access token",
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "description": "Grant type for the oauth token request.",
+            "enum": [
+              "client_credentials"
+            ],
+            "example": "client_credentials",
+            "type": "string"
+          },
+          "client_id": {
+            "example": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+            "description": "Client id for authentication",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU",
+            "description": "Client secret for authentication",
+            "type": "string"
+          }
+        },
+        "required": [
+          "grant_type",
+          "client_id",
+          "client_secret"
+        ]
+      },
+      "http_header": {
+        "Content-Type": "application/json"
+      },
+      "targetSchema": {
+        "$ref": "oauth.json#/definitions/auth_success_response"
+      },
+      "title": "authentication"
+    }
+  ]
+}

--- a/swagger/v2/offence.json
+++ b/swagger/v2/offence.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Offences",
+  "description": "Offences",
+  "id": "offence",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of offence",
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The offences type",
+      "enum": [
+        "offences"
+      ],
+      "example": "offences",
+      "type": "string"
+    },
+    "code": {
+      "readOnly": true,
+      "example": "AA06001",
+      "description": "The offence code",
+      "type": "string"
+    },
+    "order_index": {
+      "readOnly": true,
+      "example": 0,
+      "description": "The offence sequence provided by the police",
+      "type": "integer",
+      "minimum": 0
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "title": {
+      "readOnly": true,
+      "example": "Fail to wear protective clothing",
+      "description": "The offence title",
+      "type": "string"
+    },
+    "legislation": {
+      "readOnly": true,
+      "example": "Offences against the Person Act 1861 s.24",
+      "description": "The offence legislation from reference data",
+      "type": "string"
+    },
+    "mode_of_trial_reasons": {
+      "readOnly": true,
+      "items": {
+        "$ref": "#/definitions/mode_of_trial_reason"
+      },
+      "type": "array"
+    },
+    "mode_of_trial_reason": {
+      "readOnly": true,
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "pleas": {
+      "readOnly": true,
+      "items": {
+        "$ref": "#/definitions/plea"
+      },
+      "type": "array"
+    },
+    "plea": {
+      "readOnly": true,
+      "description": "The defendant's plea for a specific offence",
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "example": "GUILTY",
+          "enum": [
+            "NO_PLEA_CROWN",
+            "GUILTY",
+            "NOT_GUILTY",
+            "CHANGE_TO_NOT_GUILTY",
+            "ADMITS_CROWN",
+            "DENIES_CROWN",
+            "GUILTY_LESSER_OFFENCE_NAMELY",
+            "GUILTY_TO_ALTERNATIVE_OFFENCE",
+            "CHANGE_TO_GUILTY_AFTER_SWORN",
+            "CHANGE_TO_GUILTY_NO JURY",
+            "AUTREFOIS_ACQUIT",
+            "AUTREFOIS_CONVICT",
+            "PARDON"
+          ]
+        },
+        "pleaded_at": {
+          "readOnly": true,
+          "description": "The date the defendant entered the plea",
+          "example": "2020-02-01",
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      }
+    },
+    "resource": {
+      "description": "object representing a single offence",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/code"
+        },
+        "order_index": {
+          "$ref": "#/definitions/order_index"
+        },
+        "mode_of_trial_reasons": {
+          "$ref": "#/definitions/mode_of_trial_reasons"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "legislation": {
+          "$ref": "#/definitions/legislation"
+        },
+        "pleas": {
+          "$ref": "#/definitions/pleas"
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "description": "Info for existing offence.",
+      "href": "/offences/{(%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info",
+      "targetSchema": {
+        "$ref": "#/definitions/resource"
+      }
+    }
+  ],
+  "properties": {
+    "code": {
+      "$ref": "#/definitions/code"
+    },
+    "order_index": {
+      "$ref": "#/definitions/order_index"
+    },
+    "mode_of_trial_reasons": {
+      "$ref": "#/definitions/mode_of_trial_reasons"
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "legislation": {
+      "$ref": "#/definitions/legislation"
+    },
+    "pleas": {
+      "$ref": "#/definitions/pleas"
+    }
+  }
+}

--- a/swagger/v2/prosecution_case.json
+++ b/swagger/v2/prosecution_case.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Prosecution case search results",
+  "description": "Prosecution case search results",
+  "id": "prosecution_case",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "resource": {
+      "description": "object representing a single prosecution case",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationships"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defendants": {
+          "$ref": "#/definitions/defendant_relationship"
+        },
+        "hearing_summaries": {
+          "$ref": "#/definitions/hearing_summary_relationship"
+        }
+      }
+    },
+    "defendant_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/defendant"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defendant": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defendant.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defendant.json#/definitions/type"
+        }
+      }
+    },
+    "hearing_summary_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/hearing_summary"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "hearing_summary": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "hearing_summary.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "hearing_summary.json#/definitions/type"
+        }
+      }
+    },
+    "resource_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/resource"
+          },
+          "type": "array"
+        },
+        "included": {
+          "items": {
+            "anyOf":[
+              {
+                "$ref": "defendant.json#/definitions/resource"
+              },
+              {
+                "$ref": "offence.json#/definitions/resource"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "prosecution_case_reference": {
+          "$ref": "#/definitions/prosecution_case_reference"
+        }
+      }
+    },
+    "id": {
+      "description": "Unique identifier of prosecution case provided by HMCTS (prosecutionCaseId)",
+      "readOnly": true,
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The prosecution cases type",
+      "enum": [
+        "prosecution_cases"
+      ],
+      "example": "prosecution_cases",
+      "type": "string"
+    },
+    "arrest_summons_number": {
+      "readOnly": true,
+      "description": "The police arrest summons number when the defendant is a person",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "example": "MG25A11223344"
+        }
+      ]
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "date_of_next_hearing": {
+      "description": "The date of the next hearing for the defendant",
+      "example": "2025-05-04",
+      "readOnly": true,
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+        }
+      ]
+    },
+    "prosecution_case_reference": {
+      "readOnly": true,
+      "example": "TFL12345",
+      "description": "The prosecuting authorities reference for their prosecution case that is layed before court.  For example PTI-URN from police/cps cases",
+      "type": "string"
+    },
+    "prosecution_case_search": {
+      "description": "Search query parameters",
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "prosecution_case_reference": {
+              "$ref": "#/definitions/prosecution_case_reference"
+            }
+          }
+        },
+        {
+          "properties": {
+            "national_insurance_number": {
+              "$ref": "defendant.json#/definitions/nino"
+            }
+          }
+        },
+        {
+          "properties": {
+            "arrest_summons_number": {
+              "$ref": "#/definitions/arrest_summons_number"
+            }
+          }
+        },
+        {
+          "properties": {
+            "name": {
+              "$ref": "defendant.json#/definitions/name"
+            },
+            "date_of_birth": {
+              "$ref": "defendant.json#/definitions/date_of_birth"
+            }
+          }
+        },
+        {
+          "properties": {
+            "name": {
+              "$ref": "defendant.json#/definitions/name"
+            },
+            "date_of_next_hearing": {
+              "$ref": "#/definitions/date_of_next_hearing"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "links": [
+    {
+      "description": "Search prosecution cases.",
+      "href": "/api/internal/v1/prosecution_cases",
+      "method": "GET",
+      "rel": "instances",
+      "title": "List",
+      "schema": {
+        "properties": {
+          "filter": {
+            "$ref": "#/definitions/prosecution_case_search"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prosecution_case"
+        ]
+      },
+      "targetSchema": {
+        "$ref": "#/definitions/resource_collection"
+      },
+      "http_header": {
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer <TOKEN>"
+      }
+    }
+  ],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/resource"
+    }
+  }
+}

--- a/swagger/v2/representation_order.json
+++ b/swagger/v2/representation_order.json
@@ -1,0 +1,294 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "RepresentationOrders",
+  "description": "RepresentationOrders",
+  "id": "representation_order",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "date_pattern": {
+      "example": "2020-12-12",
+      "type": "string",
+      "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+    },
+    "uk_gov_post_code": {
+      "description": "UK Gov post code validation following CJS Data Standards",
+      "type": "string",
+      "pattern": "^(([gG][iI][rR] {0,}0[aA]{2})|(([aA][sS][cC][nN]|[sS][tT][hH][lL]|[tT][dD][cC][uU]|[bB][bB][nN][dD]|[bB][iI][qQ][qQ]|[fF][iI][qQ][qQ]|[pP][cC][rR][nN]|[sS][iI][qQ][qQ]|[iT][kK][cC][aA]) {0,}1[zZ]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yxA-HK-XY]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) [0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$",
+      "maxLength": 8
+    },
+    "phone": {
+      "type": "string",
+      "pattern": "^[\\+]?[0-9()\\-\\.\\s]+$"
+    },
+    "email": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
+    },
+    "id": {
+      "description": "unique identifier of representation_order",
+      "readOnly": true,
+      "format": "uuid",
+      "type": [
+        "string"
+      ]
+    },
+    "type": {
+      "description": "The representation_orders type",
+      "enum": [
+        "representation_orders"
+      ],
+      "example": "representation_orders",
+      "type": "string"
+    },
+    "maat_reference": {
+      "example": 314159265,
+      "description": "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 999999999
+    },
+    "status_code": {
+      "example": "GR",
+      "description": "The status of the application that aligns to the reference data",
+      "type": "string",
+      "enum": ["AP", "FB", "FJ", "FM", "WD", "G2", "GQ", "GR"]
+    },
+    "status_date": {
+      "description": "The date that the status was recorded",
+      "$ref": "#/definitions/date_pattern"
+    },
+    "effective_start_date": {
+      "description": "The start date for legal aid",
+      "$ref": "#/definitions/date_pattern"
+    },
+    "effective_end_date": {
+      "description": "The end date for legal aid",
+      "$ref": "#/definitions/date_pattern"
+    },
+    "defence_organisation": {
+      "type": "object",
+      "properties": {
+        "organisation": {
+          "description": "The organisation details",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the organisation",
+              "type": "string"
+            },
+            "incorporation_number": {
+              "description": "The incorporation details of teh organisationorganisation",
+              "type": "string"
+            },
+            "registered_charity_number": {
+              "description": "The registered charity details",
+              "type": "string"
+            },
+            "address": {
+              "description": "The organisation address details",
+              "type": "object",
+              "properties": {
+                "address1": {
+                  "description": "The address1",
+                  "type": "string"
+                },
+                "address2": {
+                  "description": "The address2",
+                  "type": "string"
+                },
+                "address3": {
+                  "description": "The address3",
+                  "type": "string"
+                },
+                "address4": {
+                  "description": "The address4",
+                  "type": "string"
+                },
+                "address5": {
+                  "description": "The address5",
+                  "type": "string"
+                },
+                "postcode": {
+                  "description": "The post code",
+                  "$ref": "#/definitions/uk_gov_post_code"
+                }
+              },
+              "required": [
+                "address1"
+              ]
+            },
+            "contact": {
+              "description": "The organisation contact details",
+              "type": "object",
+              "properties": {
+                "home": {
+                  "description": "The home telephone number",
+                  "$ref": "#/definitions/phone"
+                },
+                "work": {
+                  "description": "The work telephone number is free format to allow the specification of extensions, etc",
+                  "type": "string"
+                },
+                "mobile": {
+                  "description": "The mobile number",
+                  "$ref": "#/definitions/phone"
+                },
+                "primary_email": {
+                  "description": "The primary email address",
+                  "$ref": "#/definitions/email"
+                },
+                "secondary_email": {
+                  "description": "The secondary email address",
+                  "$ref": "#/definitions/email"
+                },
+                "fax": {
+                  "description": "The fax number",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        "laa_contract_number": {
+          "description": "When the organisation is a defence organisation that is authorised to conduct legal aid work; the contract reference that firm has with Legal Aid Agency",
+          "type": "string"
+        },
+        "sra_number": {
+          "description": "When the organisation is a defence organisation, the registration number of that firm with the Solicitors Regulation Authority",
+          "type": "string"
+        },
+        "bar_council_membership_number": {
+          "description": "When the organisation is a defence organisation, the firms membership reference with teh bar council",
+          "type": "string"
+        }
+      },
+      "required": [
+        "organisation",
+        "laa_contract_number"
+      ]
+    },
+    "offence": {
+      "description": "object representing an update to a single offence",
+      "type": "object",
+      "properties": {
+        "offence_id": {
+          "$ref": "offence.json#/definitions/id"
+        },
+        "status_code": {
+          "$ref": "#/definitions/status_code"
+        },
+        "status_date": {
+          "$ref": "#/definitions/status_date"
+        },
+        "effective_start_date": {
+          "$ref": "#/definitions/effective_start_date"
+        },
+        "effective_end_date": {
+          "$ref": "#/definitions/effective_end_date"
+        }
+      },
+      "required": [
+        "offence_id",
+        "status_code",
+        "status_date",
+        "effective_start_date"
+      ]
+    },
+    "identity": {
+      "$ref": "#/definitions/id"
+    },
+    "new_resource": {
+      "description": "object representing a single representation_order",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationships"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "maat_reference": {
+          "$ref": "#/definitions/maat_reference"
+        },
+        "offences": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/offence"
+          }
+        },
+        "defence_organisation": {
+          "$ref": "#/definitions/defence_organisation"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defendant": {
+          "$ref": "#/definitions/defendant_relationship"
+        }
+      }
+    },
+    "defendant_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/defendant",
+          "type": "object"
+        }
+      }
+    },
+    "defendant": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defendant.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defendant.json#/definitions/type"
+        }
+      }
+    }
+  },
+  "links": [{
+    "description": "Create a new LaaReference.",
+    "href": "representation_order.json",
+    "method": "POST",
+    "rel": "empty",
+    "title": "Create",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/new_resource"
+        }
+      }
+    },
+    "http_header": {
+      "Content-Type": "application/vnd.api+json",
+      "Authorization": "Bearer <TOKEN>"
+    }
+  }],
+  "properties": {
+    "maat_reference": {
+      "$ref": "#/definitions/maat_reference"
+    },
+    "defence_organisation": {
+      "$ref": "#/definitions/defence_organisation"
+    }
+  }
+}

--- a/swagger/v2/schema.json
+++ b/swagger/v2/schema.json
@@ -1,0 +1,842 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": [
+    "object"
+  ],
+  "definitions": {
+    "defendant": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Defendants",
+      "description": "Defendants",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of defendant",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The defendants type",
+          "enum": [
+            "defendants"
+          ],
+          "example": "defendants",
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "readOnly": true,
+          "example": "Elaf",
+          "description": "The first name when the defendant is a person",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/defendant/definitions/id"
+        },
+        "date_of_birth": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "The person date of birth when the defendant is a person",
+              "example": "1954-02-23",
+              "type": [
+                "string"
+              ],
+              "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+            }
+          ]
+        },
+        "nino": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "National Insurance Number for a person",
+              "example": "SJ336043A",
+              "type": [
+                "string"
+              ],
+              "pattern": "(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\s*\\d\\s*){6}([A-D]|\\s)$"
+            }
+          ]
+        },
+        "resource": {
+          "description": "object representing a single defendant",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/defendant/definitions/type"
+            },
+            "id": {
+              "$ref": "#/definitions/defendant/definitions/id"
+            },
+            "attributes": {
+              "$ref": "#/definitions/defendant/definitions/attributes"
+            }
+          }
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/defendant/definitions/name"
+            },
+            "date_of_birth": {
+              "$ref": "#/definitions/defendant/definitions/date_of_birth"
+            },
+            "national_insurance_number": {
+              "$ref": "#/definitions/defendant/definitions/nino"
+            },
+            "arrest_summons_number": {
+              "$ref": "#/definitions/prosecution_case/definitions/arrest_summons_number"
+            }
+          }
+        }
+      },
+      "relationships": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "offences": {
+            "$ref": "#/definitions/defendant/definitions/offence_relationship"
+          }
+        }
+      },
+      "offence_relationship": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/definitions/defendant/definitions/offence"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      },
+      "offence": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/definitions/offence/definitions/id"
+          },
+          "type": {
+            "$ref": "#/definitions/offence/definitions/type"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing defendant.",
+          "href": "/defendants/{(%23%2Fdefinitions%2Fdefendant%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "$ref": "#/definitions/defendant/definitions/resource"
+          }
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/defendant/definitions/name"
+        },
+        "date_of_birth": {
+          "$ref": "#/definitions/defendant/definitions/date_of_birth"
+        },
+        "national_insurance_number": {
+          "$ref": "#/definitions/defendant/definitions/nino"
+        },
+        "arrest_summons_number": {
+          "$ref": "#/definitions/prosecution_case/definitions/arrest_summons_number"
+        }
+      }
+    },
+    "laa_reference": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "LaaReferences",
+      "description": "LaaReferences",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of laa_reference",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The laa_references type",
+          "enum": [
+            "laa_references"
+          ],
+          "example": "laa_references",
+          "type": [
+            "string"
+          ]
+        },
+        "maat_reference": {
+          "example": 314159265,
+          "description": "The LAA issued reference to the application. CDA expects a numeric number, although HMCTS allows strings",
+          "type": [
+            "number"
+          ],
+          "minimum": 0,
+          "maximum": 999999999
+        },
+        "identity": {
+          "$ref": "#/definitions/laa_reference/definitions/id"
+        },
+        "new_resource": {
+          "description": "object representing a single laa_reference",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/laa_reference/definitions/type"
+            },
+            "attributes": {
+              "$ref": "#/definitions/laa_reference/definitions/attributes"
+            },
+            "relationships": {
+              "$ref": "#/definitions/laa_reference/definitions/relationships"
+            }
+          }
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "maat_reference": {
+              "$ref": "#/definitions/laa_reference/definitions/maat_reference"
+            }
+          }
+        },
+        "relationships": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "defendant": {
+              "$ref": "#/definitions/laa_reference/definitions/defendant_relationship"
+            }
+          }
+        },
+        "defendant_relationship": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "data": {
+              "items": {
+                "$ref": "#/definitions/laa_reference/definitions/defendant"
+              },
+              "type": [
+                "object"
+              ]
+            }
+          }
+        },
+        "defendant": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/defendant/definitions/id"
+            },
+            "type": {
+              "$ref": "#/definitions/defendant/definitions/type"
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new LaaReference.",
+          "href": "/laa_references",
+          "method": "POST",
+          "rel": "empty",
+          "title": "Create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/definitions/laa_reference/definitions/new_resource"
+              }
+            }
+          },
+          "http_header": {
+            "Content-Type": "application/vnd.api+json",
+            "Authorization": "Bearer <TOKEN>"
+          }
+        }
+      ],
+      "properties": {
+        "maat_reference": {
+          "$ref": "#/definitions/laa_reference/definitions/maat_reference"
+        }
+      }
+    },
+    "oauth": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "OAuth endpoints",
+      "description": "Endpoints for authentication via OAuth",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "auth_success_response": {
+          "description": "Successful Response",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "access_token": {
+              "example": "lV_-FViUsQE2OrYnXQhVyAlzYgIc8Mal8g5YBFGs3J8",
+              "description": "Token that can be used to make authenticated requests",
+              "type": [
+                "string"
+              ]
+            },
+            "token_type": {
+              "example": "Bearer",
+              "enum": [
+                "Bearer"
+              ],
+              "description": "Type of token",
+              "type": [
+                "string"
+              ]
+            },
+            "expires_in": {
+              "example": 7200,
+              "description": "Duration of the token validity",
+              "type": [
+                "integer"
+              ]
+            },
+            "created_at": {
+              "description": "when the token was created",
+              "format": "date-time",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Request a new access token.",
+          "href": "/oauth/token",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "description": "Params to request a new access token",
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "grant_type": {
+                "description": "Grant type for the oauth token request.",
+                "enum": [
+                  "client_credentials"
+                ],
+                "example": "client_credentials",
+                "type": [
+                  "string"
+                ]
+              },
+              "client_id": {
+                "example": "b0e2Uw0F_Hn4uVyxcaL6vas7WkYIdCcldv1uCo_vQAY",
+                "description": "Client id for authentication",
+                "type": [
+                  "string"
+                ]
+              },
+              "client_secret": {
+                "example": "ezLn2UTPVwqSCVYWPGTeVWcgZdRIPQLmdpQaGMHuCcU",
+                "description": "Client secret for authentication",
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "required": [
+              "grant_type",
+              "client_id",
+              "client_secret"
+            ]
+          },
+          "http_header": {
+            "Content-Type": "application/json"
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth/definitions/auth_success_response"
+          },
+          "title": "authentication"
+        }
+      ]
+    },
+    "offence": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Offences",
+      "description": "Offences",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of offence",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The offences type",
+          "enum": [
+            "offences"
+          ],
+          "example": "offences",
+          "type": [
+            "string"
+          ]
+        },
+        "code": {
+          "readOnly": true,
+          "example": "AA06001",
+          "description": "The offence code",
+          "type": [
+            "string"
+          ]
+        },
+        "order_index": {
+          "readOnly": true,
+          "example": 0,
+          "description": "The offence sequence provided by the police",
+          "type": [
+            "integer"
+          ],
+          "minimum": 0
+        },
+        "identity": {
+          "$ref": "#/definitions/offence/definitions/id"
+        },
+        "title": {
+          "readOnly": true,
+          "example": "Fail to wear protective clothing",
+          "description": "The offence title",
+          "type": [
+            "string"
+          ]
+        },
+        "mode_of_trial": {
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "description": "Indicates if the offence is either way, indictable only or summary only",
+              "example": "Indictable-Only Offence",
+              "type": [
+                "string"
+              ]
+            }
+          ]
+        },
+        "resource": {
+          "description": "object representing a single offence",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/offence/definitions/type"
+            },
+            "id": {
+              "$ref": "#/definitions/offence/definitions/id"
+            },
+            "attributes": {
+              "$ref": "#/definitions/offence/definitions/attributes"
+            }
+          }
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "code": {
+              "$ref": "#/definitions/offence/definitions/code"
+            },
+            "order_index": {
+              "$ref": "#/definitions/offence/definitions/order_index"
+            },
+            "mode_of_trial": {
+              "$ref": "#/definitions/offence/definitions/mode_of_trial"
+            },
+            "title": {
+              "$ref": "#/definitions/offence/definitions/title"
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing offence.",
+          "href": "/offences/{(%23%2Fdefinitions%2Foffence%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "$ref": "#/definitions/offence/definitions/resource"
+          }
+        }
+      ],
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/offence/definitions/code"
+        },
+        "order_index": {
+          "$ref": "#/definitions/offence/definitions/order_index"
+        },
+        "mode_of_trial": {
+          "$ref": "#/definitions/offence/definitions/mode_of_trial"
+        },
+        "title": {
+          "$ref": "#/definitions/offence/definitions/title"
+        }
+      }
+    },
+    "prosecution_case": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Prosecution case search results",
+      "description": "Prosecution case search results",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "resource": {
+          "description": "object representing a single prosecution case",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/prosecution_case/definitions/type"
+            },
+            "id": {
+              "$ref": "#/definitions/prosecution_case/definitions/id"
+            },
+            "attributes": {
+              "$ref": "#/definitions/prosecution_case/definitions/attributes"
+            },
+            "relationships": {
+              "$ref": "#/definitions/prosecution_case/definitions/relationships"
+            }
+          }
+        },
+        "relationships": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "defendants": {
+              "$ref": "#/definitions/prosecution_case/definitions/defendant_relationship"
+            }
+          }
+        },
+        "defendant_relationship": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "data": {
+              "items": {
+                "$ref": "#/definitions/prosecution_case/definitions/defendant"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          }
+        },
+        "defendant": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/defendant/definitions/id"
+            },
+            "type": {
+              "$ref": "#/definitions/defendant/definitions/type"
+            }
+          }
+        },
+        "resource_collection": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "data": {
+              "items": {
+                "$ref": "#/definitions/prosecution_case/definitions/resource"
+              },
+              "type": [
+                "array"
+              ]
+            },
+            "included": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/defendant/definitions/resource"
+                  },
+                  {
+                    "$ref": "#/definitions/offence/definitions/resource"
+                  }
+                ]
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        "attributes": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "prosecution_case_reference": {
+              "$ref": "#/definitions/prosecution_case/definitions/prosecution_case_reference"
+            }
+          }
+        },
+        "id": {
+          "description": "Unique identifier of prosecution case provided by HMCTS (prosecutionCaseId)",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The prosecution cases type",
+          "enum": [
+            "prosecution_cases"
+          ],
+          "example": "prosecution_cases",
+          "type": [
+            "string"
+          ]
+        },
+        "arrest_summons_number": {
+          "readOnly": true,
+          "description": "The police arrest summons number when the defendant is a person",
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "example": "MG25A11223344"
+            }
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/prosecution_case/definitions/id"
+        },
+        "date_of_next_hearing": {
+          "description": "The date of the next hearing for the defendant",
+          "readOnly": true,
+          "anyOf": [
+            {
+              "type": [
+                "null"
+              ]
+            },
+            {
+              "example": "1954-02-23",
+              "type": [
+                "string"
+              ],
+              "pattern": "^((([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13578]|1[02])\\-(0[1-9]|[12]\\d|3[01]))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-(0[13456789]|1[012])\\-(0[1-9]|[12]\\d|30))|(([\\+-]?\\d{4}(?!\\d{2}\b))\\-02\\-(0[1-9]|1\\d|2[0-8]))|(((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))\\-02\\-29))$"
+            }
+          ]
+        },
+        "prosecution_case_reference": {
+          "readOnly": true,
+          "example": "05PP1000915",
+          "description": "The prosecuting authorities reference for their prosecution case that is layed before court.  For example PTI-URN from police/cps cases",
+          "type": [
+            "string"
+          ]
+        },
+        "prosecution_case_search": {
+          "description": "Search query parameters",
+          "type": [
+            "object"
+          ],
+          "anyOf": [
+            {
+              "properties": {
+                "prosecution_case_reference": {
+                  "$ref": "#/definitions/prosecution_case/definitions/prosecution_case_reference"
+                }
+              }
+            },
+            {
+              "properties": {
+                "national_insurance_number": {
+                  "$ref": "#/definitions/defendant/definitions/nino"
+                }
+              }
+            },
+            {
+              "properties": {
+                "arrest_summons_number": {
+                  "$ref": "#/definitions/prosecution_case/definitions/arrest_summons_number"
+                }
+              }
+            },
+            {
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/defendant/definitions/name"
+                },
+                "date_of_birth": {
+                  "$ref": "#/definitions/defendant/definitions/date_of_birth"
+                }
+              }
+            },
+            {
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/defendant/definitions/name"
+                },
+                "date_of_next_hearing": {
+                  "$ref": "#/definitions/prosecution_case/definitions/date_of_next_hearing"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Search prosecution cases.",
+          "href": "/api/internal/v1/prosecution_cases",
+          "method": "GET",
+          "rel": "instances",
+          "title": "List",
+          "schema": {
+            "properties": {
+              "filter": {
+                "$ref": "#/definitions/prosecution_case/definitions/prosecution_case_search"
+              }
+            },
+            "type": [
+              "object"
+            ],
+            "required": [
+              "prosecution_case"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/prosecution_case/definitions/resource_collection"
+          },
+          "http_header": {
+            "Content-Type": "application/vnd.api+json",
+            "Authorization": "Bearer <TOKEN>"
+          }
+        }
+      ],
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/prosecution_case/definitions/resource"
+        }
+      }
+    }
+  },
+  "properties": {
+    "defendant": {
+      "$ref": "#/definitions/defendant"
+    },
+    "laa_reference": {
+      "$ref": "#/definitions/laa_reference"
+    },
+    "oauth": {
+      "$ref": "#/definitions/oauth"
+    },
+    "offence": {
+      "$ref": "#/definitions/offence"
+    },
+    "prosecution_case": {
+      "$ref": "#/definitions/prosecution_case"
+    }
+  },
+  "description": "LAA Court Data Adaptor API",
+  "id": "laa-court-data-adaptor-api",
+  "links": [
+    {
+      "href": "https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk",
+      "rel": "self"
+    }
+  ],
+  "title": "LAA Court Data Adaptor API"
+}

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -1,0 +1,311 @@
+---
+openapi: 3.0.1
+info:
+  title: Court Data Adaptor
+  description: |-
+    CDA exposes API endpoints to the LAA's View Court Data and
+                          MAAT/MLRA applications and the HMCTS Common Platform in order to
+                          exchange criminal court data between the two organisations.
+  version: v2
+paths:
+  "/api/external/v2/hearings":
+    post:
+      summary: post hearing
+      description: Post Common Platform hearing data to CDA
+      tags:
+      - External - available to Common Platform
+      security:
+      - oAuth: []
+      parameters: []
+      responses:
+        '202':
+          description: Accepted
+        '422':
+          description: Unprocessable Entity
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": hearing_resulted.json#/definitions/new_resource
+  "/api/internal/v2/defendants/{id}":
+    patch:
+      summary: patch defendant relationships
+      description: Delete an LAA reference from Common Platform case
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: uuid
+        schema:
+          "$ref": defendant.json#/definitions/id
+        description: The unique identifier of the defendant
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": defendant.json#/definitions/resource_to_unlink
+        required: true
+    get:
+      summary: fetch a defendant by ID
+      description: find a defendant where it exists within Court Data Adaptor
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: uuid
+        schema:
+          "$ref": defendant.json#/definitions/id
+        description: The uuid of the defendant
+      - name: include
+        in: query
+        required: false
+        type: string
+        schema: {}
+        description: Return other data through a has_many relationship </br>e.g. include=offences
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Not found
+  "/api/internal/v2/hearings/{id}":
+    get:
+      summary: get hearing
+      description: GET Common Platform hearing data
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: uuid
+        schema:
+          "$ref": hearing.json#/definitions/id
+        description: The uuid of the hearing
+      - name: include
+        in: query
+        required: false
+        type: string
+        schema: {}
+        description: Return other data through a has_many relationship </br>e.g. include=providers
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized
+  "/api/internal/v2/laa_references":
+    post:
+      summary: post laa_reference
+      description: Post an LAA reference to CDA to link a MAAT case to a Common Platform
+        case
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '202':
+          description: Accepted
+        '422':
+          description: Unprocessable entity
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": laa_reference.json#/definitions/new_resource
+  "/api/internal/v2/laa_references/{defendant_id}":
+    delete:
+      summary: delete laa_reference
+      description: Delete an LAA reference from Common Platform case
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: defendant_id
+        in: path
+        required: true
+        type: uuid
+        schema:
+          "$ref": defendant.json#/definitions/id
+        description: The unique identifier of the defendant
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '202':
+          description: Accepted
+        '422':
+          description: Unprocessable Entity
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": laa_reference.json#/definitions/unlink
+        required: true
+  "/api/internal/v2/prosecution_cases":
+    get:
+      summary: search prosecution_cases
+      description: |-
+        Search prosecution cases. Valid search combinations are: <br/><br/>
+                            1) prosecution_case_reference <br/>
+                            2) arrest_summons_number <br/>
+                            3) national_insurance_number <br/>
+                            4) name and date_of_birth <br/>
+                            5) name and date_of_next_hearing
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - name: filter[prosecution_case_reference]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/prosecution_case_reference
+        description: Searches prosecution cases by prosecution case reference
+      - name: include
+        in: query
+        required: false
+        type: string
+        schema: {}
+        description: |-
+          Return defendant and offence data through a has_many relationship </br>
+                                            eg include=defendants,defendants.offences,defendants.defence_organisation
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - name: filter[arrest_summons_number]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/arrest_summons_number
+        description: Searches prosecution cases by arrest summons number
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - name: filter[national_insurance_number]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/nino
+        description: Searches prosecution cases by national_insurance_number
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - name: filter[name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/name
+        description: Searches prosecution cases by name
+      - name: filter[date_of_birth]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/date_of_birth
+        description: Searches prosecution cases by date_of_birth
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - name: filter[name]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": defendant.json#/definitions/name
+        description: Searches prosecution cases by name
+      - name: filter[date_of_next_hearing]
+        in: query
+        required: false
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/definitions/date_of_next_hearing
+        description: Searches prosecution cases by date_of_next_hearing
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": prosecution_case.json#/definitions/resource_collection
+        '401':
+          description: Unauthorized
+  "/api/internal/v2/representation_orders":
+    post:
+      summary: post representation_order
+      description: Post a Representation Order to CDA to update the status on a MAAT
+        case to a Common Platform case
+      tags:
+      - Internal - available to other LAA applications
+      security:
+      - oAuth: []
+      parameters:
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      - "$ref": "#/components/parameters/transaction_id_header"
+      responses:
+        '202':
+          description: Accepted
+        '422':
+          description: Unprocessable entity
+        '401':
+          description: Unauthorized
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              "$ref": representation_order.json#/definitions/new_resource
+        required: true
+components:
+  securitySchemes:
+    oAuth:
+      in: header
+      type: oauth2
+      description: OAuth2 client credentials flow
+      flows:
+        clientCredentials:
+          scopes: []
+          tokenUrl: "/oauth/token"
+  parameters:
+    transaction_id_header:
+      type: uuid
+      name: Laa-Transaction-Id
+      in: header
+      required: false
+      description: A unique identifier for an individual request that can be traced
+        across multiple systems


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-581)

When VCD hits CDA’s prosecution case search endpoint (`GET /api/internal/v1/prosecution_cases`), CDA makes one call to Common Platform API for prosecution case, then one call per prosecution case hearing.

![9f85cf51-23a3-45fe-b024-90b2ba55517f](https://user-images.githubusercontent.com/3141541/115241040-a7bae180-a120-11eb-8748-43de87a72073.png)

This makes VCD case searches unbearably slow for case workers, increases the number of points of failure, and throttling issues due to CP rate limiting.

It is also overreach on CDA’s part to be making multiple requests to Common Platform API. CDA is an adaptor, and as such, it should only be forwarding requests back and forth. It should not be making complementary requests to enrich responses to VCD.

If data is deemed to be missing from a CP endpoint, a change request should be address to HMCTS for this data to be exposed on existing endpoints.

### Solution

Create a new version v2 for CDA’s API, with the same existing endpoints, but where those endpoints return only the data that is offered by HMCTS Common Platform. One request from VCD should translate to one - and one only - request to Common Platform.

![1aaec933-940e-4427-b61d-bb7105c1d4cd](https://user-images.githubusercontent.com/3141541/115241084-b4d7d080-a120-11eb-9ef5-0b282201f8f1.png)

The v1 API endpoints will remain available for some time, ideally the shortest time possible, because the performance issues are crippling.

### Technical details

Some serializers in CDA don’t just format data into JSON, they also make calls to Common Platform to fetch data. Most of the technical work for this ticket involves removing those extra calls.

Here are the known offenders:

`GET /api/internal/v1/prosecution_cases`

https://github.com/ministryofjustice/laa-court-data-adaptor/blob/master/app/models/prosecution_case.rb#L59

`GET /api/internal/v1/hearings/{id}`

https://github.com/ministryofjustice/laa-court-data-adaptor/blob/master/app/models/hearing.rb#L82 

**Resources**

CDA API documentation: https://dev.court-data-adaptor.service.justice.gov.uk/api-docs/index.html.
