### PR TITLE
Handle case of null nextHearing

### DIFF
--- a/app/models/hmcts_common_platform/judicial_result.rb
+++ b/app/models/hmcts_common_platform/judicial_result.rb
@@ -37,7 +37,7 @@ module HmctsCommonPlatform
     end
 
     def next_hearing_court_centre
-      HmctsCommonPlatform::CourtCentre.new(data.dig(:nextHearing, :courtCentre))
+      HmctsCommonPlatform::CourtCentre.new(data.dig(:nextHearing, :courtCentre)) if data[:nextHearing]
     end
 
     def next_hearing_date

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -99,7 +99,7 @@ module MaatApi
           resultText: judicial_result.text,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
-          nextHearingLocation: judicial_result.next_hearing_court_centre.short_oucode,
+          nextHearingLocation: judicial_result.next_hearing_court_centre&.short_oucode,
         }
       end
     end

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -110,7 +110,7 @@ module MaatApi
           resultText: judicial_result.text,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
-          nextHearingLocation: judicial_result.next_hearing_court_centre.short_oucode,
+          nextHearingLocation: judicial_result.next_hearing_court_centre&.short_oucode,
           laaOfficeAccount: offence.laa_reference_laa_contract_number,
           legalAidWithdrawalDate: offence.laa_reference_effective_end_date,
         }


### PR DESCRIPTION
## What

Prevents null pointer error when there is no next hearing on a judicial result.

Fixes: https://sentry.io/organizations/ministryofjustice/issues/2513879941/events/5e5dc4193c56477bb889f22c4575e5fb/events/?environment=prod&project=5375870