### PR TITLE
Refactor HearingsCreator to use data-wrapper objects only

### DIFF
--- a/app/controllers/api/external/v1/hearings_controller.rb
+++ b/app/controllers/api/external/v1/hearings_controller.rb
@@ -9,7 +9,7 @@ module Api
 
           HearingRecorder.call(
             hearing_id: params[:hearing][:id],
-            body: transformed_params,
+            hearing_resulted_data: transformed_params,
             publish_to_queue: true,
           )
 

--- a/app/controllers/api/external/v2/hearings_controller.rb
+++ b/app/controllers/api/external/v2/hearings_controller.rb
@@ -9,7 +9,7 @@ module Api
 
           HearingRecorder.call(
             hearing_id: params[:hearing][:id],
-            body: transformed_params,
+            hearing_resulted_data: transformed_params,
             publish_to_queue: true,
           )
 

--- a/app/models/hmcts_common_platform/court_application.rb
+++ b/app/models/hmcts_common_platform/court_application.rb
@@ -115,7 +115,9 @@ module HmctsCommonPlatform
     end
 
     def defendant_cases
-      Array(data.dig(:applicant, :masterDefendant, :defendantCase))
+      Array(data.dig(:applicant, :masterDefendant, :defendantCase)).map do |defendant_case_data|
+        HmctsCommonPlatform::DefendantCase.new(defendant_case_data)
+      end
     end
 
   private

--- a/app/models/hmcts_common_platform/defendant_case.rb
+++ b/app/models/hmcts_common_platform/defendant_case.rb
@@ -1,0 +1,15 @@
+module HmctsCommonPlatform
+  class DefendantCase
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def defendant_id
+      data[:defendantId]
+    end
+  end
+end

--- a/app/models/hmcts_common_platform/hearing_resulted.rb
+++ b/app/models/hmcts_common_platform/hearing_resulted.rb
@@ -1,0 +1,21 @@
+module HmctsCommonPlatform
+  class HearingResulted
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    delegate :jurisdiction_type, :court_centre_id, :first_sitting_day_date, to: :hearing, prefix: true
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def hearing
+      HmctsCommonPlatform::Hearing.new(data[:hearing])
+    end
+
+    def shared_time
+      data[:sharedTime]
+    end
+  end
+end

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -1,13 +1,10 @@
 module MaatApi
   class CourtApplication
-    attr_reader :hearing, :court_application, :maat_reference
+    attr_reader :hearing_resulted, :court_application, :maat_reference
 
-    delegate :jurisdiction_type, to: :hearing
-
-    def initialize(hearing_body, court_application_data, maat_reference)
-      @shared_time = hearing_body[:sharedTime]
-      @hearing = HmctsCommonPlatform::Hearing.new(hearing_body[:hearing])
-      @court_application = HmctsCommonPlatform::CourtApplication.new(court_application_data)
+    def initialize(hearing_resulted, court_application, maat_reference)
+      @hearing_resulted = hearing_resulted
+      @court_application = court_application
       @maat_reference = maat_reference
     end
 
@@ -18,7 +15,7 @@ module MaatApi
     end
 
     def cjs_area_code
-      find_court_centre_by_id(hearing.court_centre_id).oucode_l2_code
+      find_court_centre_by_id(hearing_resulted.hearing_court_centre_id).oucode_l2_code
     end
 
     def cjs_location
@@ -26,7 +23,7 @@ module MaatApi
     end
 
     def case_creation_date
-      @shared_time.to_date.strftime("%Y-%m-%d")
+      hearing_resulted.shared_time.to_date.strftime("%Y-%m-%d")
     end
 
     def doc_language
@@ -45,6 +42,10 @@ module MaatApi
 
     def function_type
       "APPLICATION"
+    end
+
+    def jurisdiction_type
+      hearing_resulted.hearing_jurisdiction_type
     end
 
     def defendant
@@ -108,11 +109,11 @@ module MaatApi
     end
 
     def court_centre_short_ou_code
-      find_court_centre_by_id(hearing.court_centre_id).short_oucode
+      find_court_centre_by_id(hearing_resulted.hearing_court_centre_id).short_oucode
     end
 
     def hearing_first_sitting_day_date
