### PR TITLE
Refactor LAA Reference MAAT API message publishing 

### DIFF
--- a/app/models/hmcts_common_platform/hearing_summary.rb
+++ b/app/models/hmcts_common_platform/hearing_summary.rb
@@ -2,8 +2,6 @@ module HmctsCommonPlatform
   class HearingSummary
     attr_accessor :data
 
-    delegate :short_oucode, :oucode_l2_code, to: :court_centre
-
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
     end
@@ -24,6 +22,20 @@ module HmctsCommonPlatform
 
     def court_centre
       HmctsCommonPlatform::CourtCentre.new(data[:courtCentre])
+    end
+
+    def court_centre_short_oucode
+      hmcts_common_platform_reference_court_centre.short_oucode
+    end
+
+    def court_centre_oucode_l2_code
+      hmcts_common_platform_reference_court_centre.oucode_l2_code
+    end
+
+  private
+
+    def hmcts_common_platform_reference_court_centre
+      @hmcts_common_platform_reference_court_centre ||= HmctsCommonPlatform::Reference::CourtCentre.find(court_centre.id)
     end
   end
 end

--- a/app/models/maat_api/laa_reference.rb
+++ b/app/models/maat_api/laa_reference.rb
@@ -1,0 +1,95 @@
+module MaatApi
+  class LaaReference
+    attr_reader :prosecution_case_summary, :defendant_summary, :user_name, :maat_reference
+
+    def initialize(prosecution_case_summary:, defendant_summary:, user_name:, maat_reference:)
+      @prosecution_case_summary = prosecution_case_summary
+      @maat_reference = maat_reference
+      @defendant_summary = defendant_summary
+      @user_name = user_name
+    end
+
+    def case_urn
+      prosecution_case_summary.prosecution_case_reference
+    end
+
+    def defendant_asn
+      defendant_summary.arrest_summons_number
+    end
+
+    def doc_language
+      "EN"
+    end
+
+    def is_active?
+      prosecution_case_summary.case_status == "ACTIVE"
+    end
+
+    def cjs_location
+      nearest_in_time_hearing_summary.short_oucode
+    end
+
+    def cjs_area_code
+      nearest_in_time_hearing_summary.oucode_l2_code
+    end
+
+    def defendant
+      {
+        defendantId: defendant_summary.defendant_id,
+        forename: defendant_summary.first_name,
+        surname: defendant_summary.last_name,
+        dateOfBirth: defendant_summary.date_of_birth,
+        nino: defendant_summary.national_insurance_number,
+        offences: offences_map,
+      }
+    end
+
+    def sessions
+      prosecution_case_summary.hearing_summaries.map do |hearing_summary|
+        {
+          courtLocation: hearing_summary.short_oucode,
+          dateOfHearing: hearing_summary.date_of_hearing&.strftime("%Y-%m-%d"),
+        }
+      end
+    end
+
+  private
+
+    def nearest_in_time_hearing_summary
+      return hearing_summaries_with_hearing_days.max_by(&:hearing_days) if all_hearings_in_past?
+      return hearing_summaries_with_hearing_days.min_by(&:hearing_days) if all_hearings_in_future?
+
+      hearing_summaries_with_hearing_days.reject(&:hearing_in_future?).max_by(&:hearing_days)
+    end
+
+    def hearing_summaries_with_hearing_days
+      prosecution_case_summary.hearing_summaries.reject { |summary| summary.hearing_days.blank? }
+    end
+
+    def all_hearings_in_past?
+      hearing_summaries_with_hearing_days.all? do |hearing_summary|
+        hearing_summary.hearing_days.max&.to_date.past?
+      end
+    end
+
+    def all_hearings_in_future?
+      hearing_summaries_with_hearing_days.all? do |hearing_summary|
+        hearing_summary.hearing_days.max&.to_date.future?
+      end
+    end
+
+    def offences_map
+      defendant_summary.offence_summaries.map do |offence_summary|
+        {
+          offenceId: offence_summary.offence_id,
+          offenceCode: offence_summary.offence_code,
+          asnSeq: offence_summary.order_index,
+          offenceClassification: offence_summary.mode_of_trial,
+          offenceDate: offence_summary.start_date,
+          offenceShortTitle: offence_summary.title,
+          offenceWording: offence_summary.wording,
+        }
+      end
+    end
+  end
+end

