### PR TITLE
Expose sitting days on Hearing Summary

### DIFF
--- a/app/serializers/api/internal/v1/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_summary_serializer.rb
@@ -14,6 +14,12 @@ module Api
           end
         end
 
+        attribute :sitting_days do |hearing_summary|
+          hearing_summary.sitting_days.map do |day|
+            Date.parse(day).to_formatted_s(:db)
+          end
+        end
+
         attribute :court_centre do |hearing_summary|
           {
             name: hearing_summary.court_centre.name,

--- a/app/serializers/api/internal/v2/hearing_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_summary_serializer.rb
@@ -14,6 +14,12 @@ module Api
           end
         end
 
+        attribute :sitting_days do |hearing_summary|
+          hearing_summary.sitting_days.map do |day|
+            Date.parse(day).to_formatted_s(:db)
+          end
+        end
+
         attribute :court_centre do |hearing_summary|
           {
             name: hearing_summary.court_centre.name,

--- a/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_summary_serializer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::Internal::V1::HearingSummarySerializer do
 
     it { expect(attributes[:hearing_type]).to eq("First hearing") }
     it { expect(attributes[:hearing_days]).to eq(%w[2021-03-25]) }
+    it { expect(attributes[:sitting_days]).to eq(%w[2021-03-25]) }
     it { expect(attributes[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
     it { expect(attributes[:estimated_duration]).to eq("20") }
   end

--- a/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_summary_serializer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::Internal::V2::HearingSummarySerializer do
 
     it { expect(attributes[:hearing_type]).to eq("First hearing") }
     it { expect(attributes[:hearing_days]).to eq(%w[2021-03-25]) }
+    it { expect(attributes[:sitting_days]).to eq(%w[2021-03-25]) }
     it { expect(attributes[:court_centre][:name]).to eq("Derby Justice Centre (aka Derby St Mary Adult)") }
     it { expect(attributes[:estimated_duration]).to eq("20") }
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-718)

Before we can safely modify the `hearing_days` field CDA exposes (https://github.com/ministryofjustice/laa-court-data-adaptor/pull/684),  without breaking View Court Data, we need this PR to expose `hearing_days` data under a transitory `sitting_days` field.

Next steps:

* update VCD to use `sitting_days` instead of `hearing_days`
* ship https://github.com/ministryofjustice/laa-court-data-adaptor/pull/684
* update VCD to use `hearing_days` instead of `sitting_days`