### PR TITLE
Lasb 747/serialize judicial results on hearing endpoint

### DIFF
--- a/app/controllers/api/internal/v1/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_cases_controller.rb
@@ -6,7 +6,7 @@ module Api
       class ProsecutionCasesController < ApplicationController
         def index
           @prosecution_cases = CommonPlatform::Api::SearchProsecutionCase.call(transformed_params)
-          render json: Api::Internal::V1::ProsecutionCaseSerializer.new(@prosecution_cases, serialization_options)
+          render json: ProsecutionCaseSummarySerializer.new(@prosecution_cases, serialization_options)
         end
 
       private

--- a/app/controllers/api/internal/v2/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_cases_controller.rb
@@ -6,7 +6,7 @@ module Api
       class ProsecutionCasesController < ApplicationController
         def index
           @prosecution_cases = CommonPlatform::Api::SearchProsecutionCase.call(transformed_params)
-          render json: ProsecutionCaseSerializer.new(@prosecution_cases, serialization_options)
+          render json: ProsecutionCaseSummarySerializer.new(@prosecution_cases, serialization_options)
         end
 
       private

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -69,6 +69,10 @@ class Hearing < ApplicationRecord
     court_applications.map(&:id)
   end
 
+  def prosecution_case_ids
+    prosecution_cases.map(&:id)
+  end
+
   def defendant_judicial_result_ids
     defendant_judicial_results.map(&:id)
   end
@@ -76,6 +80,12 @@ class Hearing < ApplicationRecord
   def court_applications
     Array(hearing_body["courtApplications"]).map do |court_application_data|
       HmctsCommonPlatform::CourtApplication.new(court_application_data)
+    end
+  end
+
+  def prosecution_cases
+    Array(prosecution_cases_data).map do |prosecution_case_data|
+      HmctsCommonPlatform::ProsecutionCase.new(prosecution_case_data)
     end
   end
 
@@ -91,12 +101,12 @@ private
     body["hearing"]
   end
 
-  def prosecution_cases
+  def prosecution_cases_data
     hearing_body["prosecutionCases"]
   end
 
   def defendants
-    Array(prosecution_cases).flat_map { |prosecution_case| prosecution_case["defendants"] }
+    Array(prosecution_cases_data).flat_map { |prosecution_case| prosecution_case["defendants"] }
   end
 
   def hearing_event_recordings

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -91,7 +91,7 @@ class Hearing < ApplicationRecord
 
   def defendant_judicial_results
     Array(hearing_body["defendantJudicialResults"]).map do |defendant_judicial_result_data|
-      HmctsCommonPlatform::JudicialResult.new(defendant_judicial_result_data)
+      HmctsCommonPlatform::DefendantJudicialResult.new(defendant_judicial_result_data)
     end
   end
 

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -69,9 +69,19 @@ class Hearing < ApplicationRecord
     court_applications.map(&:id)
   end
 
+  def defendant_judicial_result_ids
+    defendant_judicial_results.map(&:id)
+  end
+
   def court_applications
     Array(hearing_body["courtApplications"]).map do |court_application_data|
       HmctsCommonPlatform::CourtApplication.new(court_application_data)
+    end
+  end
+
+  def defendant_judicial_results
+    Array(hearing_body["defendantJudicialResults"]).map do |defendant_judicial_result_data|
+      HmctsCommonPlatform::JudicialResult.new(defendant_judicial_result_data)
     end
   end
 

--- a/app/models/hmcts_common_platform/defendant.rb
+++ b/app/models/hmcts_common_platform/defendant.rb
@@ -18,11 +18,39 @@ module HmctsCommonPlatform
       data[:proceedingsConcluded]
     end
 
+    def offence_ids
+      offences.map(&:id)
+    end
+
     def offences
       Array(data[:offences]).map do |offence_data|
         HmctsCommonPlatform::Offence.new(offence_data)
       end
     end
+
+    def judicial_result_ids
+      judicial_results.map(&:id)
+    end
+
+    def judicial_results
+      Array(data[:judicialResults]).map do |judicial_result_data|
+        HmctsCommonPlatform::JudicialResult.new(judicial_result_data)
+      end
+    end
+
+    def prosecution_case; end
+
+    def name; end
+
+    def national_insurance_number; end
+
+    def maat_reference; end
+
+    def post_hearing_custody_statuses; end
+
+    def defence_organisation_id; end
+
+    def prosecution_case_id; end
 
   private
 

--- a/app/models/hmcts_common_platform/defendant_judicial_result.rb
+++ b/app/models/hmcts_common_platform/defendant_judicial_result.rb
@@ -1,0 +1,21 @@
+module HmctsCommonPlatform
+  class DefendantJudicialResult
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    delegate :id, :cjs_code, :ordered_date, :text, to: :judicial_result
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def defendant_id
+      data[:masterDefendantId]
+    end
+
+    def judicial_result
+      HmctsCommonPlatform::JudicialResult.new(data[:judicialResult])
+    end
+  end
+end

--- a/app/models/hmcts_common_platform/offence.rb
+++ b/app/models/hmcts_common_platform/offence.rb
@@ -46,7 +46,11 @@ module HmctsCommonPlatform
       data.dig(:allocationDecision, :motReasonCode)
     end
 
-    def results
+    def judicial_result_ids
+      judicial_results.map(&:id)
+    end
+
+    def judicial_results
       Array(data[:judicialResults]).map do |judicial_result_data|
         HmctsCommonPlatform::JudicialResult.new(judicial_result_data)
       end
@@ -56,9 +60,17 @@ module HmctsCommonPlatform
       HmctsCommonPlatform::Plea.new(data[:plea])
     end
 
+    def pleas
+      Array(data[:plea]).map do |plea_data|
+        HmctsCommonPlatform::Plea.new(plea_data)
+      end
+    end
+
     def verdict
       HmctsCommonPlatform::Verdict.new(data[:verdict])
     end
+
+    def mode_of_trial_reasons; end
 
   private
 

--- a/app/models/hmcts_common_platform/prosecution_case.rb
+++ b/app/models/hmcts_common_platform/prosecution_case.rb
@@ -8,6 +8,10 @@ module HmctsCommonPlatform
       @data = HashWithIndifferentAccess.new(data || {})
     end
 
