### PR TITLE
Don't raise error on subsequent linking attempts

### DIFF
--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -15,7 +15,7 @@ class MaatLinkCreator < ApplicationService
     publish_laa_reference_to_queue unless laa_reference.dummy_maat_reference?
     post_laa_references_to_common_platform
     fetch_past_hearings
-    persist_laa_reference!
+    persist_laa_reference
   end
 
 private
@@ -49,8 +49,8 @@ private
     )
   end
 
-  def persist_laa_reference!
-    laa_reference.save!
+  def persist_laa_reference
+    laa_reference.save
   end
 
   def fetch_past_hearings

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -72,12 +72,6 @@ RSpec.describe MaatLinkCreator do
   context "when an LaaReference exists" do
     let!(:existing_laa_reference) { LaaReference.create!(defendant_id: SecureRandom.uuid, user_name: "MrDoe", maat_reference: maat_reference) }
 
-    it "raises an ActiveRecord::RecordInvalid error" do
-      expect {
-        create_maat_link
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
     context "and it is no longer linked" do
       before do
         existing_laa_reference.update!(linked: false)


### PR DESCRIPTION
## What

When a case worker links a defendant, it can happen that the linking request to CP fails, even though CDA has updated its `laa_references` table.

When that happens, the case worker, seeing that the defendant is still unlinked (VCD UI looks at CP data to establish that), sends another linking attempt to CDA, which fails because CDA enforces a uniqueness constraint on the pair of attributes `:linked` and `:maat_reference`.

These [Sentry errors](https://sentry.io/organizations/ministryofjustice/issues/2463922029/?project=5375870&query=is%3Aunresolved) are all due to this.

This PR keeps the constraint, but makes sure CDA doesn't block the new linking request (delayed job) by raising an error.

This is all doable because both CP and MAAT API are idempotent for linkings.