### PR TITLE
Expose defendant summary data on GET defendant v2

### DIFF
--- a/app/controllers/api/internal/v2/defendants_controller.rb
+++ b/app/controllers/api/internal/v2/defendants_controller.rb
@@ -15,10 +15,13 @@ module Api
         end
 
         def show
-          defendant = CommonPlatform::Api::DefendantFinder.call(defendant_id: params[:id])
+          defendant_summary = CommonPlatform::Api::DefendantSummary.get(
+            prosecution_case_reference: params[:prosecution_case_id],
+            defendant_id: params[:id],
+          )
 
-          if defendant.present?
-            render json: DefendantSerializer.new(defendant, serialization_options)
+          if defendant_summary.present?
+            render json: DefendantSummarySerializer.new(defendant_summary)
           else
             render status: :not_found
           end
@@ -45,17 +48,7 @@ module Api
         end
 
         def transformed_params
-          @transformed_params ||= unlink_params.slice(*allowed_params).to_hash.transform_keys(&:to_sym).merge(defendant_id: params[:id])
-        end
-
-        def serialization_options
-          return { include: inclusions } if params[:include].present?
-
-          {}
-        end
-
-        def inclusions
-          params[:include].split(",")
+          @transformed_params ||= unlink_params.slice(*allowed_params).to_hash.deep_symbolize_keys.merge(defendant_id: params[:id])
         end
       end
     end

--- a/app/models/hmcts_common_platform/defendant_summary.rb
+++ b/app/models/hmcts_common_platform/defendant_summary.rb
@@ -6,16 +6,20 @@ module HmctsCommonPlatform
       @data = HashWithIndifferentAccess.new(data || {})
     end
 
-    def defendant_id
+    def id
       data[:defendantId]
     end
 
     def name
-      data[:defendantName]
+      data[:defendantName] || [first_name, middle_name, last_name].join(" ").squish
     end
 
     def first_name
       data[:defendantFirstName]
+    end
+
+    def middle_name
+      data[:defendantMiddleName]
     end
 
     def last_name

