### PR TITLE
Add MAAT ID to prosecution concluded payload

### DIFF
--- a/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
@@ -15,19 +15,30 @@ RSpec.describe "api/external/v1/prosecution_conclusions", type: :request, swagge
       security [{ oAuth: [] }]
 
       response(202, "Accepted") do
-        parameter name: :prosecution_conclusion, in: :body, required: false, type: :object,
-                  schema: {
-                    '$ref': "prosecution_concluded_request.json#/definitions/resource",
-                  },
+        parameter name: :prosecution_conclusion,
+                  in: :body,
+                  required: true,
+                  type: :object,
+                  schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
                   description: "The minimal prosecution concluded payload"
 
         let(:Authorization) { "Bearer #{token.token}" }
         let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
 
         before do
+          LaaReference.create!(
+            user_name: "test-user",
+            defendant_id: "67d948d1-1792-4565-a522-8ab2425827e8",
+            maat_reference: "700111",
+            linked: true,
+          )
+
+          expected_message = { "prosecutionConcluded" => [prosecution_conclusion["prosecutionConcluded"].first.merge("maatId" => "700111")] }
+
           expect(Sqs::MessagePublisher).to receive(:call)
+            .once
             .with(
-              message: prosecution_conclusion,
+              message: expected_message,
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
             )
         end
@@ -55,6 +66,7 @@ RSpec.describe "api/external/v1/prosecution_conclusions", type: :request, swagge
 
       context "when request is unauthorized" do
         response("401", "Unauthorized") do
+          let(:prosecution_conclusion) {}
           let(:Authorization) { nil }
 
           run_test!

--- a/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
@@ -15,19 +15,30 @@ RSpec.describe "api/external/v2/prosecution_conclusions", type: :request, swagge
       security [{ oAuth: [] }]
 
       response(202, "Accepted") do
-        parameter name: :prosecution_conclusion, in: :body, required: false, type: :object,
-                  schema: {
-                    '$ref': "prosecution_concluded_request.json#/definitions/resource",
-                  },
+        parameter name: :prosecution_conclusion,
+                  in: :body,
+                  required: true,
+                  type: :object,
+                  schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
                   description: "The minimal prosecution concluded payload"
 
         let(:Authorization) { "Bearer #{token.token}" }
         let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
 
         before do
+          LaaReference.create!(
+            user_name: "test-user",
+            defendant_id: "67d948d1-1792-4565-a522-8ab2425827e8",
+            maat_reference: "700111",
+            linked: true,
+          )
+
+          expected_message = { "prosecutionConcluded" => [prosecution_conclusion["prosecutionConcluded"].first.merge("maatId" => "700111")] }
+
           expect(Sqs::MessagePublisher).to receive(:call)
+            .once
             .with(
-              message: prosecution_conclusion,
+              message: expected_message,
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
             )
         end
@@ -55,6 +66,7 @@ RSpec.describe "api/external/v2/prosecution_conclusions", type: :request, swagge
 
       context "when request is unauthorized" do
         response("401", "Unauthorized") do
+          let(:prosecution_conclusion) {}
           let(:Authorization) { nil }
 
           run_test!

--- a/swagger/v1/prosecution_concluded_request.json
+++ b/swagger/v1/prosecution_concluded_request.json
@@ -15,7 +15,10 @@
             "$ref": "prosecution_conclusion.json#/definitions/resource"
           }
         }
-      }
+      },
+      "required": [
+        "prosecutionConcluded"
+      ]
     }
   }
 }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -54,6 +54,7 @@ paths:
           application/json:
             schema:
               "$ref": prosecution_concluded_request.json#/definitions/resource
+        required: true
   "/api/internal/v1/defendants/{id}":
     patch:
       summary: patch defendant relationships

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -54,6 +54,7 @@ paths:
           application/json:
             schema:
               "$ref": prosecution_concluded_request.json#/definitions/resource
+        required: true
   "/api/internal/v2/defendants/{id}":
     patch:
       summary: patch defendant relationships


### PR DESCRIPTION
MAAT API is currently unable to lookup a defendant ID's associated MAAT ID, so this PR makes sure the MAAT ID is added to each prosecution conclusion payload.