### PR TITLE
Expose verdict type data on offence (API v1)

### DIFF
--- a/app/models/hmcts_common_platform/verdict.rb
+++ b/app/models/hmcts_common_platform/verdict.rb
@@ -4,6 +4,16 @@ module HmctsCommonPlatform
 
     delegate :blank?, to: :data
 
+    delegate :id,
+             :description,
+             :category,
+             :category_type,
+             :cjs_verdict_code,
+             :verdict_code,
+             :sequence,
+             to: :verdict_type,
+             prefix: true
+
     def initialize(data)
       @data = HashWithIndifferentAccess.new(data || {})
     end
@@ -20,20 +30,8 @@ module HmctsCommonPlatform
       data[:originatingHearingId]
     end
 
-    def verdict_type_category
-      data.dig(:verdictType, :category)
-    end
-
-    def verdict_type_category_type
-      data.dig(:verdictType, :categoryType)
-    end
-
-    def verdict_type_cjs_verdict_code
-      data.dig(:verdictType, :cjsVerdictCode)
-    end
-
-    def verdict_type_verdict_code
-      data.dig(:verdictType, :verdictCode)
+    def verdict_type
+      HmctsCommonPlatform::VerdictType.new(data[:verdictType])
     end
   end
 end

--- a/app/models/hmcts_common_platform/verdict_type.rb
+++ b/app/models/hmcts_common_platform/verdict_type.rb
@@ -1,0 +1,39 @@
+module HmctsCommonPlatform
+  class VerdictType
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def id
+      data[:id]
+    end
+
+    def description
+      data[:description]
+    end
+
+    def category
+      data[:category]
+    end
+
+    def category_type
+      data[:categoryType]
+    end
+
+    def cjs_verdict_code
+      data[:cjsVerdictCode]
+    end
+
+    def verdict_code
+      data[:verdictCode]
+    end
+
+    def sequence
+      data[:sequence]
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/offence_serializer.rb
+++ b/app/serializers/api/internal/v1/offence_serializer.rb
@@ -19,6 +19,13 @@ module Api
           {
             verdict_date: offence.verdict.verdict_date,
             originating_hearing_id: offence.verdict.originating_hearing_id,
+            verdict_type: {
+              id: offence.verdict.verdict_type_id,
+              description: offence.verdict.verdict_type_description,
+              category: offence.verdict.verdict_type_category,
+              category_type: offence.verdict.verdict_type_category_type,
+              sequence: offence.verdict.verdict_type_sequence,
+            },
           }
         end
 

--- a/spec/fixtures/files/offence_summary/all_fields.json
+++ b/spec/fixtures/files/offence_summary/all_fields.json
@@ -22,8 +22,10 @@
     "verdictDate": "2020-04-12",
     "verdictType": {
       "id": "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+      "description": "A verdict type description",
       "category": "A",
-      "categoryType": "Type A"
+      "categoryType": "Type A",
+      "sequence": 1
     },
     "originatingHearingId": "dda833bb-4956-4c9a-a553-59c6af5c15a6"
   }

--- a/spec/fixtures/files/verdict_type/all_fields.json
+++ b/spec/fixtures/files/verdict_type/all_fields.json
@@ -1,0 +1,9 @@
+{
+  "id": "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+  "category": "A",
+  "categoryType": "Type A",
+  "cjsVerdictCode": "1093",
+  "description": "a verdict type description",
+  "sequence": 1,
+  "verdictCode": "367A"
+}

--- a/spec/models/hmcts_common_platform/verdict_type_spec.rb
+++ b/spec/models/hmcts_common_platform/verdict_type_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe HmctsCommonPlatform::VerdictType, type: :model do
+  let(:verdict_type) { described_class.new(data) }
+
+  context "when verdict has all fields" do
+    let(:data) { JSON.parse(file_fixture("verdict_type/all_fields.json").read) }
+
+    it "matches the HMCTS Common Platform schema" do
+      expect(data).to match_json_schema(:verdict_type)
+    end
+
+    it "has an ID" do
+      expect(verdict_type.id).to eql("f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7")
+    end
+
+    it "has a category" do
+      expect(verdict_type.category).to eql("A")
+    end
+
+    it "has a category type" do
+      expect(verdict_type.category_type).to eql("Type A")
+    end
+
+    it "has a verdict code" do
+      expect(verdict_type.verdict_code).to eql("367A")
+    end
+
+    it "has a CJS verdict code" do
+      expect(verdict_type.cjs_verdict_code).to eql("1093")
+    end
+
+    it "has a sequence" do
+      expect(verdict_type.sequence).to eql(1)
+    end
+
+    it "has a description" do
+      expect(verdict_type.description).to eql("a verdict type description")
+    end
+  end
+end

