### PR TITLE
Isolate CourtCentre lookup in one method only

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -4,7 +4,7 @@ class Hearing < ApplicationRecord
   validates :body, presence: true
 
   def court_name
-    court_centre.oucode_l3_name
+    court_centre.name
   end
 
   def hearing_type
@@ -100,7 +100,7 @@ private
   end
 
   def court_centre
-    @court_centre ||= HmctsCommonPlatform::Reference::CourtCentre.find(hearing_body["courtCentre"]["id"])
+    HmctsCommonPlatform::CourtCentre.new(hearing_body["courtCentre"])
   end
 
   def common_platform_cracked_ineffective_trial

--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -38,6 +38,6 @@ class HearingSummary
 private
 
   def court_centre
-    @court_centre ||= HmctsCommonPlatform::Reference::CourtCentre.find(body["courtCentre"]["id"])
+    HmctsCommonPlatform::CourtCentre.new(body["courtCentre"])
   end
 end

--- a/app/models/hmcts_common_platform/court_centre.rb
+++ b/app/models/hmcts_common_platform/court_centre.rb
@@ -21,5 +21,19 @@ module HmctsCommonPlatform
     def room_name
       data[:roomName]
     end
+
+    def short_oucode
+      # Extract 5 first characters
+      code[0..4] if code
+    end
+
+    def oucode_l2_code
+      # Extract second and third characters, and strip any leading zeros
+      code[1..2].sub(/^0*/, "") if code
+    end
+
+    def code
+      data[:code] || HmctsCommonPlatform::Reference::CourtCentre.find(id).oucode
+    end
   end
 end

--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -31,5 +31,9 @@ module HmctsCommonPlatform
         HmctsCommonPlatform::CourtApplication.new(court_application_data)
       end
     end
+
+    def court_centre
+      HmctsCommonPlatform::CourtCentre.new(data[:courtCentre])
+    end
   end
 end

--- a/app/models/hmcts_common_platform/hearing_resulted.rb
+++ b/app/models/hmcts_common_platform/hearing_resulted.rb
@@ -4,7 +4,7 @@ module HmctsCommonPlatform
 
     delegate :blank?, to: :data
 
-    delegate :jurisdiction_type, :court_centre_id, :first_sitting_day_date, to: :hearing, prefix: true
+    delegate :jurisdiction_type, :court_centre_id, :court_centre, :first_sitting_day_date, to: :hearing, prefix: true
 
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})

--- a/app/models/hmcts_common_platform/hearing_summary.rb
+++ b/app/models/hmcts_common_platform/hearing_summary.rb
@@ -2,6 +2,8 @@ module HmctsCommonPlatform
   class HearingSummary
     attr_accessor :data
 
+    delegate :short_oucode, :oucode_l2_code, to: :court_centre, prefix: true
+
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
     end
@@ -22,20 +24,6 @@ module HmctsCommonPlatform
 
     def court_centre
       HmctsCommonPlatform::CourtCentre.new(data[:courtCentre])
-    end
-
-    def court_centre_short_oucode
-      hmcts_common_platform_reference_court_centre.short_oucode
-    end
-
-    def court_centre_oucode_l2_code
-      hmcts_common_platform_reference_court_centre.oucode_l2_code
-    end
-
-  private
-
-    def hmcts_common_platform_reference_court_centre
-      @hmcts_common_platform_reference_court_centre ||= HmctsCommonPlatform::Reference::CourtCentre.find(court_centre.id)
     end
   end
 end

--- a/app/models/hmcts_common_platform/judicial_result.rb
+++ b/app/models/hmcts_common_platform/judicial_result.rb
@@ -36,6 +36,10 @@ module HmctsCommonPlatform
       data.dig(:nextHearing, :courtCentre, :id)
     end
 
+    def next_hearing_court_centre
+      HmctsCommonPlatform::CourtCentre.new(data.dig(:nextHearing, :courtCentre))
+    end
+
     def next_hearing_date
       data.dig(:nextHearing, :listedStartDateTime)
     end

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -15,11 +15,11 @@ module MaatApi
     end
 
     def cjs_area_code
-      find_court_centre_by_id(hearing_resulted.hearing_court_centre_id).oucode_l2_code
+      hearing_resulted.hearing_court_centre.oucode_l2_code
     end
 
     def cjs_location
-      court_centre_short_ou_code
+      hearing_resulted.hearing_court_centre.short_oucode
     end
 
     def case_creation_date
@@ -71,7 +71,7 @@ module MaatApi
 
     def session
       {
-        courtLocation: court_centre_short_ou_code,
+        courtLocation: hearing_resulted.hearing_court_centre.short_oucode,
         dateOfHearing: hearing_first_sitting_day_date,
         sessionValidateDate: hearing_first_sitting_day_date,
       }
@@ -99,7 +99,7 @@ module MaatApi
           resultText: judicial_result.text,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
