### PR TITLE
Expose court application data on hearing endpoint

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -65,6 +65,16 @@ class Hearing < ApplicationRecord
     common_platform_cracked_ineffective_trial&.fetch("id", nil)
   end
 
+  def court_application_ids
+    court_applications.map(&:id)
+  end
+
+  def court_applications
+    Array(hearing_body["courtApplications"]).map do |court_application_data|
+      HmctsCommonPlatform::CourtApplication.new(court_application_data)
+    end
+  end
+
 private
 
   def hearing_body

--- a/app/models/hmcts_common_platform/court_application.rb
+++ b/app/models/hmcts_common_platform/court_application.rb
@@ -4,7 +4,7 @@ module HmctsCommonPlatform
 
     delegate :blank?, to: :data
 
-    delegate :id, :description, :code, :category_code, :legislation, to: :court_application_type, prefix: true
+    delegate :id, :description, :code, :category_code, :legislation, to: :type, prefix: true
 
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
@@ -90,10 +90,18 @@ module HmctsCommonPlatform
       person_defendant.email_secondary
     end
 
+    def respondent_ids
+      respondents.map(&:id)
+    end
+
     def respondents
       Array(data[:respondents]).map do |respondent_data|
         HmctsCommonPlatform::CourtApplicationParty.new(respondent_data)
       end
+    end
+
+    def judicial_result_ids
+      judicial_results.map(&:id)
     end
 
     def judicial_results
@@ -108,7 +116,7 @@ module HmctsCommonPlatform
       HmctsCommonPlatform::PersonDefendant.new(data.dig(:applicant, :masterDefendant, :personDefendant))
     end
 