+    def id
+      data[:id]
+    end
+
     def urn
       data.dig(:prosecutionCaseIdentifier, :caseURN)
     end

--- a/app/models/hmcts_common_platform/prosecution_case.rb
+++ b/app/models/hmcts_common_platform/prosecution_case.rb
@@ -12,6 +12,10 @@ module HmctsCommonPlatform
       data[:id]
     end
 
+    def prosecution_case_reference
+      data[:prosecutionCaseReference]
+    end
+
     def urn
       data.dig(:prosecutionCaseIdentifier, :caseURN)
     end

--- a/app/models/hmcts_common_platform/prosecution_case.rb
+++ b/app/models/hmcts_common_platform/prosecution_case.rb
@@ -12,12 +12,12 @@ module HmctsCommonPlatform
       data[:id]
     end
 
-    def prosecution_case_reference
-      data[:prosecutionCaseReference]
-    end
-
     def urn
       data.dig(:prosecutionCaseIdentifier, :caseURN)
+    end
+
+    def defendant_ids
+      defendants.map(&:id)
     end
 
     def defendants

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -107,7 +107,7 @@ module MaatApi
     end
 
     def judicial_results(offence)
-      offence.results&.map do |judicial_result|
+      offence.judicial_results&.map do |judicial_result|
         {
           resultCode: judicial_result.cjs_code,
           resultShortTitle: judicial_result.label,

--- a/app/serializers/api/internal/v1/defendant_judicial_result_serializer.rb
+++ b/app/serializers/api/internal/v1/defendant_judicial_result_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V1
+      class DefendantJudicialResultSerializer
+        include JSONAPI::Serializer
+
+        attributes :id,
+                   :defendant_id,
+                   :cjs_code,
+                   :ordered_date,
+                   :text
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v1/hearing_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_serializer.rb
@@ -18,6 +18,7 @@ module Api
         has_many :hearing_events
         has_many :providers
         has_many :court_applications
+        has_many :defendant_judicial_results
         has_one :cracked_ineffective_trial
       end
     end

--- a/app/serializers/api/internal/v1/hearing_serializer.rb
+++ b/app/serializers/api/internal/v1/hearing_serializer.rb
@@ -18,6 +18,7 @@ module Api
         has_many :hearing_events
         has_many :providers
         has_many :court_applications
+        has_many :prosecution_cases
         has_many :defendant_judicial_results
         has_one :cracked_ineffective_trial
       end

--- a/app/serializers/api/internal/v1/prosecution_case_summary_serializer.rb
+++ b/app/serializers/api/internal/v1/prosecution_case_summary_serializer.rb
@@ -3,13 +3,15 @@
 module Api
   module Internal
     module V1
-      class ProsecutionCaseSerializer
+      class ProsecutionCaseSummarySerializer
         include JSONAPI::Serializer
         set_type :prosecution_cases
 
-        attributes :urn
+        attributes :prosecution_case_reference
 
         has_many :defendants, record_type: :defendants
+        has_many :hearing_summaries, record_type: :hearing_summaries
+        has_many :hearings, record_type: :hearings
       end
     end
   end

--- a/app/serializers/api/internal/v2/defendant_judicial_result_serializer.rb
+++ b/app/serializers/api/internal/v2/defendant_judicial_result_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class DefendantJudicialResultSerializer
+        include JSONAPI::Serializer
+
+        attributes :id,
+                   :defendant_id,
+                   :cjs_code,
+                   :ordered_date,
+                   :text
+      end
+    end
+  end
+end

--- a/app/serializers/api/internal/v2/defendant_serializer.rb
+++ b/app/serializers/api/internal/v2/defendant_serializer.rb
@@ -16,6 +16,7 @@ module Api
                    :post_hearing_custody_statuses
 
         has_many :offences, record_type: :offences
+        has_many :judicial_results, record_type: :judicial_results
         has_one :defence_organisation, record_type: :defence_organisations
         has_one :prosecution_case, record_type: :prosecution_case
       end

--- a/app/serializers/api/internal/v2/hearing_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_serializer.rb
@@ -17,6 +17,7 @@ module Api
 
         has_many :providers
         has_many :court_applications
+        has_many :defendant_judicial_results
         has_one :cracked_ineffective_trial
       end
     end

--- a/app/serializers/api/internal/v2/hearing_serializer.rb
+++ b/app/serializers/api/internal/v2/hearing_serializer.rb
@@ -17,6 +17,7 @@ module Api
 
         has_many :providers
         has_many :court_applications
+        has_many :prosecution_cases
         has_many :defendant_judicial_results
         has_one :cracked_ineffective_trial
       end

--- a/app/serializers/api/internal/v2/offence_serializer.rb
+++ b/app/serializers/api/internal/v2/offence_serializer.rb
@@ -28,6 +28,8 @@ module Api
             },
           }
         end
+
+        has_many :judicial_results
       end
     end
   end

--- a/app/serializers/api/internal/v2/prosecution_case_summary_serializer.rb
+++ b/app/serializers/api/internal/v2/prosecution_case_summary_serializer.rb
@@ -3,13 +3,14 @@
 module Api
   module Internal
     module V2
-      class ProsecutionCaseSerializer
+      class ProsecutionCaseSummarySerializer
         include JSONAPI::Serializer
         set_type :prosecution_cases
 
-        attributes :urn
+        attributes :prosecution_case_reference
 
         has_many :defendants, record_type: :defendants
+        has_many :hearing_summaries, record_type: :hearing_summaries
       end
     end
   end

