### PR TITLE
Accept nil values for rep order optional fields

### DIFF
--- a/app/contracts/new_representation_order_contract.rb
+++ b/app/contracts/new_representation_order_contract.rb
@@ -13,34 +13,34 @@ class NewRepresentationOrderContract < Dry::Validation::Contract
         required(:name).filled(:string)
         optional(:address).hash do
           required(:address1).filled(:string)
-          optional(:address2).filled(:string)
-          optional(:address3).filled(:string)
-          optional(:address4).filled(:string)
-          optional(:address5).filled(:string)
-          optional(:postcode).filled(:string)
+          optional(:address2).maybe(:string)
+          optional(:address3).maybe(:string)
+          optional(:address4).maybe(:string)
+          optional(:address5).maybe(:string)
+          optional(:postcode).maybe(:string)
         end
         optional(:contact).hash do
-          optional(:home).filled(:string)
-          optional(:work).filled(:string)
-          optional(:mobile).filled(:string)
-          optional(:primary_email).filled(:string)
-          optional(:secondary_email).filled(:string)
-          optional(:fax).filled(:string)
+          optional(:home).maybe(:string)
+          optional(:work).maybe(:string)
+          optional(:mobile).maybe(:string)
+          optional(:primary_email).maybe(:string)
+          optional(:secondary_email).maybe(:string)
+          optional(:fax).maybe(:string)
         end
       end
       required(:laa_contract_number).filled(:string)
-      optional(:sra_number).filled(:string)
-      optional(:bar_council_membership_number).filled(:string)
-      optional(:incorporation_number).filled(:string)
-      optional(:registered_charity_number).filled(:string)
+      optional(:sra_number).maybe(:string)
+      optional(:bar_council_membership_number).maybe(:string)
+      optional(:incorporation_number).maybe(:string)
+      optional(:registered_charity_number).maybe(:string)
     end
     required(:defendant_id).value(:string)
     required(:offences).array(:hash) do
       required(:offence_id).value(:string)
       required(:status_code).value(:string)
-      optional(:status_date).value(:date)
-      optional(:effective_start_date).value(:date)
-      optional(:effective_end_date).value(:date)
+      optional(:status_date).maybe(:date)
+      optional(:effective_start_date).maybe(:date)
+      optional(:effective_end_date).maybe(:date)
     end
   end
 

--- a/spec/contracts/new_representation_order_contract_spec.rb
+++ b/spec/contracts/new_representation_order_contract_spec.rb
@@ -168,9 +168,36 @@ RSpec.describe NewRepresentationOrderContract do
     it { is_expected.to be_a_success }
   end
 
-  context "with unexpected keys" do
-    before { defence_organisation[:organisation][:contact][:additional_info] = "Hello" }
+  context "with nil values on optional keys" do
+    let(:defence_organisation) do
+      {
+        laa_contract_number: "CONTRACT REFERENCE",
+        sra_number: nil,
+        bar_council_membership_number: nil,
+        incorporation_number: nil,
+        registered_charity_number: nil,
+        organisation: {
+          name: "SOME ORGANISATION",
+          address: {
+            address1: "String",
+            address2: nil,
+            address3: nil,
+            address4: nil,
+            address5: nil,
+            postcode: nil,
+          },
+          contact: {
+            home: nil,
+            work: nil,
+            mobile: nil,
+            primary_email: nil,
+            secondary_email: nil,
+            fax: nil,
+          },
+        },
+      }
+    end
 
-    it { is_expected.not_to be_a_success }
+    it { is_expected.to be_a_success }
   end
 end


### PR DESCRIPTION
## What

Accept `null` values for rep order optional fields.

## Why

MAAT API has started sending `nil` values to CDA in its rep order payloads, which resulted in contract validation failures ([Sentry](https://sentry.io/organizations/ministryofjustice/issues/2308421656/events/?environment=prod&project=5375870)).

This PR makes string values optional for the optional fields on the incoming rep order payload.