-      hearing.first_sitting_day_date&.to_date&.strftime("%Y-%m-%d")
+      hearing_resulted.hearing_first_sitting_day_date&.to_date&.strftime("%Y-%m-%d")
     end
 
     def find_court_centre_by_id(id)

--- a/app/services/api/get_hearing_results.rb
+++ b/app/services/api/get_hearing_results.rb
@@ -12,7 +12,7 @@ module Api
       if successful_response?
         HearingRecorder.call(
           hearing_id: hearing_id,
-          body: response.body,
+          hearing_resulted_data: response.body,
           publish_to_queue: publish_to_queue,
         )
       end

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class HearingsCreator < ApplicationService
-  def initialize(hearing_id:)
-    @hearing_id = hearing_id
-    @hearing = hearing_body[:hearing]
-    @shared_time = hearing_body[:sharedTime]
-  end
+  attr_reader :hearing_resulted
 
-  def hearing_body
-    Hearing.find(@hearing_id).body.deep_symbolize_keys
+  def initialize(hearing_resulted_data:)
+    @hearing_resulted = HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
   end
 
   def call

--- a/app/workers/hearings_creator_worker.rb
+++ b/app/workers/hearings_creator_worker.rb
@@ -3,9 +3,9 @@
 class HearingsCreatorWorker
   include Sidekiq::Worker
 
-  def perform(request_id, hearing_id)
+  def perform(request_id, hearing_resulted_data)
     Current.set(request_id: request_id) do
-      HearingsCreator.call(hearing_id: hearing_id)
+      HearingsCreator.call(hearing_resulted_data: hearing_resulted_data)
     end
   end
 end

--- a/spec/fixtures/files/defendant_case/all_fields.json
+++ b/spec/fixtures/files/defendant_case/all_fields.json
@@ -1,0 +1,5 @@
+{
+  "defendantId": "eafdd97b-7e81-41cc-b92e-fb86fbcb2ebf",
+  "caseId": "80e9955f-f41d-486a-b12e-afda4e51b713",
+  "caseReference": "TFL12345"
+}

--- a/spec/fixtures/files/defendant_case/required_fields.json
+++ b/spec/fixtures/files/defendant_case/required_fields.json
@@ -1,0 +1,4 @@
+{
+  "defendantId": "eafdd97b-7e81-41cc-b92e-fb86fbcb2ebf",
+  "caseId": "80e9955f-f41d-486a-b12e-afda4e51b713"
+}

--- a/spec/fixtures/files/hearing_resulted.json
+++ b/spec/fixtures/files/hearing_resulted.json
@@ -20,7 +20,6 @@
         "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
         "prosecutionCaseIdentifier": {
           "caseURN": "20GD0217100",
-          "prosecutionAuthorityReference": "UXJYGCVRXJ",
           "prosecutionAuthorityId": "094e3de2-a07f-472f-81ed-da9b254c6c7c",
           "prosecutionAuthorityCode": "UBTMWMUUIJ"
         },
@@ -155,7 +154,7 @@
                     "address3": "2989",
                     "address4": "North Porfirio",
                     "address5": "Palestinian Territory",