--- a/spec/fixtures/files/defendant_judicial_result/all_fields.json
+++ b/spec/fixtures/files/defendant_judicial_result/all_fields.json
@@ -1,0 +1,87 @@
+
+{
+    "masterDefendantId": "b9d35f79-875d-4205-8a20-254a6e2877d9", 
+    "judicialResult": {
+        "alwaysPublished": false,
+        "canBeSubjectOfBreach": false,
+        "canBeSubjectOfVariation": false,
+        "category": "FINAL",
+        "cjsCode": "4600",
+        "courtClerk": {
+        "firstName": "Erica",
+        "lastName": "Wilson",
+        "userId": "a085e359-6069-4694-8820-7810e7dfe762"
+        },
+        "d20": false,
+        "excludedFromResults": false,
+        "isAdjournmentResult": false,
+        "isAvailableForCourtExtract": true,
+        "isConvictedResult": false,
+        "isDeleted": false,
+        "isFinancialResult": false,
+        "judicialResultId": "be225605-fc15-47aa-b74c-efb8629db58e",
+        "judicialResultPrompts": [
+        {
+            "isFinancialImposition": false,
+            "judicialResultPromptTypeId": "1745ee94-1564-48b3-9eca-4a34e1baf706",
+            "label": "Grant of legal aid transferred to (new firm name)",
+            "isAvailableForCourtExtract": true,
+            "promptReference": "grantOfLegalAidTransferredToNewFirmName",
+            "promptSequence": 100,
+            "usergroups": [],
+            "value": "Joe Bloggs Solicitors Ltd, London",
+            "welshValue": "Joe Bloggs Solicitors Ltd, London"
+        },
+        {
+            "isFinancialImposition": false,
+            "judicialResultPromptTypeId": "df6fe61a-b209-4fb1-9bbf-eadb2acb7c22",
+            "label": "Additional reasons",
+            "isAvailableForCourtExtract": true,
+            "promptReference": "additionalReasons",
+            "promptSequence": 200,
+            "usergroups": [],
+            "value": "Defendant's choice",
+            "welshValue": "Defendant's choice"
+        },
+        {
+            "isFinancialImposition": false,
+            "judicialResultPromptTypeId": "de946ead-b69e-4096-9008-dfecb6014e2d",
+            "label": "New firm's LAA account reference",
+            "isAvailableForCourtExtract": true,
+            "promptReference": "newFirmsLAAAccountReference",
+            "promptSequence": 300,
+            "usergroups": [],
+            "value": "55558888",
+            "welshValue": "55558888"
+        }
+        ],
+        "judicialResultTypeId": "c5520033-7389-4815-a5c9-bf28fcebb134",
+        "label": "Legal Aid Transfer Granted",
+        "lastSharedDateTime": "2021-03-09",
+        "level": "O",
+        "lifeDuration": false,
+        "nextHearing": {
+        "courtCentre": {
+            "id": "f8254db1-1683-483e-afb3-b87fde5a0a26"
+        },
+        "type": {
+            "id": "f0a970dc-ddac-48e6-b76c-ccfaa4c0e8a0",
+            "description": "Description of next hearing"
+        },
+        "listedStartDateTime": "2021-03-09T15:54:09.871Z",
+        "estimatedMinutes": 10
+        },
+        "orderedDate": "2021-03-10",
+        "orderedHearingId": "dafbe7f9-2f42-4781-8bbf-24ce47d51fd5",
+        "postHearingCustodyStatus": "A",
+        "publishedAsAPrompt": false,
+        "qualifier": "qualifier",
+        "rank": 49500,
+        "resultText": "Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888",
+        "rootJudicialResultId": "be225605-fc15-47aa-b74c-efb8629db58e",
+        "rootJudicialResultTypeId": "c5520033-7389-4815-a5c9-bf28fcebb134",
+        "terminatesOffenceProceedings": false,
+        "urgent": false,
+        "usergroups": []
+    }
+}

--- a/spec/fixtures/files/defendant_judicial_result/required_fields.json
+++ b/spec/fixtures/files/defendant_judicial_result/required_fields.json
@@ -1,0 +1,14 @@
+
+{
+    "masterDefendantId": "b9d35f79-875d-4205-8a20-254a6e2877d9", 
+    "judicialResult": {
+        "orderedHearingId": "dafbe7f9-2f42-4781-8bbf-24ce47d51fd5",
+        "label": "Legal Aid Transfer Granted",
+        "isAdjournmentResult": false,
+        "isFinancialResult": false,
+        "isConvictedResult": false,
+        "isAvailableForCourtExtract": true,
+        "orderedDate": "2021-03-10",
+        "category": "FINAL"
+    }
+}

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.hearing_days).to eq(["2020-08-17T09:01:01.001Z"]) }
       it { expect(hearing.cracked_ineffective_trial).to be_nil }
       it { expect(hearing.cracked_ineffective_trial_id).to be_nil }
+      it { expect(hearing.defendant_judicial_results).to be_blank }
 
       context "with hearing events" do
         let(:hearing_day) { "2020-08-17" }
@@ -81,6 +82,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.prosecution_advocate_names).to eq(["andrew smith"]) }
       it { expect(hearing.defence_advocate_names).to eq(["joe bloggs"]) }
       it { expect(hearing.providers).to all be_a(Provider) }
+      it { expect(hearing.defendant_judicial_results).to all be_a(HmctsCommonPlatform::JudicialResult) }
       it { expect(hearing.provider_ids).to eq(%w[536abfd5-8671-4672-bf33-aa54de5d6a24]) }
       it { expect(hearing.hearing_days).to eq(["2020-08-18T09:00:00.000Z"]) }
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.prosecution_advocate_names).to eq(["andrew smith"]) }
       it { expect(hearing.defence_advocate_names).to eq(["joe bloggs"]) }
       it { expect(hearing.providers).to all be_a(Provider) }
-      it { expect(hearing.defendant_judicial_results).to all be_a(HmctsCommonPlatform::JudicialResult) }
+      it { expect(hearing.defendant_judicial_results).to all be_a(HmctsCommonPlatform::DefendantJudicialResult) }
       it { expect(hearing.provider_ids).to eq(%w[536abfd5-8671-4672-bf33-aa54de5d6a24]) }
       it { expect(hearing.hearing_days).to eq(["2020-08-18T09:00:00.000Z"]) }
 

--- a/spec/models/hmcts_common_platform/defendant_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe HmctsCommonPlatform::Defendant, type: :model do
       expect(defendant.offences).to all(be_an(HmctsCommonPlatform::Offence))
     end
 
-    it "has judicial resutl ids" do
+    it "has judicial result ids" do
       expect(defendant.judicial_result_ids).to eql(%w[be225605-fc15-47aa-b74c-efb8629db58e])
     end
 

