### PR TITLE
Update swagger v1

### DIFF
--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "api/internal/v1/laa_references", type: :request, swagger_doc: "v
   end
 
   path "/api/internal/v1/laa_references/{defendant_id}" do
-    delete("laa_reference") do
+    delete("delete laa_reference") do
       description "Delete an LAA reference from Common Platform case"
       consumes "application/json"
       tags "Internal - available to other LAA applications"
@@ -173,7 +173,7 @@ RSpec.describe "api/internal/v1/laa_references", type: :request, swagger_doc: "v
 
         parameter name: :laa_reference, in: :body, required: true, type: :object,
                   schema: {
-                    '$ref': "laa_reference.json#/definitions/resource_to_destroy",
+                    '$ref': "laa_reference.json#/definitions/unlink",
                   },
                   description: "Object containing the user_name, unlink_reason_code and unlink_other_reason_text"
 

--- a/swagger/v1/laa_reference.json
+++ b/swagger/v1/laa_reference.json
@@ -53,8 +53,25 @@
         }
       }
     },
-    "resource_to_destroy": {
-      "description": "object representing a single laa_reference to be destroyed",
+    "user_name": {
+      "example": "example-username",
+      "description": "The user_name of the caseworker linking or unlinking the case",
+      "type": "string"
+    },
+    "unlink_reason_code": {
+      "example": 1,
+      "description": "Id of the reason for unlinking the case",
+      "type": "number",
+      "minimum": 1,
+      "maximum": 7
+    },
+    "unlink_other_reason_text": {
+      "example": "Linked to incorrect case",
+      "description": "Text describing a reason for unlinking the case when code is 7/other",
+      "type": "string"
+    },
+    "unlink": {
+      "description": "object representing unlinking data",
       "type": "object",
       "properties": {
         "type": {
@@ -146,7 +163,7 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/definitions/resource_to_destroy"
+            "$ref": "#/definitions/unlink"
           }
         }
       },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -20,16 +20,12 @@ paths:
       responses:
         '202':
           description: Accepted
-          content: {}
         '422':
           description: Unprocessable Entity
-          content: {}
         '400':
           description: Bad Request
-          content: {}
         '401':
           description: Unauthorized
-          content: {}
       requestBody:
         content:
           application/json:
@@ -57,18 +53,16 @@ paths:
       responses:
         '202':
           description: Accepted
-          content: {}
         '400':
           description: Bad Request
-          content: {}
         '401':
           description: Unauthorized
-          content: {}
       requestBody:
         content:
           application/json:
             schema:
               "$ref": defendant.json#/definitions/resource_to_unlink
+        required: true
     get:
       summary: fetch a defendant by ID
       description: find a defendant where it exists within Court Data Adaptor
@@ -94,10 +88,8 @@ paths:
       responses:
         '200':
           description: Success
-          content: {}
         '404':
           description: Not found
-          content: {}
   "/api/internal/v1/hearings/{id}":
     get:
       summary: get hearing
@@ -125,10 +117,8 @@ paths:
       responses:
         '200':
           description: Success
-          content: {}
         '401':
           description: Unauthorized
-          content: {}
   "/api/internal/v1/laa_references":
     post:
       summary: post laa_reference
@@ -147,13 +137,10 @@ paths:
       responses:
         '202':
           description: Accepted
-          content: {}
-        '400':
-          description: Bad Request
-          content: {}
+        '422':
+          description: Unprocessable entity
         '401':
           description: Unauthorized
-          content: {}
       requestBody:
         content:
           application/json:
@@ -161,7 +148,7 @@ paths:
               "$ref": laa_reference.json#/definitions/new_resource
   "/api/internal/v1/laa_references/{defendant_id}":
     delete:
-      summary: delete a defendant's LAA Reference
+      summary: delete laa_reference
       description: Delete an LAA reference from Common Platform case
       tags:
       - Internal - available to other LAA applications
@@ -181,18 +168,16 @@ paths:
       responses:
         '202':
           description: Accepted
-          content: {}
-        '400':
-          description: Bad Request
-          content: {}
+        '422':
+          description: Unprocessable Entity
         '401':
           description: Unauthorized
-          content: {}
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": laa_reference.json#/definitions/resource_to_unlink
+              "$ref": laa_reference.json#/definitions/unlink
+        required: true
   "/api/internal/v1/prosecution_cases":
     get:
       summary: search prosecution_cases
@@ -280,7 +265,6 @@ paths:
                 "$ref": prosecution_case.json#/definitions/resource_collection
         '401':
           description: Unauthorized
-          content: {}
   "/api/internal/v1/representation_orders":
     post:
       summary: post representation_order
@@ -297,18 +281,16 @@ paths:
       responses:
         '202':
           description: Accepted
-          content: {}
-        '400':
-          description: Bad Request
-          content: {}
+        '422':
+          description: Unprocessable entity
         '401':
           description: Unauthorized
-          content: {}
       requestBody:
         content:
           application/vnd.api+json:
             schema:
               "$ref": representation_order.json#/definitions/new_resource
+        required: true
 components:
   securitySchemes:
     oAuth:


### PR DESCRIPTION
## What

The swagger v1 documentation is out of sync with the spec requests we have, namely the laa reference request specs.

This PR updates the laa reference request specs, the laa_reference schema, and regenerates valid and up-to-date swagger docs with `rake rswag:specs:swaggerize` (which generates swagger docs based on request specs).

Swagger docs visible at `/api-docs`.
