### PR TITLE
Iterate through offences and return latest verdict_date

### DIFF
--- a/app/services/crown_court_outcome_creator.rb
+++ b/app/services/crown_court_outcome_creator.rb
@@ -28,7 +28,11 @@ private
   end
 
   def trial_end_date
-    defendant.dig(:offences, 0, :verdict, :verdictDate)
+    verdict_dates = []
+    defendant[:offences]&.map do |offence|
+      verdict_dates << offence.dig(:verdict, :verdictDate)
+    end
+    verdict_dates.max
   end
 
   attr_reader :defendant

--- a/spec/services/crown_court_outcome_creator_spec.rb
+++ b/spec/services/crown_court_outcome_creator_spec.rb
@@ -13,7 +13,15 @@ RSpec.describe CrownCourtOutcomeCreator do
   end
   let(:not_guilty_verdict) do
     {
-      'verdictDate': "2018-10-25",
+      'verdictDate': "2018-10-26",
+      'verdictType': {
+        'categoryType': "NOT_GUILTY",
+      },
+    }
+  end
+  let(:not_guilty_verdict_two) do
+    {
+      'verdictDate': "2018-10-27",
       'verdictType': {
         'categoryType': "NOT_GUILTY",
       },
@@ -54,11 +62,11 @@ RSpec.describe CrownCourtOutcomeCreator do
       end
 
       it "results in a AQUITTED result" do
-        expect(create).to eq({ caseEndDate: "2018-10-25", ccooOutcome: "AQUITTED" })
+        expect(create).to eq({ caseEndDate: "2018-10-26", ccooOutcome: "AQUITTED" })
       end
     end
 
-    context "with a mix of guity and not guilty trial verdicts" do
+    context "with a mix of guilty and not guilty trial verdicts" do
       let(:defendant) do
         {
           'offences': [
@@ -73,7 +81,29 @@ RSpec.describe CrownCourtOutcomeCreator do
       end
 
       it "results in a PART CONVICTED result" do
-        expect(create).to eq({ caseEndDate: "2018-10-25", ccooOutcome: "PART CONVICTED" })
+        expect(create).to eq({ caseEndDate: "2018-10-26", ccooOutcome: "PART CONVICTED" })
+      end
+    end
+
+    context "with a mix of three verdicts, guilty and not guilty" do
+      let(:defendant) do
+        {
+          'offences': [
+            {
+              'verdict': guilty_verdict,
+            },
+            {
+              'verdict': not_guilty_verdict,
+            },
+            {
+              'verdict': not_guilty_verdict_two,
+            },
+          ],
+        }
+      end
+
+      it "results in a PART CONVICTED result" do
+        expect(create).to eq({ caseEndDate: "2018-10-27", ccooOutcome: "PART CONVICTED" })
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB760)

Fixed a bug 🐛  to return the latest verdict date out of all the offences in the offence array to send to MAAT API queue as the CCO trial end date. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
