### PR TITLE
Send resulted hearing ID to MAAT API

### DIFF
--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -8,6 +8,10 @@ module HmctsCommonPlatform
       @data = HashWithIndifferentAccess.new(data || {})
     end
 
+    def id
+      data[:id]
+    end
+
     def jurisdiction_type
       data[:jurisdictionType]
     end

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -8,6 +8,10 @@ module MaatApi
       @maat_reference = maat_reference
     end
 
+    def hearing_id
+      hearing_resulted.hearing.id
+    end
+
     def case_urn; end
 
     def defendant_asn

--- a/app/models/maat_api/message.rb
+++ b/app/models/maat_api/message.rb
@@ -8,6 +8,7 @@ module MaatApi
 
     def generate
       {
+        hearingId: object.hearing_id,
         maatId: object.maat_reference.to_i,
         caseUrn: object.case_urn,
         jurisdictionType: object.jurisdiction_type,

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -9,6 +9,10 @@ module MaatApi
       @maat_reference = maat_reference
     end
 
+    def hearing_id
+      hearing_resulted.hearing.id
+    end
+
     def defendant_asn
       hmcts_common_platform_defendant.arrest_summons_number
     end

--- a/spec/models/hmcts_common_platform/hearing_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe HmctsCommonPlatform::Hearing, type: :model do
     expect(data).to match_json_schema(:hearing)
   end
 
+  it "has an ID" do
+    expect(hearing.id).to eql("b935a64a-6d03-4da4-bba6-4d32cc2e7fb4")
+  end
+
   it "has a jurisdiction type" do
     expect(hearing.jurisdiction_type).to eql("CROWN")
   end

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
   context "with all fields" do
     let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_court_application.json").read).deep_symbolize_keys }
 
+    it "has a hearing ID" do
+      expect(court_application.hearing_id).to eql("dafbe7f9-2f42-4781-8bbf-24ce47d51fd5")
+    end
+
     it "has a maat_reference" do
       expect(court_application.maat_reference).to eql("123")
     end
@@ -116,6 +120,10 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
   context "when the hearing has a court application with only the required fields" do
     let(:hearing_resulted_data) do
       JSON.parse(file_fixture("hearing/with_court_application_required_only.json").read).deep_symbolize_keys
+    end
+
+    it "has a hearing ID" do
+      expect(court_application.hearing_id).to eql("dafbe7f9-2f42-4781-8bbf-24ce47d51fd5")
     end
 
     it "has a maat_reference" do

--- a/spec/models/maat_api/message_spec.rb
+++ b/spec/models/maat_api/message_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe MaatApi::Message do
   let(:expected_payload) do
     {
+      hearingId: "1234",
       maatId: 1_209_485,
       caseUrn: "case urn",
       jurisdictionType: "jurisdiction type",
@@ -47,6 +48,10 @@ class Messageable
 
   def initialize(attrs = {})
     @attrs = attrs
+  end
+
+  def hearing_id
+    attrs[:hearing_id] || "1234"
   end
 
   def maat_reference

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
   context "when prosecution case has all fields" do
     let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_prosecution_case.json").read).deep_symbolize_keys }
 
+    it "has a hearing ID" do
+      expect(prosecution_case.hearing_id).to eql("b935a64a-6d03-4da4-bba6-4d32cc2e7fb4")
+    end
+
     it "has a maat_reference" do
       expect(prosecution_case.maat_reference).to eql("123")
     end
@@ -161,6 +165,10 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
 
   context "when the hearing body has only required fields" do
     let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_prosecution_case_required_only.json").read).deep_symbolize_keys }
+
+    it "has a hearing ID" do
+      expect(prosecution_case.hearing_id).to eql("b935a64a-6d03-4da4-bba6-4d32cc2e7fb4")
+    end
 
     it "has a maat_reference" do
       expect(prosecution_case.maat_reference).to eql("123")


### PR DESCRIPTION
## What

Send resulted hearing ID to MAAT API.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-728)

## Why

MAAT API needs to store resulted hearing IDs to enable a hearing lookup when it receives a crown court outcome.