### PR TITLE
Upgrade ruby and postgres CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           PAGER: cat
           DATABASE_URL: postgres://postgres@localhost/laa_court_data_adaptor_test
           RAILS_ENV: test
-      - image: cimg/postgres:12.8
+      - image: cimg/postgres:11.12
         environment:
           POSTGRES_DB: laa_court_data_adaptor_test
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,12 @@ commands:
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.7.3
+      - image: cimg/ruby:2.7.3
         environment:
+          PAGER: cat
           DATABASE_URL: postgres://postgres@localhost/laa_court_data_adaptor_test
           RAILS_ENV: test
-      - image: circleci/postgres:11.5-alpine
+      - image: cimg/postgres:12.8
         environment:
           POSTGRES_DB: laa_court_data_adaptor_test
     steps:


### PR DESCRIPTION
## What

[[Link to story](https://dsdmoj.atlassian.net/browse/-LASBXXX)](https://dsdmoj.atlassian.net/jira/software/c/projects/LASB/boards/454?modal=detail&selectedIssue=LASB-732)

Describe what you did and why.

Upgrade Ruby and Postgres CircleCI images so they continue to receive bug/security fixes; the legacy images will no longer be supported from the end of 2021.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
