### PR TITLE
Don't raise an error if no ProsecutionCaseDefendantOffence found

### DIFF
--- a/app/services/representation_order_creator.rb
+++ b/app/services/representation_order_creator.rb
@@ -17,7 +17,9 @@ private
 
   def call_common_platform_endpoint
     offences.each do |offence|
-      case_defendant_offence = ProsecutionCaseDefendantOffence.find_by!(defendant_id: defendant_id, offence_id: offence[:offence_id])
+      case_defendant_offence = ProsecutionCaseDefendantOffence.find_by(defendant_id: defendant_id, offence_id: offence[:offence_id])
+
+      next if case_defendant_offence.blank?
 
       Api::RecordRepresentationOrder.call(
         case_defendant_offence: case_defendant_offence,


### PR DESCRIPTION
## What

I have come across a case where the incoming representation order had more offences than listed on HMCTS Common Platform. When this happens, `RepresentationOrderCreatorWorker` jobs stay stuck in the queue, because no `ProsecutionCaseDefendantOffence` can be found for the missing offence.

Instead of raising an error, this PR makes sure we skip making the POST call to Common Platform.
