### PR TITLE
Add category attribute to judicial results in maat api message payload

### DIFF
--- a/app/models/hmcts_common_platform/judicial_result.rb
+++ b/app/models/hmcts_common_platform/judicial_result.rb
@@ -36,6 +36,10 @@ module HmctsCommonPlatform
       data[:label]
     end
 
+    def category
+      data[:category]
+    end
+
     def text
       data[:resultText]
     end

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -101,6 +101,7 @@ module MaatApi
           resultCode: judicial_result.cjs_code,
           resultShortTitle: judicial_result.label,
           resultText: judicial_result.text,
+          category: judicial_result.category,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
           nextHearingLocation: judicial_result.next_hearing_court_centre&.short_oucode,

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -112,6 +112,7 @@ module MaatApi
           resultCode: judicial_result.cjs_code,
           resultShortTitle: judicial_result.label,
           resultText: judicial_result.text,
+          category: judicial_result.category,
           resultCodeQualifiers: judicial_result.qualifier,
           nextHearingDate: judicial_result.next_hearing_date&.to_date&.strftime("%Y-%m-%d"),
           nextHearingLocation: judicial_result.next_hearing_court_centre&.short_oucode,

--- a/spec/fixtures/files/hearing/with_prosecution_case.json
+++ b/spec/fixtures/files/hearing/with_prosecution_case.json
@@ -110,6 +110,7 @@
                     {
                       "cjsCode": "4600",
                       "label": "Found guilty on all charges",
+                      "category": "A",
                       "resultText": "Result",
                       "qualifier": "Qualifier",
                       "orderedDate": "2021-03-10",

--- a/spec/models/hmcts_common_platform/judicial_result_spec.rb
+++ b/spec/models/hmcts_common_platform/judicial_result_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe HmctsCommonPlatform::JudicialResult, type: :model do
       expect(judicial_result.label).to eql("Legal Aid Transfer Granted")
     end
 
+    it "has a category" do
+      expect(judicial_result.category).to eql("FINAL")
+    end
+
     it "has text" do
       expect(judicial_result.text).to eql("Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888")
     end

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
               {
                 nextHearingDate: "2020-03-01",
                 nextHearingLocation: "B01LY",
+                category: "FINAL",
                 resultCode: "4600",
                 resultCodeQualifiers: "",
                 resultShortTitle: "Legal Aid Transfer Granted",

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
                 resultCode: "4600",
                 resultShortTitle: "Found guilty on all charges",
                 resultText: "Result",
+                category: "A",
                 resultCodeQualifiers: "Qualifier",
                 nextHearingDate: "2019-10-23",
                 nextHearingLocation: "B21JI",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB760)

Added judicialResult>category to payload sent in message to MAAT API queue.

This has been added to both Prosecution Case messages and Court Application messages. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