-    def court_application_type
+    def type
       HmctsCommonPlatform::CourtApplicationType.new(data[:type])
     end
   end

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -79,10 +79,10 @@ module MaatApi
 
     def offence
       {
-        offenceId: court_application.court_application_type_id,
-        offenceCode: court_application.court_application_type_code,
-        offenceShortTitle: court_application.court_application_type_description,
-        offenceClassification: court_application.court_application_type_category_code,
+        offenceId: court_application.type_id,
+        offenceCode: court_application.type_code,
+        offenceShortTitle: court_application.type_description,
+        offenceClassification: court_application.type_category_code,
         offenceDate: court_application.received_date,
         offenceWording: offence_wording,
         results: judicial_results,
@@ -103,7 +103,7 @@ module MaatApi
     end
 
     def offence_wording
-      [court_application.application_particulars, court_application.court_application_type_legislation].compact.join(" - ").presence
+      [court_application.application_particulars, court_application.type_legislation].compact.join(" - ").presence
     end
 
     def court_centre_short_ou_code

--- a/app/serializers/api/internal/v1/court_application_party_serializer.rb
+++ b/app/serializers/api/internal/v1/court_application_party_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V1
+      class CourtApplicationPartySerializer
+        include JSONAPI::Serializer
+
+        attribute :synonym
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/court_application_serializer.rb
+++ b/app/serializers/api/internal/v1/court_application_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module Internal
+    module V1
+      class CourtApplicationSerializer
+        include JSONAPI::Serializer
+
+        attribute :received_date
+
+        has_one :type, serializer: :court_application_type
+        has_many :respondents, serializer: :court_application_party
+        has_many :judicial_results
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/court_application_type_serializer.rb
+++ b/app/serializers/api/internal/v1/court_application_type_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V1
+      class CourtApplicationTypeSerializer
+        include JSONAPI::Serializer
+
+        attributes :id, :description, :code, :category_code, :legislation, :applicant_appellant_flag
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/hearing_event_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_event_serializer.rb
@@ -5,7 +5,6 @@ module Api
     module V1
       class HearingEventSerializer
         include JSONAPI::Serializer
-        set_type :hearing_events
 
         attributes :description
         attributes :occurred_at

--- a/app/serializers/api/internal/v1/hearing_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_serializer.rb
@@ -15,9 +15,10 @@ module Api
                    :prosecution_advocate_names,
                    :defence_advocate_names
 
-        has_many :hearing_events, record_type: :hearing_events
-        has_many :providers, record_type: :providers
-        has_one :cracked_ineffective_trial, record_type: :cracked_ineffective_trial
+        has_many :hearing_events
+        has_many :providers
+        has_many :court_applications
+        has_one :cracked_ineffective_trial
       end
     end
   end

--- a/app/serializers/api/internal/v1/judicial_result_serializer.rb
+++ b/app/serializers/api/internal/v1/judicial_result_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V1
+      class JudicialResultSerializer
+        include JSONAPI::Serializer
+
+        attributes :id, :cjs_code, :text
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/provider_serializer.rb
+++ b/app/serializers/api/internal/v1/provider_serializer.rb
@@ -5,7 +5,6 @@ module Api
     module V1
       class ProviderSerializer
         include JSONAPI::Serializer
-        set_type :providers
 
         attributes :name, :role
       end

--- a/app/serializers/api/internal/v2/court_application_party_serializer.rb
+++ b/app/serializers/api/internal/v2/court_application_party_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V2
+      class CourtApplicationPartySerializer
+        include JSONAPI::Serializer
+
+        attribute :synonym
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/court_application_serializer.rb
+++ b/app/serializers/api/internal/v2/court_application_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module Internal
+    module V2
+      class CourtApplicationSerializer
+        include JSONAPI::Serializer
+
+        attribute :received_date
+
+        has_one :type, serializer: :court_application_type
+        has_many :respondents, serializer: :court_application_party
+        has_many :judicial_results
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/court_application_type_serializer.rb
+++ b/app/serializers/api/internal/v2/court_application_type_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V2
+      class CourtApplicationTypeSerializer
+        include JSONAPI::Serializer
+
+        attributes :id, :description, :code, :category_code, :legislation, :applicant_appellant_flag
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/hearing_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_serializer.rb
@@ -15,8 +15,9 @@ module Api
                    :prosecution_advocate_names,
                    :defence_advocate_names
 
-        has_many :providers, record_type: :providers
-        has_one :cracked_ineffective_trial, record_type: :cracked_ineffective_trial
+        has_many :providers
+        has_many :court_applications
+        has_one :cracked_ineffective_trial
       end
     end
   end

--- a/app/serializers/api/internal/v2/judicial_result_serializer.rb
+++ b/app/serializers/api/internal/v2/judicial_result_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V2
+      class JudicialResultSerializer
+        include JSONAPI::Serializer
+
+        attributes :id, :cjs_code, :text
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/provider_serializer.rb
+++ b/app/serializers/api/internal/v2/provider_serializer.rb
@@ -5,7 +5,6 @@ module Api
     module V2
       class ProviderSerializer
         include JSONAPI::Serializer
-        set_type :providers
 
         attributes :name, :role
       end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -117,5 +117,22 @@ RSpec.describe Hearing, type: :model do
         it { is_expected.to respond_to(:id, :code, :description, :type) }
       end
     end
+
+    context "with court applications data available" do
+      let(:hearing_data) { JSON.parse(file_fixture("hearing/with_court_application.json").read).deep_symbolize_keys }
+      let(:hearing) { described_class.new(body: hearing_data) }
+
+      describe "#court_applications" do
+        subject { hearing.court_applications }
+
+        it { is_expected.to all be_a(HmctsCommonPlatform::CourtApplication) }
+      end
+
+      describe "#court_application_ids" do
+        subject { hearing.court_application_ids }
+
+        it { is_expected.to eql(%w[c5266a93-389c-4331-a56a-dd000b361cef]) }
+      end
+    end
   end
 end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Hearing, type: :model do
         end
 
         it { expect(hearing.hearing_events).to all be_a(HearingEvent) }
+        it { expect(hearing.hearing_event_ids).to eql %w[a6e53c75-7d42-4187-956a-0d1d80884832] }
 
         context "with blank hearing events" do
           let(:hearing_events) { [hearing_event_recording, nil] }

--- a/spec/models/hmcts_common_platform/court_application_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe HmctsCommonPlatform::CourtApplication, type: :model do
   end
 
   it "has a type id" do
-    expect(court_application.court_application_type_id).to eql("74b72f6f-414a-3464-a4a2-d91397b4c439")
+    expect(court_application.type_id).to eql("74b72f6f-414a-3464-a4a2-d91397b4c439")
   end
 
   it "has a type name" do
-    expect(court_application.court_application_type_description).to eql("Application for transfer of legal aid")
+    expect(court_application.type_description).to eql("Application for transfer of legal aid")
   end
 
   it "has a type code" do
-    expect(court_application.court_application_type_code).to eql("LA12505")
+    expect(court_application.type_code).to eql("LA12505")
   end
 
   it "has a type category code" do
-    expect(court_application.court_application_type_category_code).to eql("CO")
+    expect(court_application.type_category_code).to eql("CO")
   end
 
   it "has a type legislation" do
-    expect(court_application.court_application_type_legislation).to eql("Pursuant to Regulation 14 of the Criminal Legal Aid")
+    expect(court_application.type_legislation).to eql("Pursuant to Regulation 14 of the Criminal Legal Aid")
   end
 
   it "has an application particulars" do

--- a/spec/requests/api/internal/v1/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v1/hearings_request_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require "swagger_helper"
 
-RSpec.describe "Api::Internal::V1::Hearings", type: :request do
+RSpec.describe "api/internal/v1/hearings", type: :request, swagger_doc: "v1/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { access_token }
@@ -24,7 +25,7 @@ RSpec.describe "Api::Internal::V1::Hearings", type: :request do
 
       parameter name: "include", in: :query, required: false, type: :string,
                 schema: {},
-                description: "Return other data through a has_many relationship </br>e.g. include=hearing_events"
+                description: "Return other data through a has_many or has_one relationship </br>e.g. include=providers,court_applications.respondents"
 
       parameter "$ref" => "#/components/parameters/transaction_id_header"
 
@@ -47,18 +48,6 @@ RSpec.describe "Api::Internal::V1::Hearings", type: :request do
             run_test!
           end
         end
-
-        context "with hearing_events included" do
-          let(:include) { "hearing_events" }
-
-          response(200, "Success") do
-            run_test! do |response|
-              hashed = JSON.parse(response.body, symbolize_names: true)
-              included_types = hashed[:included].pluck(:type)
-              expect(included_types).to all(eql("hearing_events"))
-            end
-          end
-        end
       end
 
       context "when request is unauthorized" do
@@ -79,3 +68,4 @@ RSpec.describe "Api::Internal::V1::Hearings", type: :request do
     end
   end
 end
+# rubocop:enable all

--- a/spec/requests/api/internal/v2/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearings_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "api/internal/v2/hearings", type: :request, swagger_doc: "v2/swag
 
       parameter name: "include", in: :query, required: false, type: :string,
                 schema: {},
-                description: "Return other data through a has_many relationship </br>e.g. include=providers"
+                description: "Return other data through a has_many or has_one relationship </br>e.g. include=providers,court_applications.respondents"
 
       parameter "$ref" => "#/components/parameters/transaction_id_header"
 

--- a/spec/serializers/api/internal/v1/court_application_party_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/court_application_party_serializer_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Api::Internal::V1::CourtApplicationPartySerializer do
+  let(:court_application_party_data) { JSON.parse(file_fixture("court_application_party/all_fields.json").read) }
+  let(:court_application_party) { HmctsCommonPlatform::CourtApplicationParty.new(court_application_party_data) }
+
+  it "serializes" do
+    expected = {
+      data: {
+        attributes: {
+          synonym: "suspect",
+        },
+        id: "4f59e8d5-53d5-4175-b9b3-d46363671d03",
+        type: :court_application_party,
+      },
+    }
+
+    expect(described_class.new(court_application_party).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v1/court_application_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/court_application_serializer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Api::Internal::V1::CourtApplicationSerializer do
+  let(:court_application_data) { JSON.parse(file_fixture("court_application.json").read) }
+  let(:court_application) { HmctsCommonPlatform::CourtApplication.new(court_application_data) }
+
+  it "serializes court application data" do
+    expected = {
+      data: {
+        id: "c5266a93-389c-4331-a56a-dd000b361cef",
+        type: :court_application,
+        attributes: {
+          received_date: "2021-03-09",
+        },
+        relationships: {
+          type: {
+            data: {
+              id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+              type: :court_application_type,
+            },
+          },
+          judicial_results: {
+            data: [
+              {
+                id: "be225605-fc15-47aa-b74c-efb8629db58e",
+                type: :judicial_result,
+              },
+            ],
+          },
+          respondents: {
+            data: [
+              {
+                id: "4f59e8d5-53d5-4175-b9b3-d46363671d03",
+                type: :court_application_party,
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    expect(described_class.new(court_application).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v1/court_application_type_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/court_application_type_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Internal::V1::CourtApplicationTypeSerializer do
+  let(:court_application_type_data) { JSON.parse(file_fixture("court_application_type/all_fields.json").read) }
+  let(:court_application_type) { HmctsCommonPlatform::CourtApplicationType.new(court_application_type_data) }
+
+  it "serializes court application type data" do
+    expected = {
+      data: {
+        attributes: {
+          applicant_appellant_flag: false,
+          category_code: "CO",
+          code: "LA12505",
+          description: "Application for transfer of legal aid",
+          id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+          legislation: "Pursuant to Regulation 14 of the Criminal Legal Aid",
+        },
+        id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+        type: :court_application_type,
+      },
+    }
+
+    expect(described_class.new(court_application_type).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v1/hearing_event_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_event_serializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::Internal::V1::HearingEventSerializer do
     subject(:data) { serializable_hash[:data] }
 
     it { is_expected.to include(id: "UUID") }
-    it { is_expected.to include(type: :hearing_events) }
+    it { is_expected.to include(type: :hearing_event) }
     it { is_expected.to have_key(:attributes) }
   end
 

--- a/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
                     prosecution_advocate_names: ["John Rob"],
                     defence_advocate_names: ["Neil Griffiths"],
                     provider_ids: %w[PROVIDER_UUID],
+                    court_application_ids: %w[COURT_APPLICATION_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
 
@@ -33,8 +34,10 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
   context "with relationships" do
     let(:relationship_hash) { subject[:data][:relationships] }
 
-    it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_events }]) }
-    it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :providers }]) }
+    it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_event }]) }
+    it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
+    it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
+    it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 
   context "with required fields only" do

