### PR TITLE
Initialize Prometheus in production environment only

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,4 +1,4 @@
-unless Rails.env.test?
+if Rails.env.production?
   require "prometheus_exporter/instrumentation"
   require "prometheus_exporter/middleware"
 


### PR DESCRIPTION
## What

This PR makes sure we Prometheus in production environment only.

Otherwise we get this issue when in a dev environment:

<img width="828" alt="Screenshot 2021-07-01 at 16 48 12" src="https://user-images.githubusercontent.com/3141541/124144471-4b632f00-da8c-11eb-98d5-d1ecbacf09c6.png">

Note: All our live environments (UAT, stage, dev, test, etc.) are set to have `RAILS_ENV = production` so prometheus_exporter will run in these live envs and we won't encounter this issue, because a prometheus server will be running on port 9394.
