### PR TITLE
Expose DefenceCounsel on prosecution case search response

### DIFF
--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -43,11 +43,21 @@ class HearingSummary
     HmctsCommonPlatform::CourtCentre.new(body["courtCentre"])
   end
 
+  def defence_counsel_ids
+    defence_counsels.map(&:id)
+  end
+
 private
 
   def hearing_days
     Array(body["hearingDays"]).map do |hearing_day_data|
       HmctsCommonPlatform::HearingDay.new(hearing_day_data)
+    end
+  end
+
+  def defence_counsels
+    Array(body["defenceCounsel"]).map do |defence_counsel_data|
+      HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
     end
   end
 end

--- a/app/models/hmcts_common_platform/defence_counsel.rb
+++ b/app/models/hmcts_common_platform/defence_counsel.rb
@@ -1,0 +1,43 @@
+module HmctsCommonPlatform
+  class DefenceCounsel
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def id
+      data[:id]
+    end
+
+    def title
+      data[:title]
+    end
+
+    def first_name
+      data[:firstName]
+    end
+
+    def middle_name
+      data[:middleName]
+    end
+
+    def last_name
+      data[:lastName]
+    end
+
+    def status
+      data[:status]
+    end
+
+    def attendance_days
+      data[:attendanceDays]
+    end
+
+    def defendants
+      data[:defendants]
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/defence_counsel_serializer.rb
+++ b/app/serializers/api/internal/v1/defence_counsel_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V1
+      class DefenceCounselSerializer
+        include JSONAPI::Serializer
+
+        attributes :title, :first_name, :middle_name, :last_name, :status, :attendance_days, :defendants
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_summary_serializer.rb
@@ -5,6 +5,7 @@ module Api
     module V1
       class HearingSummarySerializer
         include JSONAPI::Serializer
+
         attributes :hearing_type, :estimated_duration
 
         attribute :hearing_days do |hearing_summary|
@@ -18,6 +19,8 @@ module Api
             name: hearing_summary.court_centre.name,
           }
         end
+
+        has_many :defence_counsels
       end
     end
   end

--- a/app/serializers/api/internal/v2/defence_counsel_serializer.rb
+++ b/app/serializers/api/internal/v2/defence_counsel_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module Internal
+    module V2
+      class DefenceCounselSerializer
+        include JSONAPI::Serializer
+
+        attributes :title, :first_name, :middle_name, :last_name, :status, :attendance_days, :defendants
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_summary_serializer.rb
@@ -5,6 +5,7 @@ module Api
     module V2
       class HearingSummarySerializer
         include JSONAPI::Serializer
+
         attributes :hearing_type, :estimated_duration
 
         attribute :hearing_days do |hearing_summary|
@@ -18,6 +19,8 @@ module Api
             name: hearing_summary.court_centre.name,
           }
         end
+
+        has_many :defence_counsels
       end
     end
   end

--- a/lib/schemas/global/search/apiHearingSummary.json
+++ b/lib/schemas/global/search/apiHearingSummary.json
@@ -20,6 +20,12 @@
       "description": "The type of hearing that has been listed",
       "$ref": "http://justice.gov.uk/core/courts/external/apiHearingType.json#"
     },
+    "defenceCounsel": {
+      "type": "array",
+      "items": {
+        "$ref": "http://justice.gov.uk/core/courts/external/apiDefenceCounsel.json"
+      }
+    },
     "defendantIds": {
       "description": "The identifiers of the defendants that were heard",
       "type": "array",

--- a/spec/fixtures/files/defence_counsel/all_fields.json
+++ b/spec/fixtures/files/defence_counsel/all_fields.json
@@ -1,0 +1,14 @@
+{
+  "id": "e84facce-a2df-4e57-bfe3-f5cd48c43ddc",
+  "title": "Mr.",
+  "lastName": "Fitzgerald",
+  "firstName": "Francis",
+  "middleName": "Scott",
+  "status": "status",
+  "attendanceDays": [
+    "2018-10-25"
+  ],
+  "defendants": [
+    "baff62ee-ae6e-4f6a-92f8-063a1269453c"
+  ]
+}

--- a/spec/fixtures/files/hearing_summary/all_fields.json
+++ b/spec/fixtures/files/hearing_summary/all_fields.json
@@ -22,5 +22,21 @@
     "name": "Derby Justice Centre (aka Derby St Mary Adult)",
     "roomId": "2fc95ce0-79e5-33c6-901a-733c90905e59",
     "roomName": "Courtroom 08"
-  }
+  },
+  "defenceCounsel": [
+    {
+      "id": "e84facce-a2df-4e57-bfe3-f5cd48c43ddc",
+      "title": "Mr.",
+      "lastName": "Fitzgerald",
+      "firstName": "Francis",
+      "middleName": "Scott",
+      "status": "status",
+      "attendanceDays": [
+        "2018-10-25"
+      ],
+      "defendants": [
+        "baff62ee-ae6e-4f6a-92f8-063a1269453c"
+      ]
+    }
+  ]
 }