--- a/spec/models/hmcts_common_platform/defendant_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_spec.rb
@@ -84,9 +84,20 @@ RSpec.describe HmctsCommonPlatform::Defendant, type: :model do
       expect(defendant.email_secondary).to eql("secondary@example.com")
     end
 
+    it "has offence ids" do
+      expect(defendant.offence_ids).to eql(%w[b8ffe7db-f994-45a0-9c06-9ec953eeffd7 b8ffe7db-f994-45a0-9c06-9ec953eeff99])
+    end
+
     it "has offences" do
       expect(defendant.offences).to all(be_an(HmctsCommonPlatform::Offence))
-      expect(defendant.offences).to be_an(Array)
+    end
+
+    it "has judicial resutl ids" do
+      expect(defendant.judicial_result_ids).to eql(%w[be225605-fc15-47aa-b74c-efb8629db58e])
+    end
+
+    it "has judicial results" do
+      expect(defendant.judicial_results).to all(be_an(HmctsCommonPlatform::JudicialResult))
     end
   end
 
@@ -173,10 +184,13 @@ RSpec.describe HmctsCommonPlatform::Defendant, type: :model do
       expect(defendant.email_secondary).to be_nil
     end
 
+    it "has no judicial results" do
+      expect(defendant.judicial_results).to be_empty
+    end
+
     describe "offences" do
       it "are HmctsCommonPlatform::Offence objects" do
         expect(defendant.offences).to all(be_an(HmctsCommonPlatform::Offence))
-        expect(defendant.offences).to be_an(Array)
       end
     end
   end

--- a/spec/models/hmcts_common_platform/offence_spec.rb
+++ b/spec/models/hmcts_common_platform/offence_spec.rb
@@ -64,13 +64,20 @@ RSpec.describe HmctsCommonPlatform::Offence, type: :model do
       expect(offence.laa_reference_laa_contract_number).to eql("27900")
     end
 
+    it "has result ids" do
+      expect(offence.judicial_result_ids).to eql(%w[5cb61858-7095-42d6-8a52-966593f17db0])
+    end
+
     it "has results" do
-      expect(offence.results).to all(be_an(HmctsCommonPlatform::JudicialResult))
-      expect(offence.results).to be_an(Array)
+      expect(offence.judicial_results).to all(be_an(HmctsCommonPlatform::JudicialResult))
     end
 
     it "has a plea" do
       expect(offence.plea).to be_an(HmctsCommonPlatform::Plea)
+    end
+
+    it "has pleas" do
+      expect(offence.pleas).to all(be_an(HmctsCommonPlatform::Plea))
     end
 
     it "has a verdict" do
@@ -140,7 +147,7 @@ RSpec.describe HmctsCommonPlatform::Offence, type: :model do
     end
 
     it "has no results" do
-      expect(offence.results).to eql([])
+      expect(offence.judicial_results).to eql([])
     end
 
     it "has no plea" do

--- a/spec/models/hmcts_common_platform/prosecution_case_spec.rb
+++ b/spec/models/hmcts_common_platform/prosecution_case_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe HmctsCommonPlatform::ProsecutionCase, type: :model do
       expect(prosecution_case.urn).to eql("20GD0217100")
     end
 
+    it "has defendant ids" do
+      expect(prosecution_case.defendant_ids).to eql(%w[2ecc9feb-9407-482f-b081-d9e5c8ba3ed3])
+    end
+
     it "has defendants" do
       expect(prosecution_case.defendants).to all(be_an(HmctsCommonPlatform::Defendant))
     end

--- a/spec/requests/api/internal/v1/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v1/hearings_request_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "api/internal/v1/hearings", type: :request, swagger_doc: "v1/swag
           end
         end
 
-        context "with the inclusion of hearing events, providers, court applications, cracked ineffective trial and judicial results" do
+        context "with the inclusion of hearing events, providers, court applications, prosecution cases, cracked ineffective trial and defendant judicial results" do
           response(200, "Success") do
             produces "application/vnd.api+json"
 
@@ -54,8 +54,8 @@ RSpec.describe "api/internal/v1/hearings", type: :request, swagger_doc: "v1/swag
                       },
                       description: "Include top-level and nested associations for a hearing.
                                     All top-level and nested associations available for inclusion are listed under the relationships keys of the response body.
-                                    For example to include hearing events, providers, cracked ineffective trial as well as court applications and associated judicial results:
-                                    include=hearing_events,providers,court_applications,cracked_ineffective_trial,court_applications.judicial_results"
+                                    For example to include hearing events, providers, prosecution cases, cracked ineffective trial as well as court applications and associated judicial results:
+                                    include=hearing_events,providers,court_applications,prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results"
 
             schema "$ref" => "hearing.json#/definitions/resource_collection"
 

--- a/spec/serializers/api/internal/v1/defendant_judicial_result_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/defendant_judicial_result_serializer_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Api::Internal::V1::DefendantJudicialResultSerializer do
+  subject(:attributes_hash) { described_class.new(defendant_judicial_result).serializable_hash[:data][:attributes] }
+
+  let(:defendant_judicial_result_data) { JSON.parse(file_fixture("defendant_judicial_result/all_fields.json").read) }
+  let(:defendant_judicial_result) { HmctsCommonPlatform::DefendantJudicialResult.new(defendant_judicial_result_data) }
+
+  it { expect(attributes_hash[:id]).to eql("be225605-fc15-47aa-b74c-efb8629db58e") }
+  it { expect(attributes_hash[:defendant_id]).to eql("b9d35f79-875d-4205-8a20-254a6e2877d9") }
+  it { expect(attributes_hash[:cjs_code]).to eql("4600") }
+  it { expect(attributes_hash[:ordered_date]).to eql("2021-03-10") }
+  it { expect(attributes_hash[:text]).to eql("Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888") }
+end

--- a/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
                     prosecution_advocate_names: ["John Rob"],
                     defence_advocate_names: ["Neil Griffiths"],
                     provider_ids: %w[PROVIDER_UUID],
