### PR TITLE
Use HashWithIndifferentAccess for storing HMCTS raw data

### DIFF
--- a/app/models/hmcts_common_platform/court_application.rb
+++ b/app/models/hmcts_common_platform/court_application.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class CourtApplication
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def type_id
       data.dig(:type, :id)

--- a/app/models/hmcts_common_platform/defendant.rb
+++ b/app/models/hmcts_common_platform/defendant.rb
@@ -7,7 +7,7 @@ module HmctsCommonPlatform
     delegate :arrest_summons_number, :first_name, :last_name, :date_of_birth, :documentation_language_needs, :address_1, :address_2, :address_3, :address_4, :address_5, :postcode, :nino, :phone_home, :phone_work, :phone_mobile, :email_primary, :email_secondary, to: :person_defendant
 
     def initialize(data)
-      @data = data || {}
+      @data = HashWithIndifferentAccess.new(data || {})
     end
 
     def proceedings_concluded

--- a/app/models/hmcts_common_platform/delegated_powers.rb
+++ b/app/models/hmcts_common_platform/delegated_powers.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class DelegatedPowers
     attr_reader :data
 
+    delegate :blank?, to: :data
+
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
     end
-
-    delegate :blank?, to: :data
 
     def user_id
       data[:userId]

--- a/app/models/hmcts_common_platform/delegated_powers.rb
+++ b/app/models/hmcts_common_platform/delegated_powers.rb
@@ -3,7 +3,7 @@ module HmctsCommonPlatform
     attr_reader :data
 
     def initialize(data)
-      @data = data || {}
+      @data = HashWithIndifferentAccess.new(data || {})
     end
 
     delegate :blank?, to: :data

--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -3,7 +3,7 @@ module HmctsCommonPlatform
     attr_reader :data
 
     def initialize(data)
-      @data = data || {}
+      @data = HashWithIndifferentAccess.new(data || {})
     end
 
     delegate :blank?, to: :data

--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class Hearing
     attr_reader :data
 
+    delegate :blank?, to: :data
+
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
     end
-
-    delegate :blank?, to: :data
 
     def jurisdiction_type
       data[:jurisdictionType]

--- a/app/models/hmcts_common_platform/judicial_result.rb
+++ b/app/models/hmcts_common_platform/judicial_result.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class JudicialResult
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def code
       data[:cjsCode]

--- a/app/models/hmcts_common_platform/lesser_or_alternative_offence.rb
+++ b/app/models/hmcts_common_platform/lesser_or_alternative_offence.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class LesserOrAlternativeOffence
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def offence_definition_id
       data[:offenceDefinitionId]

--- a/app/models/hmcts_common_platform/offence.rb
+++ b/app/models/hmcts_common_platform/offence.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class Offence
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def id
       data[:id]

--- a/app/models/hmcts_common_platform/person_defendant.rb
+++ b/app/models/hmcts_common_platform/person_defendant.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class PersonDefendant
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def arrest_summons_number
       data.dig(:arrestSummonsNumber)

--- a/app/models/hmcts_common_platform/plea.rb
+++ b/app/models/hmcts_common_platform/plea.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class Plea
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def originating_hearing_id
       data[:originatingHearingId]

--- a/app/models/hmcts_common_platform/verdict.rb
+++ b/app/models/hmcts_common_platform/verdict.rb
@@ -2,11 +2,11 @@ module HmctsCommonPlatform
   class Verdict
     attr_reader :data
 
-    def initialize(data)
-      @data = data || {}
-    end
-
     delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
 
     def offence_id
       data[:offenceId]