--- a/spec/models/hmcts_common_platform/defence_counsel_spec.rb
+++ b/spec/models/hmcts_common_platform/defence_counsel_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe HmctsCommonPlatform::DefenceCounsel, type: :model do
+  let(:data) { JSON.parse(file_fixture("defence_counsel/all_fields.json").read) }
+  let(:defence_counsel) { described_class.new(data) }
+
+  it "matches the HMCTS Common Platform schema" do
+    expect(data).to match_json_schema(:defence_counsel)
+  end
+
+  it "has an id" do
+    expect(defence_counsel.id).to eql("e84facce-a2df-4e57-bfe3-f5cd48c43ddc")
+  end
+
+  it "has a title" do
+    expect(defence_counsel.title).to eql("Mr.")
+  end
+
+  it "has a first_name" do
+    expect(defence_counsel.first_name).to eql("Francis")
+  end
+
+  it "has a middle_name" do
+    expect(defence_counsel.middle_name).to eql("Scott")
+  end
+
+  it "has a last_name" do
+    expect(defence_counsel.last_name).to eql("Fitzgerald")
+  end
+
+  it "has a status" do
+    expect(defence_counsel.status).to eql("status")
+  end
+
+  it "has attendance_days" do
+    expect(defence_counsel.attendance_days).to eql(%w[2018-10-25])
+  end
+
+  it "has defendants" do
+    expect(defence_counsel.defendants).to eql(%w[baff62ee-ae6e-4f6a-92f8-063a1269453c])
+  end
+end

--- a/spec/serializers/api/internal/v1/defence_counsel_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/defence_counsel_serializer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Api::Internal::V1::DefenceCounselSerializer do
+  let(:serialized_data) do
+    defence_counsel_data = JSON.parse(file_fixture("defence_counsel/all_fields.json").read)
+    defence_counsel = HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
+
+    described_class.new(defence_counsel).serializable_hash[:data]
+  end
+
+  describe "serialized data" do
+    describe "attributes" do
+      let(:attributes) { serialized_data[:attributes] }
+
+      it "title" do
+        expect(attributes[:title]).to eql("Mr.")
+      end
+
+      it "first_name" do
+        expect(attributes[:first_name]).to eql("Francis")
+      end
+
+      it "middle_name" do
+        expect(attributes[:middle_name]).to eql("Scott")
+      end
+
+      it "last_name" do
+        expect(attributes[:last_name]).to eql("Fitzgerald")
+      end
+
+      it "status" do
+        expect(attributes[:status]).to eql("status")
+      end
+
+      it "attendance_days" do
+        expect(attributes[:attendance_days]).to eql(%w[2018-10-25])
+      end
+
+      it "defendants" do
+        expect(attributes[:defendants]).to eql(%w[baff62ee-ae6e-4f6a-92f8-063a1269453c])
+      end
+    end
+  end
+end

--- a/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Internal::V1::HearingSummarySerializer do
-  subject(:attributes_hash) { described_class.new(hearing_summary).serializable_hash[:data][:attributes] }
+  let(:serialized_data) do
+    hearing_summary_data = JSON.parse(file_fixture("hearing_summary/all_fields.json").read)
+    hearing_summary = HearingSummary.new(body: hearing_summary_data)
 
-  let(:hearing_summary_data) { JSON.parse(file_fixture("hearing_summary/all_fields.json").read) }
-  let(:hearing_summary) { HearingSummary.new(body: hearing_summary_data) }
+    described_class.new(hearing_summary).serializable_hash[:data]
+  end
 