+                    defendant_judicial_result_ids: %w[DEFENDANT_JUDICIAL_RESULT_UUID],
                     court_application_ids: %w[COURT_APPLICATION_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
@@ -37,6 +38,7 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
     it { expect(relationship_hash[:hearing_events][:data]).to eq([{ id: "HEARING_EVENT_UUID", type: :hearing_event }]) }
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
     it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
+    it { expect(relationship_hash[:defendant_judicial_results][:data]).to eq([{ id: "DEFENDANT_JUDICIAL_RESULT_UUID", type: :defendant_judicial_result }]) }
     it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 

--- a/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/hearing_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
                     provider_ids: %w[PROVIDER_UUID],
                     defendant_judicial_result_ids: %w[DEFENDANT_JUDICIAL_RESULT_UUID],
                     court_application_ids: %w[COURT_APPLICATION_UUID],
+                    prosecution_case_ids: %w[PROSECUTION_CASE_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
 
@@ -39,6 +40,7 @@ RSpec.describe Api::Internal::V1::HearingSerializer do
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
     it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
     it { expect(relationship_hash[:defendant_judicial_results][:data]).to eq([{ id: "DEFENDANT_JUDICIAL_RESULT_UUID", type: :defendant_judicial_result }]) }
+    it { expect(relationship_hash[:prosecution_cases][:data]).to eq([{ id: "PROSECUTION_CASE_UUID", type: :prosecution_cases }]) }
     it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 

--- a/spec/serializers/api/internal/v1/prosecution_case_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/prosecution_case_serializer_spec.rb
@@ -4,25 +4,21 @@ RSpec.describe Api::Internal::V1::ProsecutionCaseSerializer do
   subject { described_class.new(prosecution_case).serializable_hash }
 
   let(:prosecution_case) do
-    instance_double("ProsecutionCase",
+    instance_double("HMCTSCommonPlatform::ProsecutionCase",
                     id: "UUID",
-                    prosecution_case_reference: "AAA",
-                    defendant_ids: %w[DEFENDANT-UUID],
-                    hearing_ids: %w[HEARING-UUID],
-                    hearing_summary_ids: %w[HEARING-UUID])
+                    urn: "AAA",
+                    defendant_ids: %w[DEFENDANT-UUID])
   end
 
   context "with attributes" do
     let(:attribute_hash) { subject[:data][:attributes] }
 
-    it { expect(attribute_hash[:prosecution_case_reference]).to eq("AAA") }
+    it { expect(attribute_hash[:urn]).to eq("AAA") }
   end
 
   context "with relationships" do
     let(:relationship_hash) { subject[:data][:relationships] }
 
     it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
-    it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
-    it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
   end
 end

--- a/spec/serializers/api/internal/v1/prosecution_case_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/prosecution_case_summary_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V1::ProsecutionCaseSummarySerializer do
+  subject { described_class.new(prosecution_case).serializable_hash }
+
+  let(:prosecution_case) do
+    instance_double("ProsecutionCase",
+                    id: "UUID",
+                    prosecution_case_reference: "AAA",
+                    defendant_ids: %w[DEFENDANT-UUID],
+                    hearing_ids: %w[HEARING-UUID],
+                    hearing_summary_ids: %w[HEARING-UUID])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:prosecution_case_reference]).to eq("AAA") }
+  end
+
+  context "with relationships" do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
+    it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
+    it { expect(relationship_hash[:hearings][:data]).to eq([{ id: "HEARING-UUID", type: :hearings }]) }
+  end
+end

--- a/spec/serializers/api/internal/v2/defendant_judicial_result_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defendant_judicial_result_serializer_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Api::Internal::V2::DefendantJudicialResultSerializer do
+  subject(:attributes_hash) { described_class.new(defendant_judicial_result).serializable_hash[:data][:attributes] }
+
+  let(:defendant_judicial_result_data) { JSON.parse(file_fixture("defendant_judicial_result/all_fields.json").read) }
+  let(:defendant_judicial_result) { HmctsCommonPlatform::DefendantJudicialResult.new(defendant_judicial_result_data) }
+
+  it { expect(attributes_hash[:id]).to eql("be225605-fc15-47aa-b74c-efb8629db58e") }
+  it { expect(attributes_hash[:defendant_id]).to eql("b9d35f79-875d-4205-8a20-254a6e2877d9") }
+  it { expect(attributes_hash[:cjs_code]).to eql("4600") }
+  it { expect(attributes_hash[:ordered_date]).to eql("2021-03-10") }
+  it { expect(attributes_hash[:text]).to eql("Legal Aid Transfer Granted\nGrant of legal aid transferred to (new firm name) Joe Bloggs Solicitors Ltd, London\nAdditional reasons Defendant's choice\nNew firm's LAA account reference 55558888") }
+end

--- a/spec/serializers/api/internal/v2/defendant_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/defendant_serializer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Api::Internal::V2::DefendantSerializer do
                     offence_ids: %w[55555],
                     defence_organisation_id: "88888",
                     prosecution_case_id: "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+                    judicial_result_ids: %w[be225605-fc15-47aa-b74c-efb8629db58e],
                     post_hearing_custody_statuses: %w[A])
   end
 
@@ -35,5 +36,6 @@ RSpec.describe Api::Internal::V2::DefendantSerializer do
     it { expect(relationship_hash[:offences][:data]).to eq([{ id: "55555", type: :offences }]) }
     it { expect(relationship_hash[:defence_organisation][:data]).to eq({ id: "88888", type: :defence_organisations }) }
     it { expect(relationship_hash[:prosecution_case][:data]).to eq({ id: "5edd67eb-9d8c-44f2-a57e-c8d026defaa4", type: :prosecution_case }) }
+    it { expect(relationship_hash[:judicial_results][:data]).to eq([{ id: "be225605-fc15-47aa-b74c-efb8629db58e", type: :judicial_results }]) }
   end
 end

--- a/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
                     provider_ids: %w[PROVIDER_UUID],
                     defendant_judicial_result_ids: %w[DEFENDANT_JUDICIAL_RESULT_UUID],
                     court_application_ids: %w[COURT_APPLICATION_UUID],
