### PR TITLE
Handle delayed jobs with hearing_id arg

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 class HearingsCreator < ApplicationService
-  attr_reader :hearing_resulted
+  attr_reader :hearing_resulted_data
 
   def initialize(hearing_resulted_data:)
-    @hearing_resulted = HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
+    @hearing_resulted_data = hearing_resulted_data
+  end
+
+  def hearing_resulted
+    # :nocov:
+    if hearing_resulted_data.is_a?(String)
+      hearing_id = hearing_resulted_data
+      HmctsCommonPlatform::HearingResulted.new(Hearing.find(hearing_id).body)
+    end
+    # :nocov:
+
+    if hearing_resulted_data.is_a?(Hash)
+      HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
+    end
   end
 
   def call


### PR DESCRIPTION
## What

We need to handle delayed jobs that still have `hearing_id` as one of the arguments until they've all been processed.

Once they have, we can revert this patch.