--- a/spec/models/hmcts_common_platform/verdict_type_spec.rb
+++ b/spec/models/hmcts_common_platform/verdict_type_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe HmctsCommonPlatform::VerdictType, type: :model do
     end
 
     it "has a sequence" do
-      expect(verdict_type.sequence).to eql(1)
+      expect(verdict_type.sequence).to be(1)
     end
 
     it "has a description" do

--- a/spec/serializers/api/internal/v1/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/offence_serializer_spec.rb
@@ -40,7 +40,19 @@ RSpec.describe Api::Internal::V1::OffenceSerializer do
       end
 
       it "verdict" do
-        expect(attributes[:verdict]).to eq({ verdict_date: "2020-04-12", originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6" })
+        expected = {
+          verdict_date: "2020-04-12",
+          originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6",
+          verdict_type: {
+            id: "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+            description: "A verdict type description",
+            category: "A",
+            category_type: "Type A",
+            sequence: 1,
+          },
+        }
+
+        expect(attributes[:verdict]).to eq(expected)
       end
     end
 

--- a/spec/support/json_schema_rspec.rb
+++ b/spec/support/json_schema_rspec.rb
@@ -27,4 +27,5 @@ RSpec.configure do |config|
   config.json_schemas[:prosecution_conclusion] = "#{schema_path}/api/progression.api.prosecutionConcludedRequest.json"
   config.json_schemas[:prosecution_case_summary] = "#{schema_path}/global/search/apiProsecutionCaseSummary.json"
   config.json_schemas[:verdict] = "#{schema_path}/global/apiVerdict.json"
+  config.json_schemas[:verdict_type] = "#{schema_path}/global/apiVerdictType.json"
 end

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -128,6 +128,31 @@
         "originating_hearing_id": {
           "type": "string",
           "format": "uuid"
+        },
+        "verdict_type": {
+          "properties": {
+            "id": {
+              "$ref": "verdict_type.json#/definitions/id"
+            },
+            "category": {
+              "$ref": "verdict_type.json#/definitions/category"
+            },
+            "category_type": {
+              "$ref": "verdict_type.json#/definitions/category_type"
+            },
+            "cjs_verdict_code": {
+              "$ref": "verdict_type.json#/definitions/cjs_verdict_code"
+            },
+            "verdict_code": {
+              "$ref": "verdict_type.json#/definitions/verdict_code"
+            },
+            "description": {
+              "$ref": "verdict_type.json#/definitions/description"
+            },
+            "sequence": {
+              "$ref": "verdict_type.json#/definitions/sequence"
+            }
+          }
         }
       }
     },

--- a/swagger/v1/verdict_type.json
+++ b/swagger/v1/verdict_type.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Verdict Type",
+  "description": "Verdict types",
+  "id": "verdict_type",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier",
+      "format": "uuid",
+      "type": "string"
+    },
+    "category": {
+      "type": "string",
+      "example": "A"
+    },
+    "category_type": {
+      "type": "string",
+      "example": "Type A"
+    },
+    "cjs_verdict_code": {
+      "type": "string",
+      "example": "1093"
+    },
+    "description": {
+      "type": "string"
+    },
+    "sequence": {
+      "type": "integer",
+      "example": 1
+    },
+    "verdict_code": {
+      "type": "string",
+      "example": "367A"
+    }
+  }
+}


### PR DESCRIPTION
## What

Expose verdict type data on prosecution case > defendant > offence > verdict object.

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB-721)

Depends on https://github.com/ministryofjustice/laa-court-data-adaptor/pull/691.