+                    prosecution_case_ids: %w[PROSECUTION_CASE_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
 
@@ -38,6 +39,7 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
     it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
     it { expect(relationship_hash[:defendant_judicial_results][:data]).to eq([{ id: "DEFENDANT_JUDICIAL_RESULT_UUID", type: :defendant_judicial_result }]) }
+    it { expect(relationship_hash[:prosecution_cases][:data]).to eq([{ id: "PROSECUTION_CASE_UUID", type: :prosecution_cases }]) }
     it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 

--- a/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/hearing_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
                     prosecution_advocate_names: ["John Rob"],
                     defence_advocate_names: ["Neil Griffiths"],
                     provider_ids: %w[PROVIDER_UUID],
+                    defendant_judicial_result_ids: %w[DEFENDANT_JUDICIAL_RESULT_UUID],
                     court_application_ids: %w[COURT_APPLICATION_UUID],
                     cracked_ineffective_trial_id: "CRACKED_INEFFECTIVE_TRIAL_UUID")
   end
@@ -36,6 +37,7 @@ RSpec.describe Api::Internal::V2::HearingSerializer do
 
     it { expect(relationship_hash[:providers][:data]).to eq([{ id: "PROVIDER_UUID", type: :provider }]) }
     it { expect(relationship_hash[:court_applications][:data]).to eq([{ id: "COURT_APPLICATION_UUID", type: :court_application }]) }
+    it { expect(relationship_hash[:defendant_judicial_results][:data]).to eq([{ id: "DEFENDANT_JUDICIAL_RESULT_UUID", type: :defendant_judicial_result }]) }
     it { expect(relationship_hash[:cracked_ineffective_trial][:data]).to eq({ id: "CRACKED_INEFFECTIVE_TRIAL_UUID", type: :cracked_ineffective_trial }) }
   end
 

--- a/spec/serializers/api/internal/v2/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/offence_serializer_spec.rb
@@ -54,5 +54,18 @@ RSpec.describe Api::Internal::V2::OffenceSerializer do
         expect(attributes[:verdict]).to eq(expected)
       end
     end
+
+    describe "relationships" do
+      let(:relationships) { serialized_data[:relationships] }
+
+      it "judicial_results" do
+        expected = [{
+          id: "5cb61858-7095-42d6-8a52-966593f17db0",
+          type: :judicial_result,
+        }]
+
+        expect(relationships[:judicial_results][:data]).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/prosecution_case_serializer_spec.rb
@@ -4,24 +4,21 @@ RSpec.describe Api::Internal::V2::ProsecutionCaseSerializer do
   subject { described_class.new(prosecution_case).serializable_hash }
 
   let(:prosecution_case) do
-    instance_double("ProsecutionCase",
+    instance_double("HMCTSCommonPlatform::ProsecutionCase",
                     id: "UUID",
-                    prosecution_case_reference: "AAA",
-                    defendant_ids: %w[DEFENDANT-UUID],
-                    hearing_ids: %w[HEARING-UUID],
-                    hearing_summary_ids: %w[HEARING-UUID])
+                    urn: "AAA",
+                    defendant_ids: %w[DEFENDANT-UUID])
   end
 
   context "with attributes" do
     let(:attribute_hash) { subject[:data][:attributes] }
 
-    it { expect(attribute_hash[:prosecution_case_reference]).to eq("AAA") }
+    it { expect(attribute_hash[:urn]).to eq("AAA") }
   end
 
   context "with relationships" do
     let(:relationship_hash) { subject[:data][:relationships] }
 
     it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
-    it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
   end
 end

--- a/spec/serializers/api/internal/v2/prosecution_case_summary_serializer_spec.rb
+++ b/spec/serializers/api/internal/v2/prosecution_case_summary_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Internal::V2::ProsecutionCaseSummarySerializer do
+  subject { described_class.new(prosecution_case).serializable_hash }
+
+  let(:prosecution_case) do
+    instance_double("ProsecutionCase",
+                    id: "UUID",
+                    prosecution_case_reference: "AAA",
+                    defendant_ids: %w[DEFENDANT-UUID],
+                    hearing_ids: %w[HEARING-UUID],
+                    hearing_summary_ids: %w[HEARING-UUID])
+  end
+
+  context "with attributes" do
+    let(:attribute_hash) { subject[:data][:attributes] }
+
+    it { expect(attribute_hash[:prosecution_case_reference]).to eq("AAA") }
+  end
+
+  context "with relationships" do
+    let(:relationship_hash) { subject[:data][:relationships] }
+
+    it { expect(relationship_hash[:defendants][:data]).to eq([{ id: "DEFENDANT-UUID", type: :defendants }]) }
+    it { expect(relationship_hash[:hearing_summaries][:data]).to eq([{ id: "HEARING-UUID", type: :hearing_summaries }]) }
+  end
+end

