### PR TITLE
Expose verdict attributes on prosecution case search response

### DIFF
--- a/app/models/hmcts_common_platform/verdict.rb
+++ b/app/models/hmcts_common_platform/verdict.rb
@@ -16,6 +16,10 @@ module HmctsCommonPlatform
       data[:verdictDate]
     end
 
+    def originating_hearing_id
+      data[:originatingHearingId]
+    end
+
     def verdict_type_category
       data.dig(:verdictType, :category)
     end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -59,6 +59,10 @@ class Offence
     end
   end
 
+  def verdict
+    HmctsCommonPlatform::Verdict.new(body["verdict"])
+  end
+
 private
 
   def laa_reference

--- a/app/serializers/api/internal/v1/defendant_serializer.rb
+++ b/app/serializers/api/internal/v1/defendant_serializer.rb
@@ -7,9 +7,13 @@ module Api
         include JSONAPI::Serializer
         set_type :defendants
 
-        attributes :name, :date_of_birth, :national_insurance_number,
-                   :arrest_summons_number, :maat_reference,
-                   :prosecution_case_id, :post_hearing_custody_statuses
+        attributes :name,
+                   :date_of_birth,
+                   :national_insurance_number,
+                   :arrest_summons_number,
+                   :maat_reference,
+                   :prosecution_case_id,
+                   :post_hearing_custody_statuses
 
         has_many :offences, record_type: :offences
         has_many :judicial_results, record_type: :judicial_results

--- a/app/serializers/api/internal/v1/offence_serializer.rb
+++ b/app/serializers/api/internal/v1/offence_serializer.rb
@@ -6,6 +6,7 @@ module Api
       class OffenceSerializer
         include JSONAPI::Serializer
         set_type :offences
+
         attributes :code,
                    :order_index,
                    :title,
@@ -13,6 +14,13 @@ module Api
                    :mode_of_trial,
                    :mode_of_trial_reasons,
                    :pleas
+
+        attribute :verdict do |offence|
+          {
+            verdict_date: offence.verdict.verdict_date,
+            originating_hearing_id: offence.verdict.originating_hearing_id,
+          }
+        end
 
         has_many :judicial_results
       end

--- a/app/serializers/api/internal/v2/defendant_serializer.rb
+++ b/app/serializers/api/internal/v2/defendant_serializer.rb
@@ -7,7 +7,13 @@ module Api
         include JSONAPI::Serializer
         set_type :defendants
 
-        attributes :name, :date_of_birth, :national_insurance_number, :arrest_summons_number, :maat_reference, :prosecution_case_id, :post_hearing_custody_statuses
+        attributes :name,
+                   :date_of_birth,
+                   :national_insurance_number,
+                   :arrest_summons_number,
+                   :maat_reference,
+                   :prosecution_case_id,
+                   :post_hearing_custody_statuses
 
         has_many :offences, record_type: :offences
         has_one :defence_organisation, record_type: :defence_organisations

--- a/app/serializers/api/internal/v2/offence_serializer.rb
+++ b/app/serializers/api/internal/v2/offence_serializer.rb
@@ -6,6 +6,7 @@ module Api
       class OffenceSerializer
         include JSONAPI::Serializer
         set_type :offences
+
         attributes :code,
                    :order_index,
                    :title,
@@ -13,6 +14,13 @@ module Api
                    :mode_of_trial,
                    :mode_of_trial_reasons,
                    :pleas
+
+        attribute :verdict do |offence|
+          {
+            verdict_date: offence.verdict.verdict_date,
+            originating_hearing_id: offence.verdict.originating_hearing_id,
+          }
+        end
       end
     end
   end

