### PR TITLE
rename local variables to standard format

### DIFF
--- a/app/models/maat_api/laa_reference.rb
+++ b/app/models/maat_api/laa_reference.rb
@@ -81,19 +81,19 @@ module MaatApi
     end
 
     def all_hearings_in_past?
-      hearing_summaries_with_hearing_days.all? do |hearing_summary|
-        hearing_summary.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
+      hearing_summaries_with_hearing_days.all? do |hs|
+        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
       end
     end
 
     def all_hearings_in_future?
-      hearing_summaries_with_hearing_days.all? do |hearing_summary|
-        hearing_summary.hearing_days.map(&:sitting_day).max&.to_datetime&.future?
+      hearing_summaries_with_hearing_days.all? do |hs|
+        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.future?
       end
     end
 
     def hearing_summaries_with_hearing_days
-      prosecution_case_summary.hearing_summaries.reject { |summary| summary.hearing_days.blank? }
+      prosecution_case_summary.hearing_summaries.reject { |hs| hs.hearing_days.blank? }
     end
 
     def offences


### PR DESCRIPTION
## What

Rename local variables to standardise the format used - so that the abbreviated format is used consistently

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