-  it { expect(attributes_hash[:hearing_type]).to eq("First hearing") }
-  it { expect(attributes_hash[:hearing_days]).to eq(%w[2021-03-25]) }
-  it { expect(attributes_hash[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
-  it { expect(attributes_hash[:estimated_duration]).to eq("20") }
+  context "with attributes" do
+    let(:attributes) { serialized_data[:attributes] }
+
+    it { expect(attributes[:hearing_type]).to eq("First hearing") }
+    it { expect(attributes[:hearing_days]).to eq(%w[2021-03-25]) }
+    it { expect(attributes[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
+    it { expect(attributes[:estimated_duration]).to eq("20") }
+  end
+
+  context "with relationships" do
+    let(:relationships) { serialized_data[:relationships] }
+
+    it do
+      expect(relationships[:defence_counsels][:data]).to eq([{ id: "e84facce-a2df-4e57-bfe3-f5cd48c43ddc", type: :defence_counsel }])
+    end
+  end
 end

--- a/spec/serializers/api/internal/v2/defence_counsel_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defence_counsel_serializer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Api::Internal::V2::DefenceCounselSerializer do
+  let(:serialized_data) do
+    defence_counsel_data = JSON.parse(file_fixture("defence_counsel/all_fields.json").read)
+    defence_counsel = HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
+
+    described_class.new(defence_counsel).serializable_hash[:data]
+  end
+
+  describe "serialized data" do
+    describe "attributes" do
+      let(:attributes) { serialized_data[:attributes] }
+
+      it "title" do
+        expect(attributes[:title]).to eql("Mr.")
+      end
+
+      it "first_name" do
+        expect(attributes[:first_name]).to eql("Francis")
+      end
+
+      it "middle_name" do
+        expect(attributes[:middle_name]).to eql("Scott")
+      end
+
+      it "last_name" do
+        expect(attributes[:last_name]).to eql("Fitzgerald")
+      end
+
+      it "status" do
+        expect(attributes[:status]).to eql("status")
+      end
+
+      it "attendance_days" do
+        expect(attributes[:attendance_days]).to eql(%w[2018-10-25])
+      end
+
+      it "defendants" do
+        expect(attributes[:defendants]).to eql(%w[baff62ee-ae6e-4f6a-92f8-063a1269453c])
+      end
+    end
+  end
+end

--- a/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
@@ -1,13 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Internal::V2::HearingSummarySerializer do
-  subject(:attributes_hash) { described_class.new(hearing_summary).serializable_hash[:data][:attributes] }
+  let(:serialized_data) do
+    hearing_summary_data = JSON.parse(file_fixture("hearing_summary/all_fields.json").read)
+    hearing_summary = HearingSummary.new(body: hearing_summary_data)
 
-  let(:hearing_summary_data) { JSON.parse(file_fixture("hearing_summary/all_fields.json").read) }
-  let(:hearing_summary) { HearingSummary.new(body: hearing_summary_data) }
+    described_class.new(hearing_summary).serializable_hash[:data]
+  end
 
-  it { expect(attributes_hash[:hearing_type]).to eq("First hearing") }
-  it { expect(attributes_hash[:hearing_days]).to eq(%w[2021-03-25]) }
-  it { expect(attributes_hash[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
-  it { expect(attributes_hash[:estimated_duration]).to eq("20") }
+  context "with attributes" do
+    let(:attributes) { serialized_data[:attributes] }
+
+    it { expect(attributes[:hearing_type]).to eq("First hearing") }
+    it { expect(attributes[:hearing_days]).to eq(%w[2021-03-25]) }
+    it { expect(attributes[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
+    it { expect(attributes[:estimated_duration]).to eq("20") }
+  end
+
+  context "with relationships" do
+    let(:relationships) { serialized_data[:relationships] }
+
+    it { expect(relationships[:defence_counsels][:data]).to eq([{ id: "e84facce-a2df-4e57-bfe3-f5cd48c43ddc", type: :defence_counsel }]) }
+  end
 end

--- a/spec/support/json_schema_rspec.rb
+++ b/spec/support/json_schema_rspec.rb
@@ -9,6 +9,7 @@ RSpec.configure do |config|
   config.json_schemas[:court_centre] = "#{schema_path}/global/apiCourtCentre.json"
   config.json_schemas[:defendant] = "#{schema_path}/global/apiDefendant.json"
   config.json_schemas[:defendant_case] = "#{schema_path}/global/apiDefendantCase.json"
+  config.json_schemas[:defence_counsel] = "#{schema_path}/global/apiDefenceCounsel.json"
   config.json_schemas[:defendant_summary] = "#{schema_path}/global/search/apiDefendantSummary.json"
   config.json_schemas[:delegated_powers] = "#{schema_path}/global/apiDelegatedPowers.json"
   config.json_schemas[:hearing] = "#{schema_path}/global/apiHearing.json"

--- a/swagger/v1/defence_counsel.json
+++ b/swagger/v1/defence_counsel.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defence Counsel",
+  "description": "Defence Counsel",
+  "id": "defence_counsel",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "example": "Mr."
+    },
+    "first_name": {
+      "type": "string",
+      "example": "Francis"
+    },
+    "middle_name": {
+      "type": "string",
+      "example": "Scott"
+    },
+    "last_name": {
+      "type": "string",
+      "example": "Fitzgerald"
+    },
+    "status": {
+      "type": "string",
+      "example": "status"
+    },
+    "attendance_days": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "defendants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/id"
+      }
+    }
+  },
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defence counsel",
+      "example": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The defence_counsel type",
+      "enum": [
+        "defence_counsel"
+      ],
+      "example": "defence_counsel",
+      "type": "string"
+    }
+  }
+}

--- a/swagger/v1/hearing_summary.json
+++ b/swagger/v1/hearing_summary.json
@@ -72,6 +72,9 @@
         },
         "attributes": {
           "$ref": "#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationships"
         }
       }
     },
@@ -91,6 +94,36 @@
           "$ref": "#/definitions/court_centre"
         }
       }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defence_counsels": {