--- a/lib/schemas/global/apiVerdictType.json
+++ b/lib/schemas/global/apiVerdictType.json
@@ -26,7 +26,7 @@
     "verdictCode": {
       "description": "The code of the verdict.  Required for documentation purposes and also for publishing to LAA.  Required to be enriched when publishing hearing results",
       "type": "string"
-    }   
+    }
   },
   "additionalProperties": false,
   "required": [

--- a/lib/schemas/global/search/apiOffenceSummary.json
+++ b/lib/schemas/global/search/apiOffenceSummary.json
@@ -59,6 +59,9 @@
         "laaApplnReference": {
             "description": "A reference to the LAA application relevant for this offence",
             "$ref": "http://justice.gov.uk/core/courts/external/apiLaaReference.json#"
+        },
+        "verdict": {
+            "$ref": "http://justice.gov.uk/core/courts/external/apiVerdict.json"
         }
     },
     "required": [

--- a/spec/fixtures/files/offence_summary/all_fields.json
+++ b/spec/fixtures/files/offence_summary/all_fields.json
@@ -16,5 +16,15 @@
     "statusCode": "A",
     "statusDescription": "description",
     "statusDate": "2021-05-01"
+  },
+  "verdict": {
+    "offenceId": "9aca847f-da4e-444b-8f5a-2ce7d776ab75",
+    "verdictDate": "2020-04-12",
+    "verdictType": {
+      "id": "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+      "category": "A",
+      "categoryType": "Type A"
+    },
+    "originatingHearingId": "dda833bb-4956-4c9a-a553-59c6af5c15a6"
   }
 }

--- a/spec/fixtures/files/verdict/all_fields.json
+++ b/spec/fixtures/files/verdict/all_fields.json
@@ -1,11 +1,12 @@
 {
-    "offenceId": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
-    "verdictDate": "2021-04-10",
-    "verdictType": {
-        "id": "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
-        "category": "A",
-        "categoryType": "Type A",
-        "cjsVerdictCode": "1093",
-        "verdictCode": "367A"
-    }
+  "offenceId": "3f153786-f3cf-4311-bc0c-2d6f48af68a1",
+  "verdictDate": "2021-04-10",
+  "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+  "verdictType": {
+    "id": "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+    "category": "A",
+    "categoryType": "Type A",
+    "cjsVerdictCode": "1093",
+    "verdictCode": "367A"
+  }
 }

--- a/spec/models/hmcts_common_platform/verdict_spec.rb
+++ b/spec/models/hmcts_common_platform/verdict_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe HmctsCommonPlatform::Verdict, type: :model do
       expect(verdict.verdict_type_verdict_code).to eql("367A")
     end
 
+    it "has a verdict originating hearing ID" do
+      expect(verdict.originating_hearing_id).to eql("7084b980-d09d-40bc-b856-ea1fafd401bf")
+    end
+
     context "when verdict has only required fields with offence id option" do
       let(:data) do
         JSON.parse(file_fixture("verdict/required_fields_with_offence_id.json").read).deep_symbolize_keys

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Offence, type: :model do
       "startDate" => "2020-02-01",
       "endDate" => "2020-02-01",
       "proceedingsConcluded" => false,
+      "verdict" => {
+        "verdictDate" => "2020-04-12",
+        "originatingHearingId" => "dda833bb-4956-4c9a-a553-59c6af5c15a6",
+      },
     }
   end
 

--- a/spec/serializers/api/internal/v1/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/offence_serializer_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Api::Internal::V1::OffenceSerializer do
       it "pleas" do
         expect(attributes[:pleas]).to eq([{ pleaded_at: "2020-04-12", code: "NOT_GUILTY" }])
       end
