### PR TITLE
Elevate privileges on gem install bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: install bundle
           command: |
-            gem install bundler -N
+            sudo gem install bundler -N
 
       - run:
           name: install dependencies


### PR DESCRIPTION
## What

Fix CI:

```
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /usr/local/bundle directory.
The command '/bin/sh -c gem install bundler:2.1.4 -N && bundle install --path=vendor/bundle' returned a non-zero code: 1
```

https://bundler.io/doc/troubleshooting.html