--- a/swagger/v1/defendant.json
+++ b/swagger/v1/defendant.json
@@ -161,6 +161,9 @@
                 "$ref": "offence.json#/definitions/resource"
               },
               {
+                "$ref": "judicial_result.json#/definitions/resource"
+              },
+              {
                 "$ref": "defence_organisation.json#/definitions/included_resource"
               },
               {
@@ -178,7 +181,7 @@
     "example_included_query_parameters": {
       "description": "An example of parameters that can be included in the query",
       "type": "string",
-      "example": "offences,defence_organisation,prosecution_case,prosecution_case.hearing_summaries"
+      "example": "offences,judicial_results,defence_organisation,prosecution_case,prosecution_case.hearing_summaries"
     },
     "attributes": {
       "type": "object",

--- a/swagger/v1/defendant_judicial_result.json
+++ b/swagger/v1/defendant_judicial_result.json
@@ -19,6 +19,11 @@
       "format": "uuid",
       "type": "string"
     },
+    "cjs_code": {
+      "description": "The code of the judicial result",
+      "example": "2507",
+      "type": "string"
+    },
     "ordered_date": {
       "description": "The date the result was ordered",
       "example": "2019-10-16"

--- a/swagger/v1/defendant_judicial_result.json
+++ b/swagger/v1/defendant_judicial_result.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defendant Judicial Result",
+  "description": "Defendant judicial result",
+  "id": "defendant_judicial_result",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "defendant_id": {
+      "description": "The unique identifier of the defendant this judicial result applies to",
+      "example": "07127d2e-badc-4298-86d8-9b2dff9bff91",
+      "format": "uuid",
+      "type": "string"
+    },
+    "id": {
+      "description": "The unique identifier of the judicial result",
+      "example": "fcc1a759-88d2-4260-8b3e-92c2749ecbb1",
+      "format": "uuid",
+      "type": "string"
+    },
+    "ordered_date": {
+      "description": "The date the result was ordered",
+      "example": "2019-10-16"
+    },
+    "type": {
+      "description": "The defendant judicial result type",
+      "example": "defendant_judicial_results",
+      "type": "string"
+    },
+    "included_type": {
+     "description": "Defendant judicial result is referred to in the singular form when displayed in the payload when included as part of the API query or when displayed as a relationship to another object",
+     "example": "defendant_judicial_result"
+    },
+    "relationship_type": {
+      "description": "The defendant judicial results type is referred to in the singular form when referenced as a relationship",
+      "example": "defendant_judicial_result",
+      "type": "string"
+    },
+    "text": {
+      "description": "Text of the judicial result",
+      "example": "NOT GUILTY",
+      "type": "string"
+    },
+    "resource": {
+      "description": "An object representing a single defendant judicial result",
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "included_resource": {
+      "description": "An object representing a single judicial result when included in an API query",
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/included_type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "defendant_id": {
+          "$ref": "#/definitions/defendant_id"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "cjs_code": {
+          "$ref": "#/definitions/cjs_code"
+        },
+        "ordered_date": {
+          "$ref": "#/definitions/ordered_date"
+        },
+        "text": {
+          "$ref": "#/definitions/text"
+        }
+      }
+    }
+  }
+}

--- a/swagger/v1/hearing.json
+++ b/swagger/v1/hearing.json
@@ -65,6 +65,12 @@
         "court_applications": {
           "$ref": "#/definitions/court_application_relationship"
         },
+        "prosecution_cases": {
+          "$ref": "#/definitions/prosecution_case_relationship"
+        },
+        "defendant_judicial_results": {
+          "$ref": "#/definitions/defendant_judicial_result_relationship"
+        },
         "cracked_ineffective_trial": {
           "$ref": "#/definitions/cracked_ineffective_trial_relationship"
         }
@@ -136,6 +142,50 @@
         }
       }
     },
+    "prosecution_case_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/prosecution_case"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "prosecution_case": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "prosecution_case.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "prosecution_case.json#/definitions/type"
+        }
+      }
+    },
+    "defendant_judicial_result_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/defendant_judicial_result"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defendant_judicial_result": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defendant_judicial_result.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defendant_judicial_result.json#/definitions/type"
+        }
+      }
+    },
     "cracked_ineffective_trial_relationship": {
       "type": "object",
       "properties": {
@@ -198,6 +248,12 @@
                 "$ref": "court_application.json#/definitions/resource"
               },
               {
+                "$ref": "prosecution_case.json#/definitions/resource"
+              },
+              {
+                "$ref": "defendant_judicial_result.json#/definitions/resource"
+              },
+              {
                 "$ref": "cracked_ineffective_trial.json#/definitions/resource"
               }
             ]
@@ -209,7 +265,7 @@
     "example_included_query_parameters": {
       "description": "An example of parameters that can be included in the query",
       "type": "string",
-      "example": "hearing_events,providers,court_applications,cracked_ineffective_trial,court_applications.judicial_results"
+      "example": "hearing_events,providers,court_applications,prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results"
     },
     "attributes": {
       "type": "object",

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -235,6 +235,29 @@
       }
     }
   },
+  "resource_collection": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "$ref": "#/definitions/resource"
+      },
+      "included": {
+        "items": {
+          "anyOf":[
+            {
+              "$ref": "judicial_result.json#/definitions/resource"
+            }
+          ]
+        },
+        "type": "array"
+      }
+    }
+  },
+  "example_included_query_parameters": {
+    "description": "An example of parameters that can be included in the query",
+    "type": "string",
+    "example": "judicial_results"
+  },
   "links": [
     {
       "description": "Info for existing offence.",

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -149,8 +149,8 @@ paths:
         description: |-
           Include top-level and nested associations for a hearing.
                                               All top-level and nested associations available for inclusion are listed under the relationships keys of the response body.
-                                              For example to include hearing events, providers, cracked ineffective trial as well as court applications and associated judicial results:
-                                              include=hearing_events,providers,court_applications,cracked_ineffective_trial,court_applications.judicial_results
+                                              For example to include hearing events, providers, prosecution cases, cracked ineffective trial as well as court applications and associated judicial results:
+                                              include=hearing_events,providers,court_applications,prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results
       - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '200':

--- a/swagger/v2/defendant.json
+++ b/swagger/v2/defendant.json
@@ -31,6 +31,9 @@
         "offences": {
           "$ref": "#/definitions/offence_relationship"
         },
+        "judicial_results": {
+          "$ref": "#/definitions/judicial_result_relationship"
+        },
         "defence_organisation": {
           "$ref": "#/definitions/defence_organisation_relationship"
         },
@@ -58,6 +61,28 @@
         },
         "type": {
           "$ref": "offence.json#/definitions/type"
+        }
+      }
+    },
+    "judicial_result_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/judicial_result"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "judicial_result": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "judicial_result.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "judicial_result.json#/definitions/type"
         }
       }
     },