--- a/spec/fixtures/files/hearing/all_fields.json
+++ b/spec/fixtures/files/hearing/all_fields.json
@@ -1,333 +1,330 @@
 {
-  "hearing": {
-    "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
-    "jurisdictionType": "CROWN",
-    "reportingRestrictionReason": "reporting restriction because...",
-    "courtCentre": {
-      "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
-      "name": "Warrington CCU (Decom)",
-      "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
-      "roomName": "Warrington CCU (Decom)"
-    },
-    "hearingLanguage": "WELSH",
-    "hasSharedResults": false,
-    "type": {
-      "id": "63003e58-d753-46e2-a2c8-47fd15341592",
-      "description": "Mention - Defendant to Attend (MDA)"
-    },
-    "prosecutionCases": [
-      {
-        "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
-        "prosecutionCaseIdentifier": {
-          "caseURN": "20GD0217100",
-          "prosecutionAuthorityReference": "UXJYGCVRXJ",
-          "prosecutionAuthorityId": "094e3de2-a07f-472f-81ed-da9b254c6c7c",
-          "prosecutionAuthorityCode": "UBTMWMUUIJ"
+  "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+  "jurisdictionType": "CROWN",
+  "reportingRestrictionReason": "reporting restriction because...",
+  "courtCentre": {
+    "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
+    "name": "Warrington CCU (Decom)",
+    "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
+    "roomName": "Warrington CCU (Decom)"
+  },
+  "hearingLanguage": "WELSH",
+  "hasSharedResults": false,
+  "type": {
+    "id": "63003e58-d753-46e2-a2c8-47fd15341592",
+    "description": "Mention - Defendant to Attend (MDA)"
+  },
+  "prosecutionCases": [
+    {
+      "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+      "prosecutionCaseIdentifier": {
+        "caseURN": "20GD0217100",
+        "prosecutionAuthorityReference": "UXJYGCVRXJ",
+        "prosecutionAuthorityId": "094e3de2-a07f-472f-81ed-da9b254c6c7c",
+        "prosecutionAuthorityCode": "UBTMWMUUIJ"
+      },
+      "originatingOrganisation": "Goldner, Prohaska and Hauck",
+      "initiationCode": "O",
+      "caseStatus": "CLOSED",
+      "policeOfficerInCase": {
+        "personDetails": {
+          "title": "MISS",
+          "firstName": "Alfredine",
+          "middleName": "Treutel",
+          "lastName": "Parker",
+          "dateOfBirth": "1971-05-12",
+          "nationalityId": "a1c2f090-4fb6-4c50-a08d-3ef23aac83da",
+          "nationalityCode": "Gibraltar",
+          "nationalityDescription": "Good habits formed at youth make all the difference",
+          "additionalNationalityId": "12b33a32-8857-4602-b7fa-47280bdc660d",
+          "additionalNationalityCode": "Irish",
+          "additionalNationalityDescription": "The unexamined life is not worth living.",
+          "disabilityStatus": "blind",
+          "gender": "NOT_SPECIFIED",
+          "interpreterLanguageNeeds": "Swedish",
+          "documentationLanguageNeeds": "ENGLISH",
+          "nationalInsuranceNumber": "BN102966C",
+          "occupation": "Global Real-Estate Strategist",
+          "occupationCode": "4033",
+          "specificRequirements": "Unleash back-end relationships"
         },
-        "originatingOrganisation": "Goldner, Prohaska and Hauck",
-        "initiationCode": "O",
-        "caseStatus": "CLOSED",
-        "policeOfficerInCase": {
-          "personDetails": {
-            "title": "MISS",
-            "firstName": "Alfredine",
-            "middleName": "Treutel",
-            "lastName": "Parker",
-            "dateOfBirth": "1971-05-12",
-            "nationalityId": "a1c2f090-4fb6-4c50-a08d-3ef23aac83da",
-            "nationalityCode": "Gibraltar",
-            "nationalityDescription": "Good habits formed at youth make all the difference",
-            "additionalNationalityId": "12b33a32-8857-4602-b7fa-47280bdc660d",
-            "additionalNationalityCode": "Irish",
-            "additionalNationalityDescription": "The unexamined life is not worth living.",
-            "disabilityStatus": "blind",
-            "gender": "NOT_SPECIFIED",
-            "interpreterLanguageNeeds": "Swedish",
-            "documentationLanguageNeeds": "ENGLISH",
-            "nationalInsuranceNumber": "BN102966C",
-            "occupation": "Global Real-Estate Strategist",
-            "occupationCode": "4033",
-            "specificRequirements": "Unleash back-end relationships"
-          },
-          "policeOfficerRank": "Captain",
-          "policeWorkerReferenceNumber": "4233223423",
-          "policeWorkerLocationCode": "AK"
-        },
-        "statementOfFacts": "Veritatis cardigan +1.",
-        "statementOfFactsWelsh": "Actually small batch in ea.",
-        "breachProceedingsPending": true,
-        "appealProceedingsPending": false,
-        "defendants": [
-          {
-            "id": "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3",
-            "prosecutionCaseId": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
-            "numberOfPreviousConvictionsCited": 3106,
-            "prosecutionAuthorityReference": "iusto",
-            "witnessStatement": "Harum exercitationem in. Non nulla aut. Eligendi molestiae saepe.",
-            "witnessStatementWelsh": "Eius numquam qui. Sed aspernatur expedita. Doloribus voluptas quis.",
-            "mitigation": "Et earum dolorem. Sapiente fugiat mollitia. Aut iste consequatur.",
-            "mitigationWelsh": "Repellendus officiis autem. Rem qui id. Doloribus quis quibusdam.",
-            "offences": [
-              {
-                "id": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
-                "offenceDefinitionId": "084cc312-8e01-485e-a836-c52273e83d5a",
-                "offenceCode": "PT00011",
-                "offenceTitle": "Driver / other person fail to immediately move a vehicle from a cordoned area on order of a constable",
-                "offenceTitleWelsh": "some welsh for that offence",
-                "offenceLegislation": "Common law",
-                "offenceLegislationWelsh": "Firearms Act 1968 s.2",
-                "modeOfTrial": "Either way",
-                "wording": "Random string",
-                "wordingWelsh": "Llinyn ar hap",
-                "startDate": "2019-10-17",
-                "endDate": "2019-10-17",
-                "arrestDate": "2019-10-17",
-                "chargeDate": "2019-10-17",
-                "laidDate": "2019-10-17",
-                "dateOfInformation": "2019-10-17",
-                "orderIndex": 1,
-                "count": 1,
-                "convictionDate": "2019-10-17",
-                "aquittalDate": "2019-10-17",
-                "isDiscontinued": false,
-                "proceedingsConcluded": false,
-                "allocationDecision": {
-                  "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
-                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
-                  "motReasonId": "d47268e9-db2e-3aa3-827b-ba3afb7ff94a",
-                  "motReasonDescription": "Court directs trial by jury",
-                  "motReasonCode": "5",
-                  "sequenceNumber": 20,
-                  "allocationDecisionDate": "2020-02-13",
-                  "courtIndicatedSentence": {
-                    "courtIndicatedSentenceTypeId": "f7f76e0b-366b-4746-b0b0-4d8a46c6ad4e",
-                    "courtIndicatedSentenceDescription": "Aut laborum quia et."
-                  }
-                },
-                "plea": {
-                  "originatingHearingId": "818d572c-a9e8-4bf2-8eb7-6abf98cd7a5f",
-                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
-                  "pleaDate": "2020-04-12",
-                  "pleaValue": "NOT_GUILTY"
-                },
-                "laaApplnReference": {
-                  "applicationReference": "A10000099",
-                  "statusId": "38944fbb-c8a6-45ff-9b5c-e09e9867eabc",
-                  "statusCode": "AP",
-                  "statusDescription": "FAKE NEWS",
-                  "statusDate": "2020-11-05"
+        "policeOfficerRank": "Captain",
+        "policeWorkerReferenceNumber": "4233223423",
+        "policeWorkerLocationCode": "AK"
+      },
+      "statementOfFacts": "Veritatis cardigan +1.",
+      "statementOfFactsWelsh": "Actually small batch in ea.",
+      "breachProceedingsPending": true,
+      "appealProceedingsPending": false,
+      "defendants": [
+        {
+          "id": "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3",
+          "prosecutionCaseId": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+          "numberOfPreviousConvictionsCited": 3106,
+          "prosecutionAuthorityReference": "iusto",
+          "witnessStatement": "Harum exercitationem in. Non nulla aut. Eligendi molestiae saepe.",
+          "witnessStatementWelsh": "Eius numquam qui. Sed aspernatur expedita. Doloribus voluptas quis.",
+          "mitigation": "Et earum dolorem. Sapiente fugiat mollitia. Aut iste consequatur.",
+          "mitigationWelsh": "Repellendus officiis autem. Rem qui id. Doloribus quis quibusdam.",
+          "offences": [
+            {
+              "id": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
+              "offenceDefinitionId": "084cc312-8e01-485e-a836-c52273e83d5a",
+              "offenceCode": "PT00011",
+              "offenceTitle": "Driver / other person fail to immediately move a vehicle from a cordoned area on order of a constable",
+              "offenceTitleWelsh": "some welsh for that offence",
+              "offenceLegislation": "Common law",
+              "offenceLegislationWelsh": "Firearms Act 1968 s.2",
+              "modeOfTrial": "Either way",
+              "wording": "Random string",
+              "wordingWelsh": "Llinyn ar hap",
+              "startDate": "2019-10-17",
+              "endDate": "2019-10-17",
+              "arrestDate": "2019-10-17",
+              "chargeDate": "2019-10-17",
+              "laidDate": "2019-10-17",
+              "dateOfInformation": "2019-10-17",
+              "orderIndex": 1,
+              "count": 1,
+              "convictionDate": "2019-10-17",
+              "aquittalDate": "2019-10-17",
+              "isDiscontinued": false,
+              "proceedingsConcluded": false,
+              "allocationDecision": {
+                "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+                "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                "motReasonId": "d47268e9-db2e-3aa3-827b-ba3afb7ff94a",
+                "motReasonDescription": "Court directs trial by jury",
+                "motReasonCode": "5",
+                "sequenceNumber": 20,
+                "allocationDecisionDate": "2020-02-13",
+                "courtIndicatedSentence": {
+                  "courtIndicatedSentenceTypeId": "f7f76e0b-366b-4746-b0b0-4d8a46c6ad4e",
+                  "courtIndicatedSentenceDescription": "Aut laborum quia et."
                 }
+              },
+              "plea": {
+                "originatingHearingId": "818d572c-a9e8-4bf2-8eb7-6abf98cd7a5f",
+                "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                "pleaDate": "2020-04-12",
+                "pleaValue": "NOT_GUILTY"
+              },
+              "laaApplnReference": {
+                "applicationReference": "A10000099",
+                "statusId": "38944fbb-c8a6-45ff-9b5c-e09e9867eabc",
+                "statusCode": "AP",
+                "statusDescription": "FAKE NEWS",
+                "statusDate": "2020-11-05"
               }
-            ],
-            "associatedPersons": [
-              {
-                "person": {
-                  "title": "MS",
-                  "firstName": "Katelynn",
-                  "middleName": "Harvey",
-                  "lastName": "Kunze",
-                  "dateOfBirth": "2002-10-10",
-                  "nationalityId": "fba0fbc1-3a78-46d0-9a45-9bf76d196793",
-                  "nationalityCode": "BY",
-                  "nationalityDescription": "Belarus",
-                  "additionalNationalityId": "38af2450-1717-47bf-ab1a-c17fd4745e78",
-                  "additionalNationalityCode": "AZ",
-                  "additionalNationalityDescription": "Azerbaijan",
-                  "disabilityStatus": "atque",
-                  "ethnicity": {
-                    "observedEthnicityId": "a505bd30-9727-4ece-9312-74737d4696af",
-                    "observedEthnicityCode": "B1",
-                    "observedEthnicityDescription": "Caribbean",
-                    "selfDefinedEthnicityId": "dcad92c4-53a2-43fb-b1a8-d8241458e0d3",
-                    "selfDefinedEthnicityCode": "W9",
-                    "selfDefinedEthnicityDescription": "Any other White background"
-                  },
-                  "gender": "FEMALE",
-                  "interpreterLanguageNeeds": "Tagalog",
-                  "documentationLanguageNeeds": "WELSH",
-                  "nationalInsuranceNumber": "EJ099885C",
-                  "occupation": "pharmacist",
-                  "occupationCode": "3914",
-                  "specificRequirements": "molestias",
-                  "address": {
-                    "address1": "4637 Victorina Trail",
-                    "address2": "Suite 623",
-                    "address3": "2989",
-                    "address4": "North Porfirio",
-                    "address5": "Palestinian Territory",
-                    "postcode": "51314-0859"
-                  },
-                  "contact": {
-                    "home": "1-867-889-8179",
-                    "work": "1-893-936-4102",
-                    "mobile": "640-287-7987",
-                    "primaryEmail": "anastacia@stoltenberg.io",
-                    "secondaryEmail": "joane_goyette@purdy-purdy.com",
-                    "fax": "1-275-412-9791 x8048"
-                  }
+            }
+          ],
+          "associatedPersons": [
+            {
+              "person": {
+                "title": "MS",
+                "firstName": "Katelynn",
+                "middleName": "Harvey",
+                "lastName": "Kunze",
+                "dateOfBirth": "2002-10-10",
+                "nationalityId": "fba0fbc1-3a78-46d0-9a45-9bf76d196793",
+                "nationalityCode": "BY",
+                "nationalityDescription": "Belarus",
+                "additionalNationalityId": "38af2450-1717-47bf-ab1a-c17fd4745e78",
+                "additionalNationalityCode": "AZ",
+                "additionalNationalityDescription": "Azerbaijan",
+                "disabilityStatus": "atque",
+                "ethnicity": {
+                  "observedEthnicityId": "a505bd30-9727-4ece-9312-74737d4696af",
+                  "observedEthnicityCode": "B1",
+                  "observedEthnicityDescription": "Caribbean",
+                  "selfDefinedEthnicityId": "dcad92c4-53a2-43fb-b1a8-d8241458e0d3",
+                  "selfDefinedEthnicityCode": "W9",
+                  "selfDefinedEthnicityDescription": "Any other White background"
                 },
-                "role": "Uncle"
-              }
-            ],
-            "defenceOrganisation": {
+                "gender": "FEMALE",
+                "interpreterLanguageNeeds": "Tagalog",
+                "documentationLanguageNeeds": "WELSH",
+                "nationalInsuranceNumber": "EJ099885C",
+                "occupation": "pharmacist",
+                "occupationCode": "3914",
+                "specificRequirements": "molestias",
+                "address": {
+                  "address1": "4637 Victorina Trail",
+                  "address2": "Suite 623",
+                  "address3": "2989",
+                  "address4": "North Porfirio",
+                  "address5": "Palestinian Territory",
+                  "postcode": "51314-0859"
+                },
+                "contact": {
+                  "home": "1-867-889-8179",
+                  "work": "1-893-936-4102",
+                  "mobile": "640-287-7987",
+                  "primaryEmail": "anastacia@stoltenberg.io",
+                  "secondaryEmail": "joane_goyette@purdy-purdy.com",
+                  "fax": "1-275-412-9791 x8048"
+                }
+              },
+              "role": "Uncle"
+            }
+          ],
+          "defenceOrganisation": {
+            "name": "Gutkowski-Schumm",
+            "incorporationNumber": "75-6181739",
+            "registeredCharityNumber": "44-273-5167"
+          },
+          "associatedDefenceOrganisation": {
+            "organisation": {
               "name": "Gutkowski-Schumm",
               "incorporationNumber": "75-6181739",
               "registeredCharityNumber": "44-273-5167"
             },
-            "associatedDefenceOrganisation": {
-              "organisation": {
-                "name": "Gutkowski-Schumm",
-                "incorporationNumber": "75-6181739",
-                "registeredCharityNumber": "44-273-5167"
+            "fundingType": "PRIVATE",
+            "associationStartDate": "2020-11-18",
+            "associationEndDate": "2020-12-24",
+            "isAssociatedByLAA": true,
+            "applicationReference": "A10000099"
+          },
+          "personDefendant": {
+            "personDetails": {
+              "title": "MR",
+              "firstName": "Jammy",
+              "middleName": "",
+              "lastName": "Dodger",
+              "dateOfBirth": "1987-05-21",
+              "nationalityId": "0fbfa618-77d1-4791-924a-4a1ea02dd041",
+              "nationalityCode": "MQ",
+              "nationalityDescription": "Martinique",
+              "additionalNationalityId": "740c8ea4-b6e3-4167-9d56-2ed0eadf8169",
+              "additionalNationalityCode": "HK",
+              "additionalNationalityDescription": "Hong Kong",
+              "disabilityStatus": "perferendis",
+              "ethnicity": {
+                "observedEthnicityId": "bf43941a-1627-45cb-b255-ab6efd26b25d",
+                "observedEthnicityCode": "O9",
+                "observedEthnicityDescription": "Any other ethnic group",
+                "selfDefinedEthnicityId": "90ffba21-501c-4e3b-8b00-e451c97067a6",
+                "selfDefinedEthnicityCode": "M9",
+                "selfDefinedEthnicityDescription": "Any other mixed background"
               },
-              "fundingType": "PRIVATE",
-              "associationStartDate": "2020-11-18",
-              "associationEndDate": "2020-12-24",
-              "isAssociatedByLAA": true,
-              "applicationReference": "A10000099"
-            },
-            "personDefendant": {
-              "personDetails": {
-                "title": "MR",
-                "firstName": "Jammy",
-                "middleName": "",
-                "lastName": "Dodger",
-                "dateOfBirth": "1987-05-21",
-                "nationalityId": "0fbfa618-77d1-4791-924a-4a1ea02dd041",
-                "nationalityCode": "MQ",
-                "nationalityDescription": "Martinique",
-                "additionalNationalityId": "740c8ea4-b6e3-4167-9d56-2ed0eadf8169",
-                "additionalNationalityCode": "HK",
-                "additionalNationalityDescription": "Hong Kong",
-                "disabilityStatus": "perferendis",
-                "ethnicity": {
-                  "observedEthnicityId": "bf43941a-1627-45cb-b255-ab6efd26b25d",
-                  "observedEthnicityCode": "O9",
-                  "observedEthnicityDescription": "Any other ethnic group",
-                  "selfDefinedEthnicityId": "90ffba21-501c-4e3b-8b00-e451c97067a6",
-                  "selfDefinedEthnicityCode": "M9",
-                  "selfDefinedEthnicityDescription": "Any other mixed background"
-                },
-                "gender": "MALE",
-                "interpreterLanguageNeeds": "Hakka",
-                "documentationLanguageNeeds": "WELSH",
-                "nationalInsuranceNumber": "JC123456A",
-                "occupation": "lawyer",
-                "occupationCode": "5033",
-                "specificRequirements": "natus",
-                "address": {
-                  "address1": "6376 Merrilee Loop",
-                  "address2": "Suite 304",
-                  "address3": "28301",
-                  "address4": "Cinthiatown",
-                  "address5": "Kyrgyz Republic",
-                  "postcode": "35848-9420"
-                },
-                "contact": {
-                  "home": "(376) 129-7081",
-                  "work": "793.293.0858 x83940",
-                  "mobile": "1-131-191-7418",
-                  "primaryEmail": "francesco.blick@fisher.org",
-                  "secondaryEmail": "hailey.tremblay@weissnat.net",
-                  "fax": "829-539-3102 x61653"
-                }
+              "gender": "MALE",
+              "interpreterLanguageNeeds": "Hakka",
+              "documentationLanguageNeeds": "WELSH",
+              "nationalInsuranceNumber": "JC123456A",
+              "occupation": "lawyer",
+              "occupationCode": "5033",
+              "specificRequirements": "natus",
+              "address": {
+                "address1": "6376 Merrilee Loop",
+                "address2": "Suite 304",
+                "address3": "28301",
+                "address4": "Cinthiatown",
+                "address5": "Kyrgyz Republic",
+                "postcode": "35848-9420"
               },
-              "bailStatus": {
-                "id": "9567a90f-a82c-42ee-92b4-a6ce3687c8d4",
-                "code": "0hs9ytllu5",
-                "description": "Nobis reiciendis deleniti doloremque.",
-                "custodyTimeLimit": {
-                  "timeLimit": "2021-02-02",
-                  "daysSpent": 37
-                }
-              },
-              "bailConditions": "Molestias quasi assumenda necessitatibus.",
-              "bailReasons": "Nostrum tenetur aspernatur autem.",
-              "perceivedBirthYear": 1984,
-              "driverNumber": "Vitae et quis consequatur.",
-              "driverLicenceCode": "FULL",
-              "driverLicenseIssue": "Dolores placeat veniam reprehenderit.",
-              "vehicleOperatorLicenceNumber": "FQMX65V",
-              "arrestSummonsNumber": "XVITYX8RAIHZ",
-              "employerOrganisation": {
-                "name": "Adams Group",
-                "incorporationNumber": "47-6611239",
-                "registeredCharityNumber": "93-131-3851"
-              },
-              "employerPayrollReference": "X41UERQFM"
-            },
-            "aliases": [
-              {
-                "title": "MS",
-                "firstName": "Wallace",
-                "middleName": "Cummings",
-                "lastName": "McClure",
-                "legalEntityName": "Effertz and Sons"
+              "contact": {
+                "home": "(376) 129-7081",
+                "work": "793.293.0858 x83940",
+                "mobile": "1-131-191-7418",
+                "primaryEmail": "francesco.blick@fisher.org",
+                "secondaryEmail": "hailey.tremblay@weissnat.net",
+                "fax": "829-539-3102 x61653"
               }
-            ],
-            "croNumber": "B0000W4DP6",
-            "pncId": "33629585-8"
-          }
-        ],
-        "caseMarkers": [
-          {
-            "id": "dea23b3e-d4c1-40bd-9b64-8cf8d71aa185",
-            "markerTypeid": "f08a69c8-6a69-4308-9c61-e2bfa2c092f3",
-            "markerTypeCode": "JESDPCOXOB",
-            "markerTypeDescription": "UJOBNCSJUQ"
-          }
-        ]
-      }
-    ],
-    "defenceCounsels": [
-      {
-        "id": "c819785d-d39d-4c44-b1ad-bcca76e88c14",
-        "title": "Pres.",
-        "firstName": "Adrian",
-        "middleName": "Jefferey",
-        "lastName": "Pollich",
-        "status": "Junior counsel",
-        "defendants": [
-          "b17e6c2d-1439-4f02-9179-1ff9935729a7"
+            },
+            "bailStatus": {
+              "id": "9567a90f-a82c-42ee-92b4-a6ce3687c8d4",
+              "code": "0hs9ytllu5",
+              "description": "Nobis reiciendis deleniti doloremque.",
+              "custodyTimeLimit": {
+                "timeLimit": "2021-02-02",
+                "daysSpent": 37
+              }
+            },
+            "bailConditions": "Molestias quasi assumenda necessitatibus.",
+            "bailReasons": "Nostrum tenetur aspernatur autem.",
+            "perceivedBirthYear": 1984,
+            "driverNumber": "Vitae et quis consequatur.",
+            "driverLicenceCode": "FULL",
+            "driverLicenseIssue": "Dolores placeat veniam reprehenderit.",
+            "vehicleOperatorLicenceNumber": "FQMX65V",
+            "arrestSummonsNumber": "XVITYX8RAIHZ",
+            "employerOrganisation": {
+              "name": "Adams Group",
+              "incorporationNumber": "47-6611239",
+              "registeredCharityNumber": "93-131-3851"
+            },
+            "employerPayrollReference": "X41UERQFM"
+          },
+          "aliases": [
+            {
+              "title": "MS",
+              "firstName": "Wallace",
+              "middleName": "Cummings",
+              "lastName": "McClure",
+              "legalEntityName": "Effertz and Sons"
+            }
+          ],
+          "croNumber": "B0000W4DP6",
+          "pncId": "33629585-8"
+        }
+      ],
+      "caseMarkers": [
+        {
+          "id": "dea23b3e-d4c1-40bd-9b64-8cf8d71aa185",
+          "markerTypeid": "f08a69c8-6a69-4308-9c61-e2bfa2c092f3",
+          "markerTypeCode": "JESDPCOXOB",
+          "markerTypeDescription": "UJOBNCSJUQ"
+        }
+      ]
+    }
+  ],
+  "defenceCounsels": [
+    {
+      "id": "c819785d-d39d-4c44-b1ad-bcca76e88c14",
+      "title": "Pres.",
+      "firstName": "Adrian",
+      "middleName": "Jefferey",
+      "lastName": "Pollich",
+      "status": "Junior counsel",
+      "defendants": [
+        "b17e6c2d-1439-4f02-9179-1ff9935729a7"
         ],
         "attendanceDays": [
           "2019-10-24"
         ]
-      },
-      {
-        "id": "66b5cc0d-1704-4487-a35c-6d96612b2bc2",
-        "title": "Mr.",
-        "firstName": "Leonard",
-        "middleName": "Rafael",
-        "lastName": "DuBuque",
-        "status": "Junior counsel",
-        "defendants": [
-          "d6900d6a-3d36-4d21-9723-d6bb21a5a6db"
+    },
+    {
+      "id": "66b5cc0d-1704-4487-a35c-6d96612b2bc2",
+      "title": "Mr.",
+      "firstName": "Leonard",
+      "middleName": "Rafael",
+      "lastName": "DuBuque",
+      "status": "Junior counsel",
+      "defendants": [
+        "d6900d6a-3d36-4d21-9723-d6bb21a5a6db"
         ],
         "attendanceDays": [
           "2019-10-24"
         ]
-      }
-    ],
-    "isEffectiveTrial": false,
-    "isBoxHearing": false,
-    "hearingDays": [
-      {
-        "sittingDay": "2019-10-25T10:45:00.000Z",
-        "listingSequence": 1,
-        "listedDurationMinutes": 1
-      },
-      {
-        "sittingDay": "2019-10-24T08:30:00.000Z",
-        "listingSequence": 1,
-        "listedDurationMinutes": 1
-      },
-      {
-        "sittingDay": "2019-10-23T16:19:15.000Z",
-        "listingSequence": 1,
-        "listedDurationMinutes": 1
-      }
-    ]
-  },
-  "sharedTime": "2020-10-30T10:04:27.476+00:00"
+    }
+  ],
+  "isEffectiveTrial": false,
+  "isBoxHearing": false,
+  "hearingDays": [
+    {
+      "sittingDay": "2019-10-25T10:45:00.000Z",
+      "listingSequence": 1,
+      "listedDurationMinutes": 1
+    },
+    {
+      "sittingDay": "2019-10-24T08:30:00.000Z",
+      "listingSequence": 1,
+      "listedDurationMinutes": 1
+    },
+    {
+      "sittingDay": "2019-10-23T16:19:15.000Z",
+      "listingSequence": 1,
+      "listedDurationMinutes": 1
+    }
+  ]
 }

--- a/spec/fixtures/files/hearing_resulted.json
+++ b/spec/fixtures/files/hearing_resulted.json
@@ -1,0 +1,333 @@
+{
+  "hearing": {
+    "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+    "jurisdictionType": "CROWN",
+    "reportingRestrictionReason": "reporting restriction because...",
+    "courtCentre": {
+      "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "name": "Warrington CCU (Decom)",
+      "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
+      "roomName": "Warrington CCU (Decom)"
+    },
+    "hearingLanguage": "WELSH",
+    "hasSharedResults": false,
+    "type": {
+      "id": "63003e58-d753-46e2-a2c8-47fd15341592",
+      "description": "Mention - Defendant to Attend (MDA)"
+    },
+    "prosecutionCases": [
+      {
+        "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+        "prosecutionCaseIdentifier": {
+          "caseURN": "20GD0217100",
+          "prosecutionAuthorityReference": "UXJYGCVRXJ",
+          "prosecutionAuthorityId": "094e3de2-a07f-472f-81ed-da9b254c6c7c",
+          "prosecutionAuthorityCode": "UBTMWMUUIJ"
+        },
+        "originatingOrganisation": "Goldner, Prohaska and Hauck",
+        "initiationCode": "O",
+        "caseStatus": "CLOSED",
+        "policeOfficerInCase": {
+          "personDetails": {
+            "title": "MISS",
+            "firstName": "Alfredine",
+            "middleName": "Treutel",
+            "lastName": "Parker",
+            "dateOfBirth": "1971-05-12",
+            "nationalityId": "a1c2f090-4fb6-4c50-a08d-3ef23aac83da",
+            "nationalityCode": "Gibraltar",
+            "nationalityDescription": "Good habits formed at youth make all the difference",
+            "additionalNationalityId": "12b33a32-8857-4602-b7fa-47280bdc660d",
+            "additionalNationalityCode": "Irish",
+            "additionalNationalityDescription": "The unexamined life is not worth living.",
+            "disabilityStatus": "blind",
+            "gender": "NOT_SPECIFIED",
+            "interpreterLanguageNeeds": "Swedish",
+            "documentationLanguageNeeds": "ENGLISH",
+            "nationalInsuranceNumber": "BN102966C",
+            "occupation": "Global Real-Estate Strategist",
+            "occupationCode": "4033",
+            "specificRequirements": "Unleash back-end relationships"
+          },
+          "policeOfficerRank": "Captain",
+          "policeWorkerReferenceNumber": "4233223423",
+          "policeWorkerLocationCode": "AK"
+        },
+        "statementOfFacts": "Veritatis cardigan +1.",
+        "statementOfFactsWelsh": "Actually small batch in ea.",
+        "breachProceedingsPending": true,
+        "appealProceedingsPending": false,
+        "defendants": [
+          {
+            "id": "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3",
+            "prosecutionCaseId": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+            "numberOfPreviousConvictionsCited": 3106,
+            "prosecutionAuthorityReference": "iusto",
+            "witnessStatement": "Harum exercitationem in. Non nulla aut. Eligendi molestiae saepe.",
+            "witnessStatementWelsh": "Eius numquam qui. Sed aspernatur expedita. Doloribus voluptas quis.",
+            "mitigation": "Et earum dolorem. Sapiente fugiat mollitia. Aut iste consequatur.",
+            "mitigationWelsh": "Repellendus officiis autem. Rem qui id. Doloribus quis quibusdam.",
+            "offences": [
+              {
+                "id": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
+                "offenceDefinitionId": "084cc312-8e01-485e-a836-c52273e83d5a",
+                "offenceCode": "PT00011",
+                "offenceTitle": "Driver / other person fail to immediately move a vehicle from a cordoned area on order of a constable",
+                "offenceTitleWelsh": "some welsh for that offence",
+                "offenceLegislation": "Common law",
+                "offenceLegislationWelsh": "Firearms Act 1968 s.2",
+                "modeOfTrial": "Either way",
+                "wording": "Random string",
+                "wordingWelsh": "Llinyn ar hap",
+                "startDate": "2019-10-17",
+                "endDate": "2019-10-17",
+                "arrestDate": "2019-10-17",
+                "chargeDate": "2019-10-17",
+                "laidDate": "2019-10-17",
+                "dateOfInformation": "2019-10-17",
+                "orderIndex": 1,
+                "count": 1,
+                "convictionDate": "2019-10-17",
+                "aquittalDate": "2019-10-17",
+                "isDiscontinued": false,
+                "proceedingsConcluded": false,
+                "allocationDecision": {
+                  "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                  "motReasonId": "d47268e9-db2e-3aa3-827b-ba3afb7ff94a",
+                  "motReasonDescription": "Court directs trial by jury",
+                  "motReasonCode": "5",
+                  "sequenceNumber": 20,
+                  "allocationDecisionDate": "2020-02-13",
+                  "courtIndicatedSentence": {
+                    "courtIndicatedSentenceTypeId": "f7f76e0b-366b-4746-b0b0-4d8a46c6ad4e",
+                    "courtIndicatedSentenceDescription": "Aut laborum quia et."
+                  }
+                },
+                "plea": {
+                  "originatingHearingId": "818d572c-a9e8-4bf2-8eb7-6abf98cd7a5f",
+                  "offenceId": "e58b3a59-e5e5-4ec4-a478-2c846b9e6b6d",
+                  "pleaDate": "2020-04-12",
+                  "pleaValue": "NOT_GUILTY"
+                },
+                "laaApplnReference": {
+                  "applicationReference": "A10000099",
+                  "statusId": "38944fbb-c8a6-45ff-9b5c-e09e9867eabc",
+                  "statusCode": "AP",
+                  "statusDescription": "FAKE NEWS",
+                  "statusDate": "2020-11-05"
+                }
+              }
+            ],
+            "associatedPersons": [
+              {
+                "person": {
+                  "title": "MS",
+                  "firstName": "Katelynn",
+                  "middleName": "Harvey",
+                  "lastName": "Kunze",
+                  "dateOfBirth": "2002-10-10",
+                  "nationalityId": "fba0fbc1-3a78-46d0-9a45-9bf76d196793",
+                  "nationalityCode": "BY",
+                  "nationalityDescription": "Belarus",
+                  "additionalNationalityId": "38af2450-1717-47bf-ab1a-c17fd4745e78",
+                  "additionalNationalityCode": "AZ",
+                  "additionalNationalityDescription": "Azerbaijan",
+                  "disabilityStatus": "atque",
+                  "ethnicity": {
+                    "observedEthnicityId": "a505bd30-9727-4ece-9312-74737d4696af",
+                    "observedEthnicityCode": "B1",
+                    "observedEthnicityDescription": "Caribbean",
+                    "selfDefinedEthnicityId": "dcad92c4-53a2-43fb-b1a8-d8241458e0d3",
+                    "selfDefinedEthnicityCode": "W9",
+                    "selfDefinedEthnicityDescription": "Any other White background"
+                  },
+                  "gender": "FEMALE",
+                  "interpreterLanguageNeeds": "Tagalog",
+                  "documentationLanguageNeeds": "WELSH",
+                  "nationalInsuranceNumber": "EJ099885C",
+                  "occupation": "pharmacist",
+                  "occupationCode": "3914",
+                  "specificRequirements": "molestias",
+                  "address": {
+                    "address1": "4637 Victorina Trail",
+                    "address2": "Suite 623",
+                    "address3": "2989",
+                    "address4": "North Porfirio",
+                    "address5": "Palestinian Territory",
+                    "postcode": "51314-0859"
+                  },
+                  "contact": {
+                    "home": "1-867-889-8179",
+                    "work": "1-893-936-4102",
+                    "mobile": "640-287-7987",
+                    "primaryEmail": "anastacia@stoltenberg.io",
+                    "secondaryEmail": "joane_goyette@purdy-purdy.com",
+                    "fax": "1-275-412-9791 x8048"
+                  }
+                },
+                "role": "Uncle"
+              }
+            ],
+            "defenceOrganisation": {
+              "name": "Gutkowski-Schumm",
+              "incorporationNumber": "75-6181739",
+              "registeredCharityNumber": "44-273-5167"
+            },
+            "associatedDefenceOrganisation": {
+              "organisation": {
+                "name": "Gutkowski-Schumm",
+                "incorporationNumber": "75-6181739",
+                "registeredCharityNumber": "44-273-5167"
+              },
+              "fundingType": "PRIVATE",
+              "associationStartDate": "2020-11-18",
+              "associationEndDate": "2020-12-24",
+              "isAssociatedByLAA": true,
+              "applicationReference": "A10000099"
+            },
+            "personDefendant": {
+              "personDetails": {
+                "title": "MR",
+                "firstName": "Jammy",
+                "middleName": "",
+                "lastName": "Dodger",
+                "dateOfBirth": "1987-05-21",
+                "nationalityId": "0fbfa618-77d1-4791-924a-4a1ea02dd041",
+                "nationalityCode": "MQ",
+                "nationalityDescription": "Martinique",
+                "additionalNationalityId": "740c8ea4-b6e3-4167-9d56-2ed0eadf8169",
+                "additionalNationalityCode": "HK",
+                "additionalNationalityDescription": "Hong Kong",
+                "disabilityStatus": "perferendis",
+                "ethnicity": {
+                  "observedEthnicityId": "bf43941a-1627-45cb-b255-ab6efd26b25d",
+                  "observedEthnicityCode": "O9",
+                  "observedEthnicityDescription": "Any other ethnic group",
+                  "selfDefinedEthnicityId": "90ffba21-501c-4e3b-8b00-e451c97067a6",
+                  "selfDefinedEthnicityCode": "M9",
+                  "selfDefinedEthnicityDescription": "Any other mixed background"
+                },
+                "gender": "MALE",
+                "interpreterLanguageNeeds": "Hakka",
+                "documentationLanguageNeeds": "WELSH",
+                "nationalInsuranceNumber": "JC123456A",
+                "occupation": "lawyer",
+                "occupationCode": "5033",
+                "specificRequirements": "natus",
+                "address": {
+                  "address1": "6376 Merrilee Loop",
+                  "address2": "Suite 304",
+                  "address3": "28301",
+                  "address4": "Cinthiatown",
+                  "address5": "Kyrgyz Republic",
+                  "postcode": "35848-9420"
+                },
+                "contact": {
+                  "home": "(376) 129-7081",
+                  "work": "793.293.0858 x83940",
+                  "mobile": "1-131-191-7418",
+                  "primaryEmail": "francesco.blick@fisher.org",
+                  "secondaryEmail": "hailey.tremblay@weissnat.net",
+                  "fax": "829-539-3102 x61653"
+                }
+              },
+              "bailStatus": {
+                "id": "9567a90f-a82c-42ee-92b4-a6ce3687c8d4",
+                "code": "0hs9ytllu5",
+                "description": "Nobis reiciendis deleniti doloremque.",
+                "custodyTimeLimit": {
+                  "timeLimit": "2021-02-02",
+                  "daysSpent": 37
+                }
+              },
+              "bailConditions": "Molestias quasi assumenda necessitatibus.",
+              "bailReasons": "Nostrum tenetur aspernatur autem.",
+              "perceivedBirthYear": 1984,
+              "driverNumber": "Vitae et quis consequatur.",
+              "driverLicenceCode": "FULL",
+              "driverLicenseIssue": "Dolores placeat veniam reprehenderit.",
+              "vehicleOperatorLicenceNumber": "FQMX65V",
+              "arrestSummonsNumber": "XVITYX8RAIHZ",
+              "employerOrganisation": {
+                "name": "Adams Group",
+                "incorporationNumber": "47-6611239",
+                "registeredCharityNumber": "93-131-3851"
+              },
+              "employerPayrollReference": "X41UERQFM"
+            },
+            "aliases": [
+              {
+                "title": "MS",
+                "firstName": "Wallace",
+                "middleName": "Cummings",
+                "lastName": "McClure",
+                "legalEntityName": "Effertz and Sons"
+              }
+            ],
+            "croNumber": "B0000W4DP6",
+            "pncId": "33629585-8"
+          }
+        ],
+        "caseMarkers": [
+          {
+            "id": "dea23b3e-d4c1-40bd-9b64-8cf8d71aa185",
+            "markerTypeid": "f08a69c8-6a69-4308-9c61-e2bfa2c092f3",
+            "markerTypeCode": "JESDPCOXOB",
+            "markerTypeDescription": "UJOBNCSJUQ"
+          }
+        ]
+      }
+    ],
+    "defenceCounsels": [
+      {
+        "id": "c819785d-d39d-4c44-b1ad-bcca76e88c14",
+        "title": "Pres.",
+        "firstName": "Adrian",
+        "middleName": "Jefferey",
+        "lastName": "Pollich",
+        "status": "Junior counsel",
+        "defendants": [
+          "b17e6c2d-1439-4f02-9179-1ff9935729a7"
+        ],
+        "attendanceDays": [
+          "2019-10-24"
+        ]
+      },
+      {
+        "id": "66b5cc0d-1704-4487-a35c-6d96612b2bc2",
+        "title": "Mr.",
+        "firstName": "Leonard",
+        "middleName": "Rafael",
+        "lastName": "DuBuque",
+        "status": "Junior counsel",
+        "defendants": [
+          "d6900d6a-3d36-4d21-9723-d6bb21a5a6db"
+        ],
+        "attendanceDays": [
+          "2019-10-24"
+        ]
+      }
+    ],
+    "isEffectiveTrial": false,
+    "isBoxHearing": false,
+    "hearingDays": [
+      {
+        "sittingDay": "2019-10-25T10:45:00.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      },
+      {
+        "sittingDay": "2019-10-24T08:30:00.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      },
+      {
+        "sittingDay": "2019-10-23T16:19:15.000Z",
+        "listingSequence": 1,
+        "listedDurationMinutes": 1
+      }
+    ]
+  },
+  "sharedTime": "2020-10-30T10:04:27.476+00:00"
+}

--- a/spec/models/hmcts_common_platform/court_application_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HmctsCommonPlatform::CourtApplication, type: :model do
-  let(:data) { JSON.parse(file_fixture("court_application.json").read).deep_symbolize_keys }
+  let(:data) { JSON.parse(file_fixture("court_application.json").read) }
   let(:court_application) { described_class.new(data) }
 
   it "has a type id" do

--- a/spec/models/hmcts_common_platform/defendant_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HmctsCommonPlatform::Defendant, type: :model do
   let(:defendant) { described_class.new(data) }
 
   context "when the defendant has all fields" do
-    let(:data) { JSON.parse(file_fixture("defendant/all_fields.json").read).deep_symbolize_keys }
+    let(:data) { JSON.parse(file_fixture("defendant/all_fields.json").read) }
 
     it "has a proceedings concluded" do
       expect(defendant.proceedings_concluded).to be(false)

--- a/spec/models/hmcts_common_platform/delegated_powers_spec.rb
+++ b/spec/models/hmcts_common_platform/delegated_powers_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HmctsCommonPlatform::DelegatedPowers, type: :model do
-  let(:data) { JSON.parse(file_fixture("delegated_powers.json").read).deep_symbolize_keys }
+  let(:data) { JSON.parse(file_fixture("delegated_powers.json").read) }
   let(:delegated_powers) { described_class.new(data) }
 
   it "has a user id" do

--- a/spec/models/hmcts_common_platform/hearing_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe HmctsCommonPlatform::Hearing, type: :model do
   let(:data) { JSON.parse(file_fixture("hearing/all_fields.json").read) }
-  let(:hearing) { described_class.new(data[:hearing]) }
+  let(:hearing) { described_class.new(data) }
 
   it "has a jurisdiction type" do
     expect(hearing.jurisdiction_type).to eql("CROWN")

--- a/spec/models/hmcts_common_platform/hearing_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HmctsCommonPlatform::Hearing, type: :model do
-  let(:data) { JSON.parse(file_fixture("hearing/all_fields.json").read).deep_symbolize_keys }
+  let(:data) { JSON.parse(file_fixture("hearing/all_fields.json").read) }
   let(:hearing) { described_class.new(data[:hearing]) }
 
   it "has a jurisdiction type" do

--- a/spec/models/hmcts_common_platform/lesser_or_alternative_offence_spec.rb
+++ b/spec/models/hmcts_common_platform/lesser_or_alternative_offence_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HmctsCommonPlatform::LesserOrAlternativeOffence, type: :model do
   let(:lesser_or_alternative_offence) { described_class.new(data) }
 
   context "when lesser or alternative offence has all fields" do
-    let(:data) { JSON.parse(file_fixture("lesser_or_alternative_offence/all_fields.json").read).deep_symbolize_keys }
+    let(:data) { JSON.parse(file_fixture("lesser_or_alternative_offence/all_fields.json").read) }
 
     it "has an offence definition id" do
       expect(lesser_or_alternative_offence.offence_definition_id).to eql("pd22b110-4dbc-3036-a076-e4bb40d0a82t")

--- a/spec/models/hmcts_common_platform/offence_spec.rb
+++ b/spec/models/hmcts_common_platform/offence_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HmctsCommonPlatform::Offence, type: :model do
   let(:offence) { described_class.new(data) }
 
   context "when offence has all fields" do
-    let(:data) { JSON.parse(file_fixture("offence/all_fields.json").read).deep_symbolize_keys }
+    let(:data) { JSON.parse(file_fixture("offence/all_fields.json").read) }
 
     it "has an id" do
       expect(offence.id).to eql("3f153786-f3cf-4311-bc0c-2d6f48af68a1")

--- a/spec/models/hmcts_common_platform/person_defendant_spec.rb
+++ b/spec/models/hmcts_common_platform/person_defendant_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HmctsCommonPlatform::PersonDefendant, type: :model do
-  let(:data) { JSON.parse(file_fixture("person_defendant.json").read).deep_symbolize_keys }
+  let(:data) { JSON.parse(file_fixture("person_defendant.json").read) }
   let(:person_defendant) { described_class.new(data) }
 
   it "has an ASN" do

--- a/spec/models/hmcts_common_platform/plea_spec.rb
+++ b/spec/models/hmcts_common_platform/plea_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HmctsCommonPlatform::Plea, type: :model do
   let(:plea) { described_class.new(data) }
 
   context "when plea has al fields" do
-    let(:data) { JSON.parse(file_fixture("plea/all_fields.json").read).deep_symbolize_keys }
+    let(:data) { JSON.parse(file_fixture("plea/all_fields.json").read) }
 
     it "has an originating hearing id" do
       expect(plea.originating_hearing_id).to eql("pd22b110-4dbc-3036-a076-e4bb40d0a82t")

--- a/spec/models/hmcts_common_platform/verdict_spec.rb
+++ b/spec/models/hmcts_common_platform/verdict_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HmctsCommonPlatform::Verdict, type: :model do
   let(:verdict) { described_class.new(data) }
 
   context "when verdict has all fields" do
-    let(:data) { JSON.parse(file_fixture("verdict/all_fields.json").read).deep_symbolize_keys }
+    let(:data) { JSON.parse(file_fixture("verdict/all_fields.json").read) }
 
     it "has an offence id" do
       expect(verdict.offence_id).to eql("3f153786-f3cf-4311-bc0c-2d6f48af68a1")

--- a/spec/services/defendant_finder_spec.rb
+++ b/spec/services/defendant_finder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DefendantFinder do
   let(:prosecution_cases_hash) { JSON.parse(prosecution_cases_json) }
   let(:prosecution_case) { prosecution_cases_hash["cases"][0] }
 
-  let(:hearing_json) { file_fixture("hearing/all_fields.json").read }
+  let(:hearing_json) { file_fixture("hearing_resulted.json").read }
 
   before do
     ProsecutionCase.create!(id: prosecution_case_id, body: prosecution_case)


### PR DESCRIPTION
## What

Use HashWithIndifferentAccess for storing HMCTS raw data, so as to avoid not being able to access the hash key's value because we're accessing with symbolised rather than stringified keys.

Documentation: https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html

We also split `hearing/all_fields.json` JSON fixture file into `hearing_resulted.json` and removed the `"sharedTime"` and `"hearing"` keys from `hearing/all_fields.json`, which are two distinct entities as per the schema, and are not be confused with one another.