### PR TITLE
Use to_datetime instead of to_date for more granular time comparison

### DIFF
--- a/app/models/maat_api/laa_reference.rb
+++ b/app/models/maat_api/laa_reference.rb
@@ -75,18 +75,20 @@ module MaatApi
     end
 
     def past_hearing_summaries
-      hearing_summaries_with_hearing_days.select { |hs| hs.hearing_days.map(&:sitting_day).max&.to_date&.past? }
+      hearing_summaries_with_hearing_days.select do |hs|
+        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
+      end
     end
 
     def all_hearings_in_past?
       hearing_summaries_with_hearing_days.all? do |hearing_summary|
-        hearing_summary.hearing_days.map(&:sitting_day).max&.to_date&.past?
+        hearing_summary.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
       end
     end
 
     def all_hearings_in_future?
       hearing_summaries_with_hearing_days.all? do |hearing_summary|
-        hearing_summary.hearing_days.map(&:sitting_day).max&.to_date&.future?
+        hearing_summary.hearing_days.map(&:sitting_day).max&.to_datetime&.future?
       end
     end
 

--- a/spec/models/maat_api/laa_reference_spec.rb
+++ b/spec/models/maat_api/laa_reference_spec.rb
@@ -103,4 +103,22 @@ RSpec.describe MaatApi::LaaReference, type: :model do
       end
     end
   end
+
+  context "when the closest hearing in time is the present day" do
+    let(:first_sitting_day) do
+      Time.zone.parse(prosecution_case_summary.hearing_summaries.first.hearing_days.first.sitting_day)
+    end
+
+    it "has a cjs_location" do
+      travel_to(first_sitting_day + 1.minute) do
+        expect(laa_reference.cjs_location).to eql("B30PI")
+      end
+    end
+
+    it "has a cjs_area_code" do
+      travel_to(first_sitting_day + 1.minute) do
+        expect(laa_reference.cjs_area_code).to eql("30")
+      end
+    end
+  end
 end


### PR DESCRIPTION
When hearings are not all in the past, or not all in the future,
the relevant hearing is the most recent one in the past.

However, when we process a defendant on the same day as their
most recent hearing, our time comparison is not granular enough
(unit: day) to determine that a hearing that is a _minute_ old is indeed
in the past.

This commit makes sure we use `datetime` rather than `date` to be able
to handle this particular case.

Fixes: `NoMethodError: undefined method court_centre_oucode_l2_code for nil:NilClass` in `MaatLinkCreatorWorker`

https://sentry.io/organizations/ministryofjustice/issues/2393237966/events/53890fb1778a414baf93431ed1b911f9/?environment=prod&project=5375870