### PR TITLE
Inject queue URL from the worker

### DIFF
--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -49,7 +49,10 @@ private
   end
 
   def publish_hearing_to_queue
-    HearingsCreatorWorker.perform_async(Current.request_id, hearing_resulted_data)
+    HearingsCreatorWorker.perform_async(
+      Current.request_id,
+      hearing_resulted_data,
+    )
   end
 
   attr_reader :hearing, :hearing_resulted_data, :publish_to_queue

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class HearingsCreator < ApplicationService
-  attr_reader :hearing_resulted
+  attr_reader :hearing_resulted, :queue_url
 
-  def initialize(hearing_resulted_data:)
+  def initialize(hearing_resulted_data:, queue_url:)
     @hearing_resulted = HmctsCommonPlatform::HearingResulted.new(hearing_resulted_data)
+    @queue_url = queue_url
   end
 
   def call
@@ -34,7 +35,7 @@ private
 
         Sqs::MessagePublisher.call(
           message: MaatApi::Message.new(maat_api_prosecution_case).generate,
-          queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
+          queue_url: queue_url,
         )
       end
     end
@@ -55,7 +56,7 @@ private
 
         Sqs::MessagePublisher.call(
           message: MaatApi::Message.new(maat_api_court_application).generate,
-          queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
+          queue_url: queue_url,
         )
       end
     end

--- a/app/workers/hearings_creator_worker.rb
+++ b/app/workers/hearings_creator_worker.rb
@@ -5,7 +5,10 @@ class HearingsCreatorWorker
 
   def perform(request_id, hearing_resulted_data)
     Current.set(request_id: request_id) do
-      HearingsCreator.call(hearing_resulted_data: hearing_resulted_data)
+      HearingsCreator.call(
+        hearing_resulted_data: hearing_resulted_data,
+        queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
+      )
     end
   end
 end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe HearingsCreator do
-  subject(:create_hearings) { described_class.call(hearing_resulted_data: hearing_resulted_data) }
+  subject(:create_hearings) { described_class.call(hearing_resulted_data: hearing_resulted_data, queue_url: "url") }
 
   let(:defendant_array) { [defendant_one] }
   let(:offence_array) { [offence_one, offence_two] }
@@ -90,7 +90,7 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service once" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a888", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once
+        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -105,7 +105,7 @@ RSpec.describe HearingsCreator do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a888", linked: true, maat_reference: "123", user_name: "Bob")
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a899", linked: true, maat_reference: "456", user_name: "Steve")
 
-        expect(Sqs::MessagePublisher).to receive(:call).twice
+        expect(Sqs::MessagePublisher).to receive(:call).twice.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -132,7 +132,7 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service twice" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a888", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).twice
+        expect(Sqs::MessagePublisher).to receive(:call).twice.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -155,7 +155,7 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a888", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once
+        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -200,7 +200,7 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service once" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a666", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once
+        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -214,7 +214,7 @@ RSpec.describe HearingsCreator do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a666", linked: true, maat_reference: "123", user_name: "Bob")
         LaaReference.create!(defendant_id: "ad22b110-7fbc-3036-a076-e4bb40d0a667", linked: true, maat_reference: "456", user_name: "Steve")
 
-        expect(Sqs::MessagePublisher).to receive(:call).twice
+        expect(Sqs::MessagePublisher).to receive(:call).twice.with(hash_including(queue_url: "url"))
 
         create_hearings
       end
@@ -228,7 +228,7 @@ RSpec.describe HearingsCreator do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a666", linked: true, maat_reference: "123", user_name: "Bob")
         LaaReference.create!(defendant_id: "ad22b110-7fbc-3036-a076-e4bb40d0a667", linked: false, maat_reference: "456", user_name: "Steve")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once
+        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
 
         create_hearings
       end

--- a/spec/workers/hearings_creator_worker_spec.rb
+++ b/spec/workers/hearings_creator_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe HearingsCreatorWorker, type: :worker do
 
   it "creates a HearingsCreator and calls with a transformed hash" do
     Sidekiq::Testing.inline! do
-      expect(HearingsCreator).to receive(:call).once.with(hearing_resulted_data: "some data")
+      expect(HearingsCreator).to receive(:call).once.with(hearing_resulted_data: "some data", queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted)
       work
     end
   end


### PR DESCRIPTION
This makes it easy to switch queue URL for the HearingsCreator
at runtime.

e.g. my use case: Fetch hearing results from Common Platform and send
the hearing resulted data to the prosecution_concluded queue rather
than the hearing_resulted queue.