-                    "postcode": "51314-0859"
+                    "postcode": "SE1 6TY"
                   },
                   "contact": {
                     "home": "1-867-889-8179",
@@ -221,7 +220,7 @@
                   "address3": "28301",
                   "address4": "Cinthiatown",
                   "address5": "Kyrgyz Republic",
-                  "postcode": "35848-9420"
+                  "postcode": "SW3 6TR"
                 },
                 "contact": {
                   "home": "(376) 129-7081",

--- a/spec/models/hmcts_common_platform/court_application_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe HmctsCommonPlatform::CourtApplication, type: :model do
   end
 
   it "has defendant cases" do
-    expected = [{ "caseId" => "80e9955f-f41d-486a-b12e-afda4e51b713", "defendantId" => "eafdd97b-7e81-41cc-b92e-fb86fbcb2ebf" }]
-    expect(court_application.defendant_cases).to eql(expected)
+    expect(court_application.defendant_cases).to all(be_a(HmctsCommonPlatform::DefendantCase))
   end
 
   it "has a type name" do

--- a/spec/models/hmcts_common_platform/defendant_case_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_case_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe HmctsCommonPlatform::DefendantCase, type: :model do
+  let(:defendant_case) { described_class.new(data) }
+
+  context "with all fields" do
+    let(:data) { JSON.parse(file_fixture("defendant_case/all_fields.json").read) }
+
+    it "matches the HMCTS Common Platform schema" do
+      expect(data).to match_json_schema(:defendant_case)
+    end
+
+    it "has a defendant ID" do
+      expect(defendant_case.defendant_id).to eql("eafdd97b-7e81-41cc-b92e-fb86fbcb2ebf")
+    end
+  end
+
+  context "with required fields" do
+    let(:data) { JSON.parse(file_fixture("defendant_case/required_fields.json").read) }
+
+    it "matches the HMCTS Common Platform schema" do
+      expect(data).to match_json_schema(:defendant_case)
+    end
+
+    it "has a defendant ID" do
+      expect(defendant_case.defendant_id).to eql("eafdd97b-7e81-41cc-b92e-fb86fbcb2ebf")
+    end
+  end
+end

--- a/spec/models/hmcts_common_platform/hearing_resulted_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_resulted_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe HmctsCommonPlatform::HearingResulted, type: :model do
+  let(:data) { JSON.parse(file_fixture("hearing_resulted.json").read) }
+  let(:hearing_resulted) { described_class.new(data) }
+
+  it "matches the HMCTS Common Platform schema" do
+    expect(data).to match_json_schema(:hearing_resulted)
+  end
+
+  it "has a hearing" do
+    expect(hearing_resulted.hearing).to be_a(HmctsCommonPlatform::Hearing)
+  end
+
+  it "has a shared time" do
+    expect(hearing_resulted.shared_time).to eql("2020-10-30T10:04:27.476+00:00")
+  end
+end

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -1,11 +1,9 @@
 RSpec.describe MaatApi::CourtApplication, type: :model do
-  let(:shared_time) { "2021-03-09T15:54:09.871Z" }
   let(:maat_reference) { "123" }
 
   let(:court_application) do
     described_class.new(
-      shared_time,
-      HmctsCommonPlatform::Hearing.new(hearing_resulted_data[:hearing]),
+      HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data),
       HmctsCommonPlatform::CourtApplication.new(hearing_resulted_data.dig(:hearing, :courtApplications).first),
       maat_reference,
     )

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -1,111 +1,124 @@
 RSpec.describe MaatApi::CourtApplication, type: :model do
-  let(:hearing_body) { JSON.parse(file_fixture("hearing/with_court_application.json").read).deep_symbolize_keys }
+  let(:shared_time) { "2021-03-09T15:54:09.871Z" }
   let(:maat_reference) { "123" }
-  let(:court_application_data) { hearing_body.dig(:hearing, :courtApplications).first }
-  let(:court_application) { described_class.new(hearing_body, court_application_data, maat_reference) }
 
-  it "has a maat_reference" do
-    expect(court_application.maat_reference).to eql("123")
+  let(:court_application) do
+    described_class.new(
+      shared_time,
+      HmctsCommonPlatform::Hearing.new(hearing_resulted_data[:hearing]),
+      HmctsCommonPlatform::CourtApplication.new(hearing_resulted_data.dig(:hearing, :courtApplications).first),
+      maat_reference,
+    )
   end
 