-          nextHearingLocation: find_court_centre_by_id(judicial_result.next_hearing_court_centre_id)&.short_oucode,
+          nextHearingLocation: judicial_result.next_hearing_court_centre.short_oucode,
         }
       end
     end
@@ -108,18 +108,8 @@ module MaatApi
       [court_application.application_particulars, court_application.type_legislation].compact.join(" - ").presence
     end
 
-    def court_centre_short_ou_code
-      find_court_centre_by_id(hearing_resulted.hearing_court_centre_id).short_oucode
-    end
-
     def hearing_first_sitting_day_date
       hearing_resulted.hearing_first_sitting_day_date&.to_date&.strftime("%Y-%m-%d")
-    end
-
-    def find_court_centre_by_id(id)
-      return if id.blank?
-
-      HmctsCommonPlatform::Reference::CourtCentre.find(id)
     end
   end
 end

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -14,7 +14,7 @@ module MaatApi
     end
 
     def cjs_area_code
-      court_centre.oucode_l2_code
+      hearing_resulted.hearing_court_centre.oucode_l2_code
     end
 
     def case_creation_date
@@ -22,7 +22,7 @@ module MaatApi
     end
 
     def cjs_location
-      court_centre.short_oucode
+      hearing_resulted.hearing_court_centre.short_oucode
     end
 
     def doc_language
@@ -68,7 +68,7 @@ module MaatApi
 
     def session
       {
-        courtLocation: court_centre.short_oucode,
+        courtLocation: hearing_resulted.hearing_court_centre.short_oucode,
         dateOfHearing: hmcts_common_platform_defendant.offences&.first&.results&.first&.ordered_date,
         postHearingCustody: PostHearingCustodyCalculator.call(offences: hmcts_common_platform_defendant.data[:offences]),
         sessionValidateDate: hmcts_common_platform_defendant.offences&.first&.results&.first&.ordered_date,
@@ -110,7 +110,7 @@ module MaatApi
           resultText: judicial_result.text,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
-          nextHearingLocation: find_court_centre_by_id(judicial_result.next_hearing_court_centre_id)&.short_oucode,
+          nextHearingLocation: judicial_result.next_hearing_court_centre.short_oucode,
           laaOfficeAccount: offence.laa_reference_laa_contract_number,
           legalAidWithdrawalDate: offence.laa_reference_effective_end_date,
         }
@@ -157,16 +157,6 @@ module MaatApi
         offenceLegislation: data.offence_legislation,
         offenceLegislationWelsh: data.offence_legislation_welsh,
       }.compact
-    end
-
-    def court_centre
-      find_court_centre_by_id(hearing_resulted.hearing_court_centre_id)
-    end
-
-    def find_court_centre_by_id(id)
-      return if id.blank?
-
-      HmctsCommonPlatform::Reference::CourtCentre.find(id)
     end
 
     def result_is_a_conclusion?

--- a/spec/fixtures/files/court_centre/all_fields.json
+++ b/spec/fixtures/files/court_centre/all_fields.json
@@ -2,5 +2,6 @@
   "id": "14876ea1-5f7c-32ef-9fbd-aa0b63193550",
   "name": "Derby Justice Centre (aka Derby St Mary Adult)",
   "roomId": "2fc95ce0-79e5-33c6-901a-733c90905e59",
-  "roomName": "Courtroom 08"
+  "roomName": "Courtroom 08",
+  "code": "B30PI00"
 }

--- a/spec/fixtures/files/hearing/with_court_application.json
+++ b/spec/fixtures/files/hearing/with_court_application.json
@@ -456,7 +456,8 @@
             "lifeDuration": false,
             "nextHearing": {
               "courtCentre": {
-                "id": "f8254db1-1683-483e-afb3-b87fde5a0a26"
+                "id": "f8254db1-1683-483e-afb3-b87fde5a0a26",
+                "code": "B01LY00"
               },
               "listedStartDateTime": "2020-03-01"
             },

--- a/spec/fixtures/files/hearing/with_court_application_required_only.json
+++ b/spec/fixtures/files/hearing/with_court_application_required_only.json
@@ -3,7 +3,8 @@
       "id": "dafbe7f9-2f42-4781-8bbf-24ce47d51fd5",
       "jurisdictionType": "MAGISTRATES",
       "courtCentre": {
-        "id": "f8254db1-1683-483e-afb3-b87fde5a0a26"
+        "id": "f8254db1-1683-483e-afb3-b87fde5a0a26",
+        "code": "B01LY00"
       },
       "type": {
         "description": "First hearing",

--- a/spec/fixtures/files/hearing/with_prosecution_case.json
+++ b/spec/fixtures/files/hearing/with_prosecution_case.json
@@ -7,7 +7,8 @@
         "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
         "name": "Warrington CCU (Decom)",
         "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
-        "roomName": "Warrington CCU (Decom)"
+        "roomName": "Warrington CCU (Decom)",
+        "code": "A07AF00"
       },
       "hearingLanguage": "WELSH",
       "hasSharedResults": false,