+          "$ref": "#/definitions/defence_counsel_relationship"
+        }
+      }
+    },
+    "defence_counsel_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/defence_counsel"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defence_counsel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defence_counsel.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defence_counsel.json#/definitions/type"
+        }
+      }
     }
   },
   "links": [
@@ -106,14 +139,8 @@
     }
   ],
   "properties": {
-    "hearing_type": {
-      "$ref": "#/definitions/hearing_type"
-    },
-    "estimated_duration": {
-      "$ref": "#/definitions/estimated_duration"
-    },
-    "hearing_days": {
-      "$ref": "#/definitions/hearing_days"
+    "data": {
+      "$ref": "#/definitions/resource"
     }
   }
 }

--- a/swagger/v2/defence_counsel.json
+++ b/swagger/v2/defence_counsel.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defence Counsel",
+  "description": "Defence Counsel",
+  "id": "defence_counsel",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "example": "Mr."
+    },
+    "first_name": {
+      "type": "string",
+      "example": "Francis"
+    },
+    "middle_name": {
+      "type": "string",
+      "example": "Scott"
+    },
+    "last_name": {
+      "type": "string",
+      "example": "Fitzgerald"
+    },
+    "status": {
+      "type": "string",
+      "example": "status"
+    },
+    "attendance_days": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "defendants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/id"
+      }
+    }
+  },
+  "definitions": {
+    "id": {
+      "description": "unique identifier of defence counsel",
+      "example": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+      "format": "uuid",
+      "type": "string"
+    },
+    "type": {
+      "description": "The defence_counsel type",
+      "enum": [
+        "defence_counsel"
+      ],
+      "example": "defence_counsel",
+      "type": "string"
+    }
+  }
+}

--- a/swagger/v2/hearing_summary.json
+++ b/swagger/v2/hearing_summary.json
@@ -8,7 +8,7 @@
   "type": "object",
   "definitions": {
     "id": {
-      "description": "The unique identifier of the hearing summary",
+      "description": "unique identifier of hearing_summary",
       "example": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
       "format": "uuid",
       "type": "string"
@@ -72,42 +72,9 @@
         },
         "attributes": {
           "$ref": "#/definitions/attributes"
-        }
-      }
-    },
-    "relationships": {
-      "type": "object",
-      "properties": {
-        "offences": {
-          "$ref": "#/definitions/offence_relationship"
         },
-        "defence_organisation": {
-          "$ref": "#/definitions/defence_organisation_relationship"
-        },
-        "prosecution_case": {
-          "$ref": "#/definitions/prosecution_case_relationship"
-        }
-      }
-    },
-    "offence_relationship": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "items": {
-            "$ref": "#/definitions/offence"
-          },
-          "type": "array"
-        }
-      }
-    },
-    "offence": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "$ref": "offence.json#/definitions/id"
-        },
-        "type": {
-          "$ref": "offence.json#/definitions/type"
+        "relationships": {
+          "$ref": "#/definitions/relationships"
         }
       }
     },
@@ -127,6 +94,36 @@
           "$ref": "#/definitions/court_centre"
         }
       }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "defence_counsels": {
+          "$ref": "#/definitions/defence_counsel_relationship"
+        }
+      }
+    },
+    "defence_counsel_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/defence_counsel"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defence_counsel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defence_counsel.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defence_counsel.json#/definitions/type"
+        }
+      }
     }
   },
   "links": [
@@ -142,14 +139,8 @@
     }
   ],
   "properties": {
-    "hearing_type": {
-      "$ref": "#/definitions/hearing_type"
-    },
-    "estimated_duration": {
-      "$ref": "#/definitions/estimated_duration"
-    },
-    "hearing_days": {
-      "$ref": "#/definitions/hearing_days"
+    "data": {
+      "$ref": "#/definitions/resource"
     }
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-720)

Exposes Defence Counsel information for VCD to consume during the prosecution search operation.

This information will be available within the `hearingSummary.DefenseCounsel` as part of HMCTS’ prosecution case search API response.