--- a/app/models/maat_api/laa_reference_message.rb
+++ b/app/models/maat_api/laa_reference_message.rb
@@ -1,0 +1,24 @@
+module MaatApi
+  class LaaReferenceMessage
+    attr_reader :object
+
+    def initialize(object)
+      @object = object
+    end
+
+    def generate
+      {
+        maatId: object.maat_reference,
+        caseUrn: object.case_urn,
+        asn: object.defendant_asn,
+        cjsAreaCode: object.cjs_area_code,
+        createdUser: object.user_name,
+        cjsLocation: object.cjs_location,
+        docLanguage: object.doc_language,
+        isActive: object.is_active?,
+        defendant: object.defendant,
+        sessions: object.sessions,
+      }.compact
+    end
+  end
+end

--- a/spec/models/maat_api/laa_reference_spec.rb
+++ b/spec/models/maat_api/laa_reference_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe MaatApi::LaaReference, type: :model do
     )
   end
 
+  include ActiveSupport::Testing::TimeHelpers
+
   it "has a maat_reference" do
     expect(laa_reference.maat_reference).to eql("123")
   end
@@ -78,18 +80,27 @@ RSpec.describe MaatApi::LaaReference, type: :model do
     expect(laa_reference.defendant).to eql(expected)
   end
 
-  it "has a sessions payload" do
-    expected = [
-      {
-        courtLocation: "B30PI",
-        dateOfHearing: "2021-03-25",
-      },
-      {
-        courtLocation: "C30DE",
-        dateOfHearing: "2021-05-20",
-      },
-    ]
+  context "when all hearings are in the past" do
+    it "has cjs_location" do
+      expect(laa_reference.cjs_location).to eql("B30PI")
+    end
 
-    expect(laa_reference.sessions).to eql(expected)
+    it "has cjs_area_code" do
+      expect(laa_reference.cjs_area_code).to eql("30")
+    end
+  end
+
+  context "when all hearings are in the future" do
+    it "has cjs_location" do
+      travel_to(Date.new(2007, 5, 12)) do
+        expect(laa_reference.cjs_location).to eql("B30PI")
+      end
+    end
+
+    it "has cjs_area_code" do
+      travel_to(Date.new(2007, 5, 12)) do
+        expect(laa_reference.cjs_area_code).to eql("30")
+      end
+    end
   end
 end

--- a/spec/models/maat_api/laa_reference_spec.rb
+++ b/spec/models/maat_api/laa_reference_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe MaatApi::LaaReference, type: :model do
+  let(:prosecution_case_summary_data) { JSON.parse(file_fixture("prosecution_case_summary/all_fields.json").read) }
+  let(:prosecution_case_summary) { HmctsCommonPlatform::ProsecutionCaseSummary.new(prosecution_case_summary_data) }
+  let(:maat_reference) { "123" }
+  let(:defendant_summary) { prosecution_case_summary.defendant_summaries.first }
+  let(:user_name) { "test-user" }
+
+  let(:laa_reference) do
+    described_class.new(
+      prosecution_case_summary: prosecution_case_summary,
+      defendant_summary: defendant_summary,
+      user_name: user_name,
+      maat_reference: maat_reference,
+    )
+  end
+
+  it "has a maat_reference" do
+    expect(laa_reference.maat_reference).to eql("123")
+  end
+
+  it "has a prosecution case URN" do
+    expect(laa_reference.case_urn).to eql("30DI0570888")
+  end
+
+  it "has a defendant ASN" do
+    expect(laa_reference.defendant_asn).to eql("2100000000000267128K")
+  end
+
+  it "has a cjs area code" do
+    expect(laa_reference.cjs_area_code).to eql("30")
+  end
+
+  it "has a cjs location" do
+    expect(laa_reference.cjs_location).to eql("B30PI")
+  end
+
+  it "has a user name" do
+    expect(laa_reference.user_name).to eql("test-user")
+  end
+
+  it "has a doc language" do
+    expect(laa_reference.doc_language).to eql("EN")
+  end
+
+  it "has an isActive flag" do
+    expect(laa_reference.is_active?).to be true
+  end
+
+  it "has a defendant payload" do
+    expected = {
+      dateOfBirth: "1986-11-10",
+      defendantId: "b760daba-0d38-4bae-ad57-fbfd8419aefe",
+      forename: "Bob",
+      nino: "SJ12345678",
+      surname: "Smith",
+      offences: [
+        {
+          asnSeq: 1,
+          offenceClassification: "Indictable",
+          offenceCode: "TH68026C",
+          offenceDate: "2021-03-06",
+          offenceId: "9aca847f-da4e-444b-8f5a-2ce7d776ab75",
+          offenceShortTitle: "Conspire to commit a burglary dwelling with intent to steal",
+          offenceWording: "In the county of DERBYSHIRE, conspired together with John Doe to enter as a trespasser",
+        },
+        {
+          asnSeq: 2,
+          offenceClassification: "Either Way",
+          offenceCode: "CJ88149",
+          offenceDate: "2021-03-23",
+          offenceId: "4a852bd1-0068-422c-994f-78a5373ecd75",
+          offenceShortTitle: "Assault by beating of an emergency worker",
+          offenceWording: "On 23.05.2021 at DERBY in the county of DERBYSHIRE assaulted an emergency worker, namely Police Constable",
+        },
+      ],
+    }
+
+    expect(laa_reference.defendant).to eql(expected)
+  end
+
+  it "has a sessions payload" do
+    expected = [
+      {
+        courtLocation: "B30PI",
+        dateOfHearing: "2021-03-25",
+      },
+      {
+        courtLocation: "C30DE",
+        dateOfHearing: "2021-05-20",
+      },
+    ]
+
+    expect(laa_reference.sessions).to eql(expected)
+  end
+end

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MaatLinkCreator do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:maat_reference) { 12_345_678 }
-  let(:defendant_id) { "8cd0ba7e-df89-45a3-8c61-4008a2186d64" }
+  let(:defendant_id) { "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3" }
   let(:prosecution_case_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
   let(:offence_id) { "cacbd4d4-9102-4687-98b4-d529be3d5710" }
   let(:laa_reference) { LaaReference.create!(defendant_id: defendant_id, user_name: "caseWorker", maat_reference: maat_reference) }
@@ -18,11 +18,14 @@ RSpec.describe MaatLinkCreator do
       id: prosecution_case_id,
       body: JSON.parse(file_fixture("prosecution_case_search_result.json").read)["cases"][0],
     )
