### PR TITLE
Expose verdict type data on offence (API v2)

### DIFF
--- a/app/serializers/api/internal/v2/offence_serializer.rb
+++ b/app/serializers/api/internal/v2/offence_serializer.rb
@@ -19,6 +19,13 @@ module Api
           {
             verdict_date: offence.verdict.verdict_date,
             originating_hearing_id: offence.verdict.originating_hearing_id,
+            verdict_type: {
+              id: offence.verdict.verdict_type_id,
+              description: offence.verdict.verdict_type_description,
+              category: offence.verdict.verdict_type_category,
+              category_type: offence.verdict.verdict_type_category_type,
+              sequence: offence.verdict.verdict_type_sequence,
+            },
           }
         end
       end

--- a/spec/serializers/api/internal/v2/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/offence_serializer_spec.rb
@@ -39,7 +39,19 @@ RSpec.describe Api::Internal::V2::OffenceSerializer do
       end
 
       it "verdict" do
-        expect(attributes[:verdict]).to eq({ verdict_date: "2020-04-12", originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6" })
+        expected = {
+          verdict_date: "2020-04-12",
+          originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6",
+          verdict_type: {
+            id: "f8df61d4-6e89-4b3f-85b4-5bfbc137a0b7",
+            description: "A verdict type description",
+            category: "A",
+            category_type: "Type A",
+            sequence: 1,
+          },
+        }
+
+        expect(attributes[:verdict]).to eq(expected)
       end
     end
   end

--- a/swagger/v2/offence.json
+++ b/swagger/v2/offence.json
@@ -128,6 +128,31 @@
         "originating_hearing_id": {
           "type": "string",
           "format": "uuid"
+        },
+        "verdict_type": {
+          "properties": {
+            "id": {
+              "$ref": "verdict_type.json#/definitions/id"
+            },
+            "category": {
+              "$ref": "verdict_type.json#/definitions/category"
+            },
+            "category_type": {
+              "$ref": "verdict_type.json#/definitions/category_type"
+            },
+            "cjs_verdict_code": {
+              "$ref": "verdict_type.json#/definitions/cjs_verdict_code"
+            },
+            "verdict_code": {
+              "$ref": "verdict_type.json#/definitions/verdict_code"
+            },
+            "description": {
+              "$ref": "verdict_type.json#/definitions/description"
+            },
+            "sequence": {
+              "$ref": "verdict_type.json#/definitions/sequence"
+            }
+          }
         }
       }
     },

--- a/swagger/v2/verdict_type.json
+++ b/swagger/v2/verdict_type.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Verdict Type",
+  "description": "Verdict types",
+  "id": "verdict_type",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "id": {
+      "description": "unique identifier",
+      "format": "uuid",
+      "type": "string"
+    },
+    "category": {
+      "type": "string",
+      "example": "A"
+    },
+    "category_type": {
+      "type": "string",
+      "example": "Type A"
+    },
+    "cjs_verdict_code": {
+      "type": "string",
+      "example": "1093"
+    },
+    "description": {
+      "type": "string"
+    },
+    "sequence": {
+      "type": "integer",
+      "example": 1
+    },
+    "verdict_code": {
+      "type": "string",
+      "example": "367A"
+    }
+  }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-721)

CDA needs to expose Verdict information for VCD to consume during the prosecution search operation. 

Note: Currently CDA exposes this information by calling HMCTS’  get hearing results API. There will be a change needed to source Verdict information from the prosecution search API  instead of get hearing results API.

![Screenshot from 2021-11-12 15-34-35](https://user-images.githubusercontent.com/3141541/141483707-e1fe7657-31af-47e6-b556-ed671c34c774.png)

Follows https://github.com/ministryofjustice/laa-court-data-adaptor/pull/692.

## Why

This information will be displayed on the VCD screen which will enable billing caseworkers to assess a claim.

## Definition of done

* [x] Verdict information is made available within CDA’s search API and tested
* [x] The relevant API docs are updated to reflect this new info
* [x] v2 services are updated