@@ -133,6 +158,9 @@
                 "$ref": "offence.json#/definitions/resource"
               },
               {
+                "$ref": "judicial_result.json#/definitions/resource"
+              },
+              {
                 "$ref": "defence_organisation.json#/definitions/included_resource"
               },
               {
@@ -150,7 +178,7 @@
     "example_included_query_parameters": {
       "description": "An example of parameters that can be included in the query",
       "type": "string",
-      "example": "offences,defence_organisation,prosecution_case,prosecution_case.hearing_summaries"
+      "example": "offences,judicial_results,defence_organisation,prosecution_case,prosecution_case.hearing_summaries"
     },
     "attributes": {
       "type": "object",

--- a/swagger/v2/defendant_judicial_result.json
+++ b/swagger/v2/defendant_judicial_result.json
@@ -19,6 +19,11 @@
       "format": "uuid",
       "type": "string"
     },
+    "cjs_code": {
+      "description": "The code of the judicial result",
+      "example": "2507",
+      "type": "string"
+    },
     "ordered_date": {
       "description": "The date the result was ordered",
       "example": "2019-10-16"

--- a/swagger/v2/defendant_judicial_result.json
+++ b/swagger/v2/defendant_judicial_result.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Defendant Judicial Result",
+  "description": "Defendant judicial result",
+  "id": "defendant_judicial_result",
+  "stability": "prototype",
+  "strictProperties": true,
+  "type": "object",
+  "definitions": {
+    "defendant_id": {
+      "description": "The unique identifier of the defendant this judicial result applies to",
+      "example": "07127d2e-badc-4298-86d8-9b2dff9bff91",
+      "format": "uuid",
+      "type": "string"
+    },
+    "id": {
+      "description": "The unique identifier of the judicial result",
+      "example": "fcc1a759-88d2-4260-8b3e-92c2749ecbb1",
+      "format": "uuid",
+      "type": "string"
+    },
+    "ordered_date": {
+      "description": "The date the result was ordered",
+      "example": "2019-10-16"
+    },
+    "type": {
+      "description": "The defendant judicial result type",
+      "example": "defendant_judicial_results",
+      "type": "string"
+    },
+    "included_type": {
+     "description": "Defendant judicial result is referred to in the singular form when displayed in the payload when included as part of the API query or when displayed as a relationship to another object",
+     "example": "defendant_judicial_result"
+    },
+    "relationship_type": {
+      "description": "The defendant judicial results type is referred to in the singular form when referenced as a relationship",
+      "example": "defendant_judicial_result",
+      "type": "string"
+    },
+    "text": {
+      "description": "Text of the judicial result",
+      "example": "NOT GUILTY",
+      "type": "string"
+    },
+    "resource": {
+      "description": "An object representing a single defendant judicial result",
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "included_resource": {
+      "description": "An object representing a single judicial result when included in an API query",
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/included_type"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "defendant_id": {
+          "$ref": "#/definitions/defendant_id"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "cjs_code": {
+          "$ref": "#/definitions/cjs_code"
+        },
+        "ordered_date": {
+          "$ref": "#/definitions/ordered_date"
+        },
+        "text": {
+          "$ref": "#/definitions/text"
+        }
+      }
+    }
+  }
+}

--- a/swagger/v2/hearing.json
+++ b/swagger/v2/hearing.json
@@ -73,6 +73,12 @@
          "court_applications": {
            "$ref": "#/definitions/court_application_relationship"
          },
+         "prosecution_cases": {
+           "$ref": "#/definitions/prosecution_case_relationship"
+         },
+         "defendant_judicial_results": {
+           "$ref": "#/definitions/defendant_judicial_result_relationship"
+         },
          "cracked_ineffective_trial": {
            "$ref": "#/definitions/cracked_ineffective_trial_relationship"
          }
@@ -119,6 +125,50 @@
         },
         "type": {
           "$ref": "court_application.json#/definitions/type"
+        }
+      }
+    },
+    "prosecution_case_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/prosecution_case"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "prosecution_case": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "prosecution_case.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "prosecution_case.json#/definitions/type"
+        }
+      }
+    },
+    "defendant_judicial_result_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/defendant_judicial_result"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "defendant_judicial_result": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "defendant_judicial_result.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "defendant_judicial_result.json#/definitions/type"
         }
       }
     },
@@ -181,6 +231,12 @@
                 "$ref": "court_application.json#/definitions/resource"
               },
               {
+                "$ref": "prosecution_case.json#/definitions/resource"
+              },
+              {
+                "$ref": "defendant_judicial_result.json#/definitions/resource"
+              },
+              {
                 "$ref": "cracked_ineffective_trial.json#/definitions/resource"
               }
             ]
@@ -195,7 +251,7 @@
     "example_included_query_parameters": {
       "description": "An example of parameters that can be included in the query",
       "type": "string",
-      "example": "providers,court_applications,cracked_ineffective_trial,court_applications.judicial_results"
+      "example": "providers,court_applications, prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results"
     },
     "attributes": {
       "type": "object",

--- a/swagger/v2/offence.json
+++ b/swagger/v2/offence.json
@@ -202,6 +202,59 @@
           "$ref": "#/definitions/verdict"
         }
       }
+    },
+    "relationships": {
+      "type": "object",
+      "properties": {
+        "judicial_results": {
+          "$ref": "#/definitions/judicial_result_relationship"
+        }
+      }
+    },
+    "judicial_result_relationship": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/judicial_result"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "judicial_result": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "judicial_result.json#/definitions/id"
+        },
+        "type": {
+          "$ref": "judicial_result.json#/definitions/included_type"
+        }
+      }
+    },
+    "resource_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/resource"
+        },
+        "included": {
+          "items": {
+            "anyOf":[
+              {
+                "$ref": "judicial_result.json#/definitions/resource"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      }
+    },
+    "example_included_query_parameters": {
+      "description": "An example of parameters that can be included in the query",
+      "type": "string",
+      "example": "judicial_results"
     }
   },
   "links": [

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -150,7 +150,7 @@ paths:
           Include top-level and nested associations for a hearing.
                                               All top-level and nested associations available for inclusion are listed under the relationships keys of the response body.
                                               For example to include providers, cracked ineffective trial as well as court applications and associated judicial results:
-                                              include=providers,court_applications,cracked_ineffective_trial,court_applications.judicial_results
+                                              include=providers,court_applications,prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results
       - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '200':


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-747)

VCD wants to display sentencing details on the hearing page. These show up as part of judicial results in 3 place:

1. Hearing>defendantJudicialResults
2. Hearing>ProsecutionCase>Defendant>judicialResults
3. Hearing>ProsecutionCase>Defendant>Offence>judicialResults

This PR serializes the data to expose judicial results on the hearings endpoint for v1 and v2 in all these places. Updates swagger documentation for v1 and v2 to reflect this. 

Broken into commits for ease of review

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
