### PR TITLE
Expose court name on case search endpoint

### DIFF
--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -15,8 +15,8 @@ class HearingSummary
     body["hearingType"]["description"]
   end
 
-  def hearing_days
-    body["hearingDays"].map { |hearing_day| hearing_day["sittingDay"] }
+  def sitting_days
+    hearing_days.map(&:sitting_day)
   end
 
   def hearing_in_past?
@@ -32,12 +32,18 @@ class HearingSummary
   end
 
   def date_of_hearing
-    hearing_days.max&.to_date
+    sitting_days.max&.to_date
+  end
+
+  def court_centre
+    HmctsCommonPlatform::CourtCentre.new(body["courtCentre"])
   end
 
 private
 
-  def court_centre
-    HmctsCommonPlatform::CourtCentre.new(body["courtCentre"])
+  def hearing_days
+    Array(body["hearingDays"]).map do |hearing_day_data|
+      HmctsCommonPlatform::HearingDay.new(hearing_day_data)
+    end
   end
 end

--- a/app/serializers/api/internal/v1/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_summary_serializer.rb
@@ -5,9 +5,19 @@ module Api
     module V1
       class HearingSummarySerializer
         include JSONAPI::Serializer
-        set_type :hearing_summaries
+        attributes :hearing_type
 
-        attributes :hearing_type, :hearing_days
+        attribute :hearing_days do |hearing_summary|
+          hearing_summary.sitting_days.map do |day|
+            Date.parse(day).to_formatted_s(:db)
+          end
+        end
+
+        attribute :court_centre do |hearing_summary|
+          {
+            name: hearing_summary.court_centre.name,
+          }
+        end
       end
     end
   end

--- a/app/serializers/api/internal/v2/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_summary_serializer.rb
@@ -5,9 +5,19 @@ module Api
     module V2
       class HearingSummarySerializer
         include JSONAPI::Serializer
-        set_type :hearing_summaries
+        attributes :hearing_type
 
-        attributes :hearing_type, :hearing_days
+        attribute :hearing_days do |hearing_summary|
+          hearing_summary.sitting_days.map do |day|
+            Date.parse(day).to_formatted_s(:db)
+          end
+        end
+
+        attribute :court_centre do |hearing_summary|
+          {
+            name: hearing_summary.court_centre.name,
+          }
+        end
       end
     end
   end

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HearingSummary, type: :model do
 
   it { expect(hearing_summary.id).to eq("b935a64a-6d03-4da4-bba6-4d32cc2e7fb4") }
   it { expect(hearing_summary.hearing_type).to eq("First hearing") }
-  it { expect(hearing_summary.hearing_days).to eq(["2020-02-17T15:00:00Z"]) }
+  it { expect(hearing_summary.sitting_days).to eq(["2020-02-17T15:00:00Z"]) }
   it { expect(hearing_summary.short_oucode).to eq("B01BH") }
   it { expect(hearing_summary.oucode_l2_code).to eq("1") }
   it { expect(hearing_summary.resulted?).to eq false }

--- a/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Internal::V1::HearingSummarySerializer do
-  subject { described_class.new(hearing_summary).serializable_hash }
+  subject(:attributes_hash) { described_class.new(hearing_summary).serializable_hash[:data][:attributes] }
 
-  let(:hearing_summary) do
-    instance_double("HearingSummary",
-                    id: "UUID",
-                    hearing_type: "Committal for Sentencing",
-                    hearing_days: %w[2020-02-01])
-  end
+  let(:hearing_summary_data) { JSON.parse(file_fixture("hearing_summary/all_fields.json").read) }
+  let(:hearing_summary) { HearingSummary.new(body: hearing_summary_data) }
 
-  context "with attributes" do
-    let(:attribute_hash) { subject[:data][:attributes] }
-
-    it { expect(attribute_hash[:hearing_type]).to eq("Committal for Sentencing") }
-    it { expect(attribute_hash[:hearing_days]).to eq(%w[2020-02-01]) }
-  end
+  it { expect(attributes_hash[:hearing_type]).to eq("First hearing") }
+  it { expect(attributes_hash[:hearing_days]).to eq(%w[2021-03-25]) }
+  it { expect(attributes_hash[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
 end

--- a/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Internal::V2::HearingSummarySerializer do
-  subject { described_class.new(hearing_summary).serializable_hash }
+  subject(:attributes_hash) { described_class.new(hearing_summary).serializable_hash[:data][:attributes] }
 
-  let(:hearing_summary) do
-    instance_double("HearingSummary",
-                    id: "UUID",
-                    hearing_type: "Committal for Sentencing",
-                    hearing_days: %w[2020-02-01])
-  end
+  let(:hearing_summary_data) { JSON.parse(file_fixture("hearing_summary/all_fields.json").read) }
+  let(:hearing_summary) { HearingSummary.new(body: hearing_summary_data) }
 
-  context "with attributes" do
-    let(:attribute_hash) { subject[:data][:attributes] }
-
-    it { expect(attribute_hash[:hearing_type]).to eq("Committal for Sentencing") }
-    it { expect(attribute_hash[:hearing_days]).to eq(%w[2020-02-01]) }
-  end
+  it { expect(attributes_hash[:hearing_type]).to eq("First hearing") }
+  it { expect(attributes_hash[:hearing_days]).to eq(%w[2021-03-25]) }
+  it { expect(attributes_hash[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
 end

--- a/swagger/v1/hearing_summary.json
+++ b/swagger/v1/hearing_summary.json
@@ -27,6 +27,18 @@
       "description": "A description of the hearing type",
       "type": "string"
     },
+    "court_centre": {
+      "readOnly": true,
+      "description": "An object representing court centre details",
+      "type": "object",
+      "properties": {
+        "name": {
+          "example": "Derby Justice Centre",
+          "description": "The name of the court centre",
+          "type": "string"
+        }
+      }
+    },
     "identity": {
       "$ref": "#/definitions/id"
     },
@@ -65,6 +77,9 @@
         },
         "hearing_days": {
           "$ref": "#/definitions/hearing_days"
+        },
+        "court_centre": {
+          "$ref": "#/definitions/court_centre"
         }
       }
     }

--- a/swagger/v2/hearing_summary.json
+++ b/swagger/v2/hearing_summary.json
@@ -27,6 +27,18 @@
       "description": "A description of the hearing type",
       "type": "string"
     },
+    "court_centre": {
+      "readOnly": true,
+      "description": "An object representing court centre details",
+      "type": "object",
+      "properties": {
+        "name": {
+          "example": "Derby Justice Centre",
+          "description": "The name of the court centre",
+          "type": "string"
+        }
+      }
+    },
     "identity": {
       "$ref": "#/definitions/id"
     },
@@ -101,6 +113,9 @@
         },
         "hearing_days": {
           "$ref": "#/definitions/hearing_days"
+        },
+        "court_centre": {
+          "$ref": "#/definitions/court_centre"
         }
       }
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-727)

CDA needs to expose the court house name for VCD to consume during the search operation. This information is available within the `hearingSummary.courtcenter.name`  as part of HMCTS’ search API response.

## Why

This information will be displayed on the VCD screen which will enable billing caseworkers to understand the status of the results shared. 

## Definition of Done

* [x] Court House Name is made available within CDA’s search API & tested.
* [x] The relevant API docs are updated to reflect this new info. 
* [x] v1/v2 services are updated. 