-  it "has no case URN" do
-    expect(court_application.case_urn).to be_nil
+  context "with all fields" do
+    let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_court_application.json").read).deep_symbolize_keys }
+
+    it "has a maat_reference" do
+      expect(court_application.maat_reference).to eql("123")
+    end
+
+    it "has no case URN" do
+      expect(court_application.case_urn).to be_nil
+    end
+
+    it "has a jurisdiction type" do
+      expect(court_application.jurisdiction_type).to eql("MAGISTRATES")
+    end
+
+    it "has a defendant ASN" do
+      expect(court_application.defendant_asn).to eql("TFL1")
+    end
+
+    it "has a cjs area code" do
+      expect(court_application.cjs_area_code).to eql("1")
+    end
+
+    it "has no cjs location" do
+      expect(court_application.cjs_location).to eql("B01LY")
+    end
+
+    it "has a case creation date" do
+      expect(court_application.case_creation_date).to eql("2021-03-09")
+    end
+
+    it "has a doc language" do
+      expect(court_application.doc_language).to eql("WELSH")
+    end
+
+    it "has proceedings_concluded flag" do
+      expect(court_application.proceedings_concluded).to be(false)
+    end
+
+    it "has no crown_court_outcome" do
+      expect(court_application.crown_court_outcome).to be_nil
+    end
+
+    it "is always inactive" do
+      expect(court_application.inactive).to eql("Y")
+    end
+
+    it "has a function type of APPLICATION " do
+      expect(court_application.function_type).to eql("APPLICATION")
+    end
+
+    it "has a defendant object" do
+      expected = {
+        forename: "Carlee",
+        surname: "WilliamsonConnelly",
+        dateOfBirth: "1990-01-01",
+        addressLine1: "Address Line 1",
+        addressLine2: "Address Line 2",
+        addressLine3: "Address Line 3",
+        addressLine4: "Address Line 4",
+        addressLine5: "Address Line 5",
+        postcode: "SW1H 9EA",
+        nino: "AA123456C",
+        email1: "primary@example.com",
+        email2: "secondary@example.com",
+        telephoneHome: "000-000-0000",
+        telephoneMobile: "222-222-2222",
+        telephoneWork: "111-111-1111",
+        offences: [
+          {
+            offenceClassification: "CO",
+            offenceCode: "LA12505",
+            offenceDate: "2021-03-09",
+            offenceId: "74b72f6f-414a-3464-a4a2-d91397b4c439",
+            offenceShortTitle: "Application for transfer of legal aid",
+            offenceWording: "application particulars - Pursuant to Regulation 14 of the Criminal Legal Aid",
+            results: [
+              {
+                nextHearingDate: "2020-03-01",
+                nextHearingLocation: "B01LY",
+                resultCode: "4600",
+                resultCodeQualifiers: "",
+                resultShortTitle: "Legal Aid Transfer Granted",
+                resultText: "Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888",
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(court_application.defendant).to eql(expected)
+    end
+
+    it "has a session object" do
+      expected = {
+        courtLocation: "B01LY",
+        dateOfHearing: "2021-03-10",
+        sessionValidateDate: "2021-03-10",
+      }
+
+      expect(court_application.session).to eql(expected)
+    end
   end
 
-  it "has a jurisdiction type" do
-    expect(court_application.jurisdiction_type).to eql("MAGISTRATES")
-  end
-
-  it "has a defendant ASN" do
-    expect(court_application.defendant_asn).to eql("TFL1")
-  end
-
-  it "has a cjs area code" do
-    expect(court_application.cjs_area_code).to eql("1")
-  end
-
-  it "has no cjs location" do
-    expect(court_application.cjs_location).to eql("B01LY")
-  end
-
-  it "has a case creation date" do
-    expect(court_application.case_creation_date).to eql("2021-03-09")
-  end
-
-  it "has a doc language" do
-    expect(court_application.doc_language).to eql("WELSH")
-  end
-
-  it "has proceedings_concluded flag" do
-    expect(court_application.proceedings_concluded).to be(false)
-  end
-
-  it "has no crown_court_outcome" do
-    expect(court_application.crown_court_outcome).to be_nil
-  end
-
-  it "is always inactive" do
-    expect(court_application.inactive).to eql("Y")
-  end
-
-  it "has a function type of APPLICATION " do
-    expect(court_application.function_type).to eql("APPLICATION")
-  end
-
-  it "has a defendant object" do
-    expected = {
-      forename: "Carlee",
-      surname: "WilliamsonConnelly",
-      dateOfBirth: "1990-01-01",
-      addressLine1: "Address Line 1",
-      addressLine2: "Address Line 2",
-      addressLine3: "Address Line 3",
-      addressLine4: "Address Line 4",
-      addressLine5: "Address Line 5",
-      postcode: "SW1H 9EA",
-      nino: "AA123456C",
-      email1: "primary@example.com",
-      email2: "secondary@example.com",
-      telephoneHome: "000-000-0000",
-      telephoneMobile: "222-222-2222",
-      telephoneWork: "111-111-1111",
-      offences: [
-        {
-          offenceClassification: "CO",
-          offenceCode: "LA12505",
-          offenceDate: "2021-03-09",
-          offenceId: "74b72f6f-414a-3464-a4a2-d91397b4c439",
-          offenceShortTitle: "Application for transfer of legal aid",
-          offenceWording: "application particulars - Pursuant to Regulation 14 of the Criminal Legal Aid",
-          results: [
-            {
-              nextHearingDate: "2020-03-01",
-              nextHearingLocation: "B01LY",
-              resultCode: "4600",
-              resultCodeQualifiers: "",
-              resultShortTitle: "Legal Aid Transfer Granted",
-              resultText: "Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888",
-            },
-          ],
-        },
-      ],
-    }
-
-    expect(court_application.defendant).to eql(expected)
-  end
-
-  it "has a session object" do
-    expected = {
-      courtLocation: "B01LY",
-      dateOfHearing: "2021-03-10",
-      sessionValidateDate: "2021-03-10",
-    }
-
-    expect(court_application.session).to eql(expected)
-  end
-
-  context "when the hearing body has only required fields" do
-    let(:hearing_body) { JSON.parse(file_fixture("hearing/with_court_application_required_only.json").read).deep_symbolize_keys }
+  context "when the hearing has a court application with only the required fields" do
+    let(:hearing_resulted_data) do
+      JSON.parse(file_fixture("hearing/with_court_application_required_only.json").read).deep_symbolize_keys
+    end
 
     it "has a maat_reference" do
       expect(court_application.maat_reference).to eql("123")

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe MaatApi::ProsecutionCase, type: :model do
-  let(:shared_time) { "2021-03-09T15:54:09.871Z" }
   let(:maat_reference) { "123" }
   let(:prosecution_case_data) { hearing_resulted_data.dig(:hearing, :prosecutionCases).first }
   let(:case_urn) { prosecution_case_data[:prosecutionCaseIdentifier][:caseURN] }

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -1,12 +1,21 @@
 RSpec.describe MaatApi::ProsecutionCase, type: :model do
+  let(:shared_time) { "2021-03-09T15:54:09.871Z" }
   let(:maat_reference) { "123" }
-  let(:prosecution_case_data) { hearing_body.dig(:hearing, :prosecutionCases).first }
+  let(:prosecution_case_data) { hearing_resulted_data.dig(:hearing, :prosecutionCases).first }
   let(:case_urn) { prosecution_case_data[:prosecutionCaseIdentifier][:caseURN] }
   let(:defendant_data) { prosecution_case_data[:defendants].first }
-  let(:prosecution_case) { described_class.new(hearing_body, case_urn, defendant_data, maat_reference) }
+
+  let(:prosecution_case) do
+    described_class.new(
+      HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data),
+      case_urn,
+      HmctsCommonPlatform::Defendant.new(defendant_data),
+      maat_reference,
+    )
+  end
 
   context "when prosecution case has all fields" do
-    let(:hearing_body) { JSON.parse(file_fixture("hearing/with_prosecution_case.json").read).deep_symbolize_keys }
+    let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_prosecution_case.json").read).deep_symbolize_keys }
 
     it "has a maat_reference" do
       expect(prosecution_case.maat_reference).to eql("123")
@@ -152,7 +161,7 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
   end
 
   context "when the hearing body has only required fields" do
-    let(:hearing_body) { JSON.parse(file_fixture("hearing/with_prosecution_case_required_only.json").read).deep_symbolize_keys }
+    let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_prosecution_case_required_only.json").read).deep_symbolize_keys }
 
     it "has a maat_reference" do
       expect(prosecution_case.maat_reference).to eql("123")

--- a/spec/services/api/get_hearing_results_spec.rb
+++ b/spec/services/api/get_hearing_results_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::GetHearingResults do
   end
 
   it "calls the HearingRecorder service" do
-    expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, body: response.body, publish_to_queue: false)
+    expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: false)
     get_hearing_results
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Api::GetHearingResults do
     subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, publish_to_queue: true) }
 
     it "calls the HearingRecorder service" do