--- a/spec/serializers/api/internal/v1/judicial_result_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/judicial_result_serializer_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::Internal::V1::JudicialResultSerializer do
+  subject(:attributes_hash) { described_class.new(judicial_result).serializable_hash[:data][:attributes] }
+
+  let(:judicial_result_data) { JSON.parse(file_fixture("judicial_result/all_fields.json").read) }
+  let(:judicial_result) { HmctsCommonPlatform::JudicialResult.new(judicial_result_data) }
+
+  it { expect(attributes_hash[:id]).to eql("be225605-fc15-47aa-b74c-efb8629db58e") }
+  it { expect(attributes_hash[:cjs_code]).to eql("4600") }
+  it { expect(attributes_hash[:text]).to eql("Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888") }
+end

--- a/spec/serializers/api/internal/v1/provider_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/provider_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::Internal::V1::ProviderSerializer do
     subject(:data) { serializable_hash[:data] }
 
     it { is_expected.to include(id: "PROVIDER_UUID") }
-    it { is_expected.to include(type: :providers) }
+    it { is_expected.to include(type: :provider) }
     it { is_expected.to have_key(:attributes) }
   end
 

--- a/spec/serializers/api/internal/v2/court_application_party_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/court_application_party_serializer_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Api::Internal::V2::CourtApplicationPartySerializer do
+  let(:court_application_party_data) { JSON.parse(file_fixture("court_application_party/all_fields.json").read) }
+  let(:court_application_party) { HmctsCommonPlatform::CourtApplicationParty.new(court_application_party_data) }
+
+  it "serializes" do
+    expected = {
+      data: {
+        attributes: {
+          synonym: "suspect",
+        },
+        id: "4f59e8d5-53d5-4175-b9b3-d46363671d03",
+        type: :court_application_party,
+      },
+    }
+
+    expect(described_class.new(court_application_party).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v2/court_application_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/court_application_serializer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Api::Internal::V2::CourtApplicationSerializer do
+  let(:court_application_data) { JSON.parse(file_fixture("court_application.json").read) }
+  let(:court_application) { HmctsCommonPlatform::CourtApplication.new(court_application_data) }
+
+  it "serializes court application data" do
+    expected = {
+      data: {
+        id: "c5266a93-389c-4331-a56a-dd000b361cef",
+        type: :court_application,
+        attributes: {
+          received_date: "2021-03-09",
+        },
+        relationships: {
+          type: {
+            data: {
+              id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+              type: :court_application_type,
+            },
+          },
+          judicial_results: {
+            data: [
+              {
+                id: "be225605-fc15-47aa-b74c-efb8629db58e",
+                type: :judicial_result,
+              },
+            ],
+          },
+          respondents: {
+            data: [
+              {
+                id: "4f59e8d5-53d5-4175-b9b3-d46363671d03",
+                type: :court_application_party,
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    expect(described_class.new(court_application).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v2/court_application_type_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/court_application_type_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Internal::V2::CourtApplicationTypeSerializer do
+  let(:court_application_type_data) { JSON.parse(file_fixture("court_application_type/all_fields.json").read) }
+  let(:court_application_type) { HmctsCommonPlatform::CourtApplicationType.new(court_application_type_data) }
+
+  it "serializes court application type data" do
+    expected = {
+      data: {
+        attributes: {
+          applicant_appellant_flag: false,
+          category_code: "CO",
+          code: "LA12505",
+          description: "Application for transfer of legal aid",
+          id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+          legislation: "Pursuant to Regulation 14 of the Criminal Legal Aid",
+        },
+        id: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+        type: :court_application_type,
+      },
+    }
+
+    expect(described_class.new(court_application_type).serializable_hash).to eql(expected)
+  end
+end

--- a/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
                     prosecution_advocate_names: ["John Rob"],
                     defence_advocate_names: ["Neil Griffiths"],
                     provider_ids: %w[PROVIDER_UUID],
+                    court_application_ids: %w[COURT_APPLICATION_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
 
@@ -33,7 +34,9 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
   context "with relationships" do
     let(:relationship_hash) { subject[:data][:relationships] }
 
-    it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :providers }]) }
+    it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
+    it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
+    it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 
   context "with required fields only" do

--- a/spec/serializers/api/internal/v2/judicial_result_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/judicial_result_serializer_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::Internal::V2::JudicialResultSerializer do
+  subject(:attributes_hash) { described_class.new(judicial_result).serializable_hash[:data][:attributes] }
+
+  let(:judicial_result_data) { JSON.parse(file_fixture("judicial_result/all_fields.json").read) }
+  let(:judicial_result) { HmctsCommonPlatform::JudicialResult.new(judicial_result_data) }
+
+  it { expect(attributes_hash[:id]).to eql("be225605-fc15-47aa-b74c-efb8629db58e") }
+  it { expect(attributes_hash[:cjs_code]).to eql("4600") }
+  it { expect(attributes_hash[:text]).to eql("Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888") }
+end

--- a/spec/serializers/api/internal/v2/provider_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/provider_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::Internal::V2::ProviderSerializer do
     subject(:data) { serializable_hash[:data] }
 
     it { is_expected.to include(id: "PROVIDER_UUID") }
-    it { is_expected.to include(type: :providers) }
+    it { is_expected.to include(type: :provider) }
     it { is_expected.to have_key(:attributes) }
   end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -111,7 +111,8 @@ paths:
         required: false
         type: string
         schema: {}
-        description: Return other data through a has_many relationship </br>e.g. include=hearing_events
+        description: Return other data through a has_many or has_one relationship
+          </br>e.g. include=providers,court_applications.respondents
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
       responses:

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -111,7 +111,8 @@ paths:
         required: false
         type: string
         schema: {}
-        description: Return other data through a has_many relationship </br>e.g. include=providers
+        description: Return other data through a has_many or has_one relationship
+          </br>e.g. include=providers,court_applications.respondents
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
       responses:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-590)

Expose court application data on the `GET /hearing/:id` endpoint, on both v1 and v2 of the CDA API.

Data points to expose:

```
hearing.courtApplications.applicationReceivedDate
hearing.courtApplications.type.code
hearing.courtApplications.type.type
hearing.courtApplications.type.legislation
hearing.courtApplications.judicialResults.cjsCode
hearing.courtApplications.judicialResults.resultText
hearing.courtApplications.respondents.synonym
hearing.courtApplications.type.applicantAppellantFlag
```

To get all this information in the response, CDA clients must specify the `include` parameter as follows:

`court_applications.type,court_applications.judicial_results,court_applications.respondents`

Docs: https://github.com/jsonapi-serializer/jsonapi-serializer

## Why

So that VCD can display this data for case workers to view