### PR TITLE
Report to Sentry when response body contains HTML

### DIFF
--- a/app/services/api/search_prosecution_case.rb
+++ b/app/services/api/search_prosecution_case.rb
@@ -13,6 +13,10 @@ module Api
   private
 
     def search_results?
+      if response.body.include?("<html>")
+        Sentry.capture_message("Response body contains HTML")
+      end
+
       response.status == 200 && response.body["totalResults"]&.positive?
     end
 

--- a/spec/services/api/search_prosecution_case_spec.rb
+++ b/spec/services/api/search_prosecution_case_spec.rb
@@ -66,4 +66,13 @@ RSpec.describe Api::SearchProsecutionCase do
       search_prosecution_case
     end
   end
+
+  context "when containing HTML" do
+    let(:response_body) { "<html>" }
+
+    it "reports to Sentry" do
+      expect(Sentry).to receive(:capture_message)
+      search_prosecution_case
+    end
+  end
 end


### PR DESCRIPTION
Report to Sentry when response body contains HTML.

Issue: https://dsdmoj.atlassian.net/browse/AAC-100