@@ -115,7 +116,11 @@
                       "postHearingCustodyStatus": "B",
                       "nextHearing": {
                         "courtCentre": {
-                          "id": "f8254db1-1683-483e-afb3-b87fde5a0a26"
+                          "id": "bab6ad2d-e25c-367c-9b4f-4a4d6b1d1edb",
+                          "name": "North Staffordshire Justice Centre",
+                          "roomId": "4e1b2465-6694-3cae-9887-1c1fc61c9668",
+                          "roomName": "Courtroom 03",
+                          "code": "B21JI00"
                         },
                         "listedStartDateTime": "2019-10-23T16:19:15.000Z"
                       }

--- a/spec/fixtures/files/hearing/with_prosecution_case_required_only.json
+++ b/spec/fixtures/files/hearing/with_prosecution_case_required_only.json
@@ -6,7 +6,8 @@
         "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
         "name": "Warrington CCU (Decom)",
         "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
-        "roomName": "Warrington CCU (Decom)"
+        "roomName": "Warrington CCU (Decom)",
+        "code": "A07AF00"
       },
       "type": {
         "id": "63003e58-d753-46e2-a2c8-47fd15341592",

--- a/spec/fixtures/files/prosecution_case_search_result.json
+++ b/spec/fixtures/files/prosecution_case_search_result.json
@@ -65,7 +65,8 @@
             "id": "7e967376-eacf-4fca-9b30-21b0c5aad427",
             "name": "Bexley Magistrates' Court",
             "roomId": "8e912353-3b5d-36c3-953e-ad3b94b19de3",
-            "roomName": "Courtroom 01"
+            "roomName": "Courtroom 01",
+            "code": "B01BH00"
           }
         },
         {

--- a/spec/fixtures/files/prosecution_case_summary/all_fields.json
+++ b/spec/fixtures/files/prosecution_case_summary/all_fields.json
@@ -110,7 +110,8 @@
         "id": "14876ea1-5f7c-32ef-9fbd-aa0b63193550",
         "name": "Derby Justice Centre (aka Derby St Mary Adult)",
         "roomId": "2fc95ce0-79e5-33c6-901a-733c90905e59",
-        "roomName": "Courtroom 08"
+        "roomName": "Courtroom 08",
+        "code": "B30PI00"
       }
     },
     {
@@ -135,7 +136,8 @@
         "id": "6131bd34-33d9-3d1e-8152-8b5a2084f1bd",
         "name": "Derby Crown Court",
         "roomId": "594d6332-9806-38ab-830d-5941e671e0bb",
-        "roomName": "Courtroom 01"
+        "roomName": "Courtroom 01",
+        "code": "C30DE00"
       }
     }
   ]

--- a/spec/models/hmcts_common_platform/court_centre_spec.rb
+++ b/spec/models/hmcts_common_platform/court_centre_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
     it { expect(court_centre.name).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
     it { expect(court_centre.room_id).to eq("2fc95ce0-79e5-33c6-901a-733c90905e59") }
     it { expect(court_centre.room_name).to eq("Courtroom 08") }
+    it { expect(court_centre.code).to eq("B30PI00") }
+    it { expect(court_centre.short_oucode).to eq("B30PI") }
+    it { expect(court_centre.oucode_l2_code).to eq("30") }
   end
 
   context "with required fields only" do
@@ -25,5 +28,8 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
     it { expect(court_centre.name).to be_nil }
     it { expect(court_centre.room_id).to be_nil }
     it { expect(court_centre.room_name).to be_nil }
+    it { expect(court_centre.code).to eq("B30PI00") }
+    it { expect(court_centre.short_oucode).to eq("B30PI") }
+    it { expect(court_centre.oucode_l2_code).to eq("30") }
   end
 end

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
                 resultText: "Result",
                 resultCodeQualifiers: "Qualifier",
                 nextHearingDate: "2019-10-23",
-                nextHearingLocation: "B01LY",
+                nextHearingLocation: "B21JI",
                 laaOfficeAccount: "092874",
                 legalAidWithdrawalDate: "2021-04-11",
               },


### PR DESCRIPTION
PR https://github.com/ministryofjustice/laa-court-data-adaptor/pull/584 had to be urgently reverted because the court centre code is not yet present in all court centre payloads coming from Common Platform (contrarily to what we were promised).

This PR:

* reinstates the above reverted PR
* adds back the dependency on the Court Centre table lookup
* isolates the CourtCentre lookup to [one method only](https://github.com/ministryofjustice/laa-court-data-adaptor/pull/601/files#diff-87e9a4033fcc352a52c78edaefb576fa7c97f200245fd91d5159b1c925dddd09R36)

This means that once CP includes court centre codes in their payloads, we'll be able to remove the dependency on the court centre lookup with a one-line change in the code.

