### PR TITLE
Report response body to Sentry on Hearing ContractError

### DIFF
--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -29,6 +29,12 @@ private
   end
 
   def report_to_sentry(error)
+    # :nocov:
+    Sentry.configure_scope do |scope|
+      scope.set_context("hearing", { body: body })
+    end
+    # :nocov:
+
     Sentry.capture_exception(
       error,
       tags: {

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -87,6 +87,11 @@ RSpec.describe HearingRecorder do
     let(:hearing) { Hearing.create!(body: { foo: "bar" }) }
     let(:body) { "<span>Clearly not a processable hearing body</span>" }
 
+    it "reports exception to Sentry" do
+      expect(Sentry).to receive(:capture_exception)
+      record_hearing
+    end
+
     it "does not create a new record" do
       expect {
         record_hearing


### PR DESCRIPTION
## What

We suspect the hearing endpoint is still returning HTML for a captcha form. Reporting the hearing body to Sentry will let us inspect that.

Tested issue reporting on dev: https://sentry.io/organizations/ministryofjustice/issues/2434542608/?project=5375870&query=is%3Aunresolved