-      expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, body: response.body, publish_to_queue: true)
+      expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: true)
       get_hearing_results
     end
   end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe HearingsCreator do
-  subject(:create_hearings) { described_class.call(hearing_id: hearing.id) }
+  subject(:create_hearings) { described_class.call(hearing_resulted_data: hearing_resulted_data) }
 
   let(:defendant_array) { [defendant_one] }
   let(:offence_array) { [offence_one, offence_two] }
@@ -65,7 +65,7 @@ RSpec.describe HearingsCreator do
       },
     ]
   end
-  let(:hearing_body) do
+  let(:hearing_resulted_data) do
     {
       "hearing": {
         "jurisdictionType": "MAGISTRATES",
@@ -79,7 +79,7 @@ RSpec.describe HearingsCreator do
     }
   end
 
-  let(:hearing) { Hearing.create!(body: hearing_body) }
+  let(:hearing) { Hearing.create!(body: hearing_resulted_data) }
 
   before { allow(Sqs::MessagePublisher).to receive(:call) }
 
@@ -139,7 +139,7 @@ RSpec.describe HearingsCreator do
     end
 
     context "with a crown court hearing" do
-      let(:hearing_body) do
+      let(:hearing_resulted_data) do
         {
           "hearing": {
             "jurisdictionType": "CROWN",

--- a/spec/support/json_schema_rspec.rb
+++ b/spec/support/json_schema_rspec.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
   config.json_schemas[:delegated_powers] = "#{schema_path}/global/apiDelegatedPowers.json"
   config.json_schemas[:hearing] = "#{schema_path}/global/apiHearing.json"
   config.json_schemas[:hearing_day] = "#{schema_path}/global/apiHearingDay.json"
+  config.json_schemas[:hearing_resulted] = "#{schema_path}/api/hearing-resulted.json"
   config.json_schemas[:hearing_summary] = "#{schema_path}/global/search/apiHearingSummary.json"
   config.json_schemas[:judicial_result] = "#{schema_path}/global/apiJudicialResult.json"
   config.json_schemas[:laa_reference] = "#{schema_path}/global/apiLaaReference.json"

--- a/spec/support/json_schema_rspec.rb
+++ b/spec/support/json_schema_rspec.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
   config.json_schemas[:court_application_type] = "#{schema_path}/global/apiCourtApplicationType.json"
   config.json_schemas[:court_centre] = "#{schema_path}/global/apiCourtCentre.json"
   config.json_schemas[:defendant] = "#{schema_path}/global/apiDefendant.json"
+  config.json_schemas[:defendant_case] = "#{schema_path}/global/apiDefendantCase.json"
   config.json_schemas[:defendant_summary] = "#{schema_path}/global/search/apiDefendantSummary.json"
   config.json_schemas[:delegated_powers] = "#{schema_path}/global/apiDelegatedPowers.json"
   config.json_schemas[:hearing] = "#{schema_path}/global/apiHearing.json"

--- a/spec/workers/hearings_creator_worker_spec.rb
+++ b/spec/workers/hearings_creator_worker_spec.rb
@@ -3,26 +3,18 @@
 require "sidekiq/testing"
 
 RSpec.describe HearingsCreatorWorker, type: :worker do
-  subject(:work) do
-    described_class.perform_async(request_id, hearing_id)
-  end
+  subject(:work) { described_class.perform_async(request_id, hearing_resulted_data) }
 
-  let(:hearing_id) { "04180ff1-99b0-40b7-9929-ca05bdc767d8" }
+  let(:hearing_resulted_data) { "some data" }
   let(:request_id) { "XYZ" }
 
-  before do
-    Hearing.create!(id: hearing_id, body: JSON.parse(file_fixture("hearing/valid.json").read))
-  end
-
   it "queues the job" do
-    expect {
-      work
-    }.to change(described_class.jobs, :size).by(1)
+    expect { work }.to change(described_class.jobs, :size).by(1)
   end
 
   it "creates a HearingsCreator and calls with a transformed hash" do
     Sidekiq::Testing.inline! do
-      expect(HearingsCreator).to receive(:call).once.with(hearing_id: hearing_id).and_call_original
+      expect(HearingsCreator).to receive(:call).once.with(hearing_resulted_data: "some data")
       work
     end
   end


### PR DESCRIPTION
## What

* Rename body to hearing_resulted_data
* Create extra data-wrapper objects
* Refactor HearingsCreator to use data-wrapper objects only
* Refactor MaatApi::CourtApplication
* MaatApi::ProsecutionCase

