### PR TITLE
derive dateOfHearing from hearingDay sittingDay

### DIFF
--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -73,9 +73,9 @@ module MaatApi
     def session
       {
         courtLocation: hearing_resulted.hearing_court_centre.short_oucode,
-        dateOfHearing: hmcts_common_platform_defendant.offences&.first&.results&.first&.ordered_date,
+        dateOfHearing: hearing_first_sitting_day_date,
         postHearingCustody: PostHearingCustodyCalculator.call(offences: hmcts_common_platform_defendant.data[:offences]),
-        sessionValidateDate: hmcts_common_platform_defendant.offences&.first&.results&.first&.ordered_date,
+        sessionValidateDate: hearing_first_sitting_day_date,
       }
     end
 
@@ -166,6 +166,10 @@ module MaatApi
 
     def result_is_a_conclusion?
       hmcts_common_platform_defendant.offences.any? { |offence| offence.verdict.present? }
+    end
+
+    def hearing_first_sitting_day_date
+      hearing_resulted.hearing_first_sitting_day_date&.to_date&.strftime("%Y-%m-%d")
     end
   end
 end

--- a/spec/fixtures/files/hearing/all_fields.json
+++ b/spec/fixtures/files/hearing/all_fields.json
@@ -367,16 +367,6 @@
       "sittingDay": "2019-10-25T10:45:00.000Z",
       "listingSequence": 1,
       "listedDurationMinutes": 1
-    },
-    {
-      "sittingDay": "2019-10-24T08:30:00.000Z",
-      "listingSequence": 1,
-      "listedDurationMinutes": 1
-    },
-    {
-      "sittingDay": "2019-10-23T16:19:15.000Z",
-      "listingSequence": 1,
-      "listedDurationMinutes": 1
     }
   ]
 }

--- a/spec/fixtures/files/hearing/with_prosecution_case.json
+++ b/spec/fixtures/files/hearing/with_prosecution_case.json
@@ -365,16 +365,6 @@
           "sittingDay": "2019-10-25T10:45:00.000Z",
           "listingSequence": 1,
           "listedDurationMinutes": 1
-        },
-        {
-          "sittingDay": "2019-10-24T08:30:00.000Z",
-          "listingSequence": 1,
-          "listedDurationMinutes": 1
-        },
-        {
-          "sittingDay": "2019-10-23T16:19:15.000Z",
-          "listingSequence": 1,
-          "listedDurationMinutes": 1
         }
       ]
     },

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -155,9 +155,9 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
 
       expected = {
         courtLocation: "A07AF",
-        dateOfHearing: "2021-03-10",
+        dateOfHearing: "2019-10-25",
         postHearingCustody: "B",
-        sessionValidateDate: "2021-03-10",
+        sessionValidateDate: "2019-10-25",
       }
 
       expect(prosecution_case.session).to eql(expected)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB771)

MAAT unable to process court location data to display on MLRA because CDA was not populating the dateOfHearing date consistently. 

CDA was deriving dateOfHearing to sent to SQS queue for MAAT API from judicialResults which are an optional field and when missing caused issues in MAAT. 

This change derives dayOfHearing (and sessionValidateDate) from hearingDays sittingDay instead which is a more reliable source (although N.B. still not a required field)

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