--- a/app/models/maat_api/laa_reference.rb
+++ b/app/models/maat_api/laa_reference.rb
@@ -35,7 +35,7 @@ module MaatApi
 
     def defendant
       {
-        defendantId: defendant_summary.defendant_id,
+        defendantId: defendant_summary.id,
         forename: defendant_summary.first_name,
         surname: defendant_summary.last_name,
         dateOfBirth: defendant_summary.date_of_birth,

--- a/app/serializers/api/internal/v2/defendant_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/defendant_summary_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class DefendantSummarySerializer
+        include JSONAPI::Serializer
+
+        attributes :name,
+                   :date_of_birth,
+                   :national_insurance_number,
+                   :arrest_summons_number
+      end
+    end
+  end
+end

--- a/app/services/common_platform/api/defendant_summary.rb
+++ b/app/services/common_platform/api/defendant_summary.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module CommonPlatform
+  module Api
+    class DefendantSummary
+      def self.get(prosecution_case_reference:, defendant_id:)
+        data = ProsecutionCaseSearcher.call(prosecution_case_reference: prosecution_case_reference).body["cases"].first
+        prosecution_case_summary = HmctsCommonPlatform::ProsecutionCaseSummary.new(data)
+
+        prosecution_case_summary.defendant_summaries.find do |ds|
+          ds.id == defendant_id
+        end
+      end
+    end
+  end
+end

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -60,7 +60,7 @@ private
   end
 
   def defendant_summary
-    prosecution_case_summary.defendant_summaries.find { |d| d.defendant_id == laa_reference.defendant_id }
+    prosecution_case_summary.defendant_summaries.find { |ds| ds.id == laa_reference.defendant_id }
   end
 
   def prosecution_case_summary

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,10 @@ Rails.application.routes.draw do
 
       api_version(module: "V2", path: { value: "v2" }) do
         resources :prosecution_cases, only: [:index]
+        resources :prosecution_cases, only: [:show] do
+          resources :defendants, only: %i[update show]
+        end
         resources :laa_references, only: %i[create destroy], param: :defendant_id
-        resources :defendants, only: %i[update show]
         resources :representation_orders, only: [:create]
         resources :hearing_results, only: [:show]
       end

--- a/lib/schemas/global/search/apiOffenceSummary.json
+++ b/lib/schemas/global/search/apiOffenceSummary.json
@@ -1,77 +1,77 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://justice.gov.uk/core/courts/search/external/apiOffenceSummary.json",
-    "description": "A summary of offence details",
-    "type": "object",
-    "properties": {
-        "offenceId": {
-            "description": "The identifier of the offence",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
-        },
-        "offenceCode": {
-            "description": "The offence code from reference data",
-            "type": "string"
-        },
-        "orderIndex": {
-            "description": "The offence sequence provided by the Police",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/positiveInteger"
-        },
-        "offenceTitle": {
-            "description": "The offence title from reference data",
-            "type": "string"
-        },
-        "offenceLegislation": {
-            "description": "The offence legislation from reference data",
-            "type": "string"
-        },
-        "wording": {
-            "description": "The particulars of the accused charges",
-            "type": "string"
-        },
-        "arrestDate": {
-            "description": "The date that the defendant was arrested in relation to this matter",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
-        },
-        "chargeDate": {
-            "description": "The date that the defendant was charged in relation to this matter",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
-        },
-        "dateOfInformation": {
-            "description": "The date that the matter is brought to court attention for consideration and for proceeding",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
-        },
-        "modeOfTrial": {
-            "description": "Indicates if the offence is either way, indictable only or summary only",
-            "type": "string"
-        },
-        "startDate": {
-            "description": "The date that the defendant is accused to have started committing this charge",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
-        },
-        "endDate": {
-            "description": "The date that the defendant is accused to have stopped commiting this charge",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
-        },
-        "proceedingsConcluded": {
-          "description": "Indicates that proceedings for this offence have been conckuded i.e. it has been disposed with final results or withdrawn by the prosecuting authority",
-          "type": "boolean"
-        },
-        "laaApplnReference": {
-            "description": "A reference to the LAA application relevant for this offence",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiLaaReference.json#"
-        },
-        "plea": {
-            "description": "The plea associated with this offence.",
-            "$ref": "http://justice.gov.uk/core/courts/external/apiPlea.json"
-        },
-        "verdict": {
-            "$ref": "http://justice.gov.uk/core/courts/external/apiVerdict.json"
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://justice.gov.uk/core/courts/search/external/apiOffenceSummary.json",
+  "description": "A summary of offence details",
+  "type": "object",
+  "properties": {
+    "offenceId": {
+      "description": "The identifier of the offence",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
     },
-    "required": [
-        "offenceId",
-        "offenceCode",
-        "offenceTitle"
-    ],
-    "additionalProperties": false
+    "offenceCode": {
+      "description": "The offence code from reference data",
+      "type": "string"
+    },
+    "orderIndex": {
+      "description": "The offence sequence provided by the Police",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/positiveInteger"
+    },
+    "offenceTitle": {
+      "description": "The offence title from reference data",
+      "type": "string"
+    },
+    "offenceLegislation": {
+      "description": "The offence legislation from reference data",
+      "type": "string"
+    },
+    "wording": {
+      "description": "The particulars of the accused charges",
+      "type": "string"
+    },
+    "arrestDate": {
+      "description": "The date that the defendant was arrested in relation to this matter",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "chargeDate": {
+      "description": "The date that the defendant was charged in relation to this matter",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "dateOfInformation": {
+      "description": "The date that the matter is brought to court attention for consideration and for proceeding",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "modeOfTrial": {
+      "description": "Indicates if the offence is either way, indictable only or summary only",
+      "type": "string"
+    },
+    "startDate": {
+      "description": "The date that the defendant is accused to have started committing this charge",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "endDate": {
+      "description": "The date that the defendant is accused to have stopped commiting this charge",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "proceedingsConcluded": {
+      "description": "Indicates that proceedings for this offence have been conckuded i.e. it has been disposed with final results or withdrawn by the prosecuting authority",
+      "type": "boolean"
+    },
+    "laaApplnReference": {
+      "description": "A reference to the LAA application relevant for this offence",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiLaaReference.json#"
+    },
+    "plea": {
+      "description": "The plea associated with this offence.",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiPlea.json"
+    },
+    "verdict": {
+      "$ref": "http://justice.gov.uk/core/courts/external/apiVerdict.json"
+    }
+  },
+  "required": [
+    "offenceId",
+    "offenceCode",
+    "offenceTitle"
+  ],
+  "additionalProperties": false
 }

--- a/spec/models/hmcts_common_platform/defendant_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_summary_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe HmctsCommonPlatform::DefendantSummary, type: :model do
       expect(data).to match_json_schema(:defendant_summary)
     end
 
-    it { expect(defendant_summary.defendant_id).to eql("b760daba-0d38-4bae-ad57-fbfd8419aefe") }
-    it { expect(defendant_summary.first_name).to eql("Bob") }
-    it { expect(defendant_summary.last_name).to eql("Smith") }
+    it { expect(defendant_summary.id).to eql("b760daba-0d38-4bae-ad57-fbfd8419aefe") }
+    it { expect(defendant_summary.name).to eql("Bob Steven Smith") }
     it { expect(defendant_summary.arrest_summons_number).to eql("2100000000000267128K") }
     it { expect(defendant_summary.date_of_birth).to eql("1986-11-10") }
     it { expect(defendant_summary.national_insurance_number).to eql("AA123456C") }
@@ -24,10 +23,8 @@ RSpec.describe HmctsCommonPlatform::DefendantSummary, type: :model do
       expect(data).to match_json_schema(:defendant_summary)
     end
 
-    it { expect(defendant_summary.defendant_id).to eql("b760daba-0d38-4bae-ad57-fbfd8419aefe") }
+    it { expect(defendant_summary.id).to eql("b760daba-0d38-4bae-ad57-fbfd8419aefe") }
     it { expect(defendant_summary.name).to eql("Bob Smith") }
-    it { expect(defendant_summary.first_name).to be_nil }
-    it { expect(defendant_summary.last_name).to be_nil }
     it { expect(defendant_summary.arrest_summons_number).to be_nil }
     it { expect(defendant_summary.date_of_birth).to be_nil }
     it { expect(defendant_summary.national_insurance_number).to be_nil }

--- a/spec/serializers/api/internal/v2/defendant_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defendant_summary_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::DefendantSummarySerializer do
+  subject { described_class.new(defendant_summary).serializable_hash }
+
+  let(:defendant_summary_data) { JSON.parse(file_fixture("defendant_summary/all_fields.json").read) }
+  let(:defendant_summary) { HmctsCommonPlatform::DefendantSummary.new(defendant_summary_data) }
+
+  context "with attributes" do
+    let(:attributes) { subject[:data][:attributes] }
+
+    it { expect(attributes[:name]).to eq("Bob Steven Smith") }
+    it { expect(attributes[:date_of_birth]).to eq("1986-11-10") }
+    it { expect(attributes[:national_insurance_number]).to eq("AA123456C") }
+    it { expect(attributes[:arrest_summons_number]).to eq("2100000000000267128K") }
+  end
+end

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -54,7 +54,7 @@ paths:
           application/json:
             schema:
               "$ref": prosecution_concluded_request.json#/definitions/resource
-  "/api/internal/v2/defendants/{id}":
+  "/api/internal/v2/prosecution_cases/{prosecution_case_reference}/defendants/{defendant_id}":
     patch:
       summary: patch defendant relationships
       description: Delete an LAA reference from Common Platform case
@@ -63,7 +63,13 @@ paths:
       security:
       - oAuth: []
       parameters:
-      - name: id
+      - name: prosecution_case_reference
+        in: path
+        required: true
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/prosecution_case_reference
+      - name: defendant_id
         in: path
         required: true
         type: uuid
@@ -87,14 +93,20 @@ paths:
               "$ref": defendant.json#/definitions/resource_to_unlink
         required: true
     get:
-      summary: fetch a defendant by ID
+      summary: fetch a case defendant
       description: find a defendant where it exists within Court Data Adaptor
       tags:
       - Internal - available to other LAA applications
       security:
       - oAuth: []
       parameters:
-      - name: id
+      - name: prosecution_case_reference
+        in: path
+        required: true
+        type: string
+        schema:
+          "$ref": prosecution_case.json#/prosecution_case_reference
+      - name: defendant_id
         in: path
         required: true
         type: uuid
@@ -102,24 +114,9 @@ paths:
           "$ref": defendant.json#/definitions/id
         description: The uuid of the defendant
       - "$ref": "#/components/parameters/transaction_id_header"
-      - name: include
-        in: query
-        required: false
-        type: string
-        schema:
-          "$ref": defendant.json#/definitions/example_included_query_parameters
-        description: |-
-          Include top-level and nested associations for a defendant.
-                                              All top-level and nested associations available for inclusion are listed under the relationships keys of the response body.
-                                              For example to include offences, defence organisation as well as prosecution case and its associated hearing summaries:
-                                              include=offences,defence_organisation,prosecution_case,prosecution_case.hearing_summaries
       responses:
         '200':
           description: Success
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": defendant.json#/definitions/resource_collection
         '404':
           description: Not found
   "/api/internal/v2/hearing_results/{hearing_id}":


### PR DESCRIPTION
This changes API v2 GET defendant/id endpoint to:

* respond with prosecution case summary and defendant summary data
* remove the reliance on CDA's internal database
## to do

* [x] update Swagger documentation
* [ ] expose as many data points as possible in comparison to API v1