### PR TITLE
Remove hearing ID temporary patch

### DIFF
--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -1,25 +1,10 @@
 # frozen_string_literal: true
 
 class HearingsCreator < ApplicationService
-  attr_reader :hearing_resulted_data
+  attr_reader :hearing_resulted
 
   def initialize(hearing_resulted_data:)
-    @hearing_resulted_data = hearing_resulted_data
-  end
-
-  def hearing_resulted
-    # :nocov:
-    if hearing_resulted_data.is_a?(String)
-      hearing_id = hearing_resulted_data
-      result = HmctsCommonPlatform::HearingResulted.new(Hearing.find(hearing_id).body)
-    end
-    # :nocov:
-
-    if hearing_resulted_data.is_a?(Hash)
-      result = HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
-    end
-
-    result
+    @hearing_resulted = HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
   end
 
   def call


### PR DESCRIPTION
## What

Now that all the jobs in the retry queue have successfully been processed, this removes the temporary patch to be able to handle delayed jobs containing `hearing_id` as argument.

reverts https://github.com/ministryofjustice/laa-court-data-adaptor/pull/570