-    ProsecutionCaseDefendantOffence.create!(prosecution_case_id: prosecution_case_id,
-                                            defendant_id: defendant_id,
-                                            offence_id: offence_id)
 
-    allow(Sqs::PublishLaaReference).to receive(:call)
+    ProsecutionCaseDefendantOffence.create!(
+      prosecution_case_id: prosecution_case_id,
+      defendant_id: defendant_id,
+      offence_id: offence_id,
+    )
+
+    allow(Sqs::MessagePublisher).to receive(:call)
     allow(Api::RecordLaaReference).to receive(:call)
   end
 
@@ -42,8 +45,8 @@ RSpec.describe MaatLinkCreator do
     create_maat_link
   end
 
-  it "calls the Sqs::PublishLaaReference service once" do
-    expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: "12345678", user_name: "caseWorker")
+  it "calls the Sqs::MessagePublisher service once" do
+    expect(Sqs::MessagePublisher).to receive(:call).once
     create_maat_link
   end
 
@@ -54,8 +57,8 @@ RSpec.describe MaatLinkCreator do
                                               offence_id: SecureRandom.uuid)
     end
 
-    it "calls the Sqs::PublishLaaReference service once" do
-      expect(Sqs::PublishLaaReference).to receive(:call).once.with(defendant_id: defendant_id, prosecution_case_id: prosecution_case_id, maat_reference: "12345678", user_name: "caseWorker")
+    it "calls the Sqs::MessagePublisher service once" do
+      expect(Sqs::MessagePublisher).to receive(:call).once
       create_maat_link
     end
 
@@ -68,8 +71,8 @@ RSpec.describe MaatLinkCreator do
   context "with a dummy_maat_reference" do
     let(:laa_reference) { LaaReference.create!(defendant_id: defendant_id, user_name: "caseWorker", maat_reference: "A10000000") }
 
-    it "does not call the Sqs::PublishLaaReference service" do
-      expect(Sqs::PublishLaaReference).not_to receive(:call)
+    it "does not call the Sqs::MessagePublisher service" do
+      expect(Sqs::MessagePublisher).not_to receive(:call)
       create_maat_link
     end
 

--- a/spec/workers/maat_link_creator_worker_spec.rb
+++ b/spec/workers/maat_link_creator_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MaatLinkCreatorWorker, type: :worker do
 
   let(:request_id) { "XYZ" }
   let(:maat_reference) { 12_345_678 }
-  let(:defendant_id) { "8cd0ba7e-df89-45a3-8c61-4008a2186d64" }
+  let(:defendant_id) { "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3" }
   let(:prosecution_case_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
   let(:offence_id) { "cacbd4d4-9102-4687-98b4-d529be3d5710" }
   let(:laa_reference) { LaaReference.create!(defendant_id: defendant_id, user_name: "caseWorker", maat_reference: maat_reference) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-569)

The current implementation of LAA Reference publishing (e.g. https://github.com/ministryofjustice/laa-court-data-adaptor/blob/master/app/services/sqs/publish_laa_reference.rb ) couples message shaping, data populating, and publishing.

We’d like to refactor this feature to use the same pattern as Court Applications.

## Why

Encourage code reuse, avoid duplication of MAAT API-related logic, make the code easier to understand, to change and to expand.