+
+      it "verdict" do
+        expect(attributes[:verdict]).to eq({ verdict_date: "2020-04-12", originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6" })
+      end
     end
 
     describe "relationships" do

--- a/spec/serializers/api/internal/v2/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/offence_serializer_spec.rb
@@ -1,29 +1,46 @@
-# frozen_string_literal: true
-
 RSpec.describe Api::Internal::V2::OffenceSerializer do
-  subject { described_class.new(offence).serializable_hash }
-
-  let(:offence) do
-    instance_double("Offence",
-                    id: "UUID",
-                    code: "AA06001",
-                    order_index: "0",
-                    title: "Fail to wear protective clothing",
-                    legislation: "Offences against the Person Act 1861 s.24",
-                    mode_of_trial: "Indictable-Only Offence",
-                    mode_of_trial_reasons: [{ description: "Court directs trial by jury", code: "5" }],
-                    pleas: %w[GUILTY NOT_GUILTY])
+  let(:serialized_data) do
+    offence_summary_data = JSON.parse(file_fixture("offence_summary/all_fields.json").read)
+    offence_data = JSON.parse(file_fixture("offence/all_fields.json").read)
+    offence = Offence.new(body: offence_summary_data, details: [offence_data])
+    described_class.new(offence).serializable_hash[:data]
   end
 
-  context "with attributes" do
-    let(:attribute_hash) { subject[:data][:attributes] }
+  describe "offence serialized data" do
+    describe "attributes" do
+      let(:attributes) { serialized_data[:attributes] }
 
-    it { expect(attribute_hash[:code]).to eq("AA06001") }
-    it { expect(attribute_hash[:order_index]).to eq("0") }
-    it { expect(attribute_hash[:title]).to eq("Fail to wear protective clothing") }
-    it { expect(attribute_hash[:legislation]).to eq("Offences against the Person Act 1861 s.24") }
-    it { expect(attribute_hash[:mode_of_trial]).to eq("Indictable-Only Offence") }
-    it { expect(attribute_hash[:mode_of_trial_reasons]).to eq([{ description: "Court directs trial by jury", code: "5" }]) }
-    it { expect(attribute_hash[:pleas]).to eq(%w[GUILTY NOT_GUILTY]) }
+      it "code" do
+        expect(attributes[:code]).to eql("TH68026C")
+      end
+
+      it "order_index" do
+        expect(attributes[:order_index]).to be(1)
+      end
+
+      it "title" do
+        expect(attributes[:title]).to eql("Conspire to commit a burglary dwelling with intent to steal")
+      end
+
+      it "legislation" do
+        expect(attributes[:legislation]).to eql("Contrary to section 1(1) of the    Criminal Law Act 1977.")
+      end
+
+      it "mode_of_trial" do
+        expect(attributes[:mode_of_trial]).to eq("Indictable")
+      end
+
+      it "mode_of_trial_reasons" do
+        expect(attributes[:mode_of_trial_reasons]).to eq([{ description: "Court directs trial by jury", code: "5" }])
+      end
+
+      it "pleas" do
+        expect(attributes[:pleas]).to eq([{ pleaded_at: "2020-04-12", code: "NOT_GUILTY" }])
+      end
+
+      it "verdict" do
+        expect(attributes[:verdict]).to eq({ verdict_date: "2020-04-12", originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6" })
+      end
+    end
   end
 end

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -116,6 +116,21 @@
         }
       }
     },
+    "verdict": {
+      "readOnly": true,
+      "description": "The defendant's verdict for a specific offence",
+      "type": "object",
+      "properties": {
+        "verdict_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "originating_hearing_id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
     "resource": {
       "description": "An object representing a single offence",
       "type": "object",
@@ -157,6 +172,9 @@
         },
         "pleas": {
           "$ref": "#/definitions/pleas"
+        },
+        "verdict": {
+          "$ref": "#/definitions/verdict"
         }
       }
     },
@@ -221,6 +239,9 @@
     },
     "pleas": {
       "$ref": "#/definitions/pleas"
+    },
+    "verdict": {
+      "$ref": "#/definitions/verdict"
     }
   }
 }

--- a/swagger/v2/offence.json
+++ b/swagger/v2/offence.json
@@ -116,6 +116,21 @@
         }
       }
     },
+    "verdict": {
+      "readOnly": true,
+      "description": "The defendant's verdict for a specific offence",
+      "type": "object",
+      "properties": {
+        "verdict_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "originating_hearing_id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
     "resource": {
       "description": "object representing a single offence",
       "type": "object",
@@ -154,6 +169,9 @@
         },
         "pleas": {
           "$ref": "#/definitions/pleas"
+        },
+        "verdict": {
+          "$ref": "#/definitions/verdict"
         }
       }
     }
@@ -188,6 +206,9 @@
     },
     "pleas": {
       "$ref": "#/definitions/pleas"
+    },
+    "verdict": {
+      "$ref": "#/definitions/verdict"
     }
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB-721) part 1 of 2.

Expose verdict attributes `verdictDate` and `originatingHearingId` on prosecution case search response.

I'll expose the child `verdictType` data in a separate branch, for reviewing convenience.

