### PR TITLE
Ensure nil judicial results processed as empty array

### DIFF
--- a/app/models/hmcts_common_platform/court_application.rb
+++ b/app/models/hmcts_common_platform/court_application.rb
@@ -105,7 +105,7 @@ module HmctsCommonPlatform
     end
 
     def judicial_results
-      data[:judicialResults]&.map do |judicial_result_data|
+      Array(data[:judicialResults]).map do |judicial_result_data|
         HmctsCommonPlatform::JudicialResult.new(judicial_result_data)
       end
     end

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
             offenceId: "74b72f6f-414a-3464-a4a2-d91397b4c439",
             offenceShortTitle: "Application for transfer of legal aid",
             offenceWording: nil,
-            results: nil,
+            results: [],
           },
         ],
       }


### PR DESCRIPTION
## What

Judicial results is not a required field on Court Applications. This makes sure if null, judicial results is still processed as an Array and avoids NoMethodError for NilClass 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
