### PR TITLE
Enforce stricter encryption rules in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,0 @@
-# git-crypt kubernetes secrets
-helm_deploy/**/**/values-*.yaml filter=git-crypt diff=git-crypt
-# client certificate
-helm_deploy/**/**/client.crt filter=git-crypt diff=git-crypt
-# client certificate key
-helm_deploy/**/**/client.key filter=git-crypt diff=git-crypt
-# CA certificate
-helm_deploy/**/**/ca.crt filter=git-crypt diff=git-crypt

--- a/helm_deploy/laa-court-data-adaptor/.gitattributes
+++ b/helm_deploy/laa-court-data-adaptor/.gitattributes
@@ -1,0 +1,24 @@
+# TIP: to check file encryption status the repo, run git-crypt status.
+
+# Documentation: https://github.com/AGWA/git-crypt#gitattributes-file
+
+### ENCRYPT ###
+
+# encrypt all .yaml files in current and subdirectories
+*.yaml filter=git-crypt diff=git-crypt
+
+# encrypt all .yml files in current and subdirectories
+*.yml filter=git-crypt diff=git-crypt
+
+# encrypt all .key files in current and subdirectories
+*.key filter=git-crypt diff=git-crypt
+
+# encrypt all .crt files in current and subdirectories
+*.crt filter=git-crypt diff=git-crypt
+
+### DO NOT ENCRYPT ###
+
+.gitattributes !filter !diff
+.helmignore !filter !diff
+Chart.yaml !filter !diff
+templates/** !filter !diff


### PR DESCRIPTION
With the current rules, we list the files we want to encrypt,
according to their exact paths. This makes it too easy to accidentally
commit unencrypted files, e.g. by simply moving a file to another folder,
or renaming it.

This PR makes sure our inclusion rules are much broader, and exclusion rules
are narrow or downright specific.

```
$ git-crypt status | grep helm_deploy
not encrypted: helm_deploy/laa-court-data-adaptor/.gitattributes
not encrypted: helm_deploy/laa-court-data-adaptor/.helmignore
not encrypted: helm_deploy/laa-court-data-adaptor/Chart.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/NOTES.txt
not encrypted: helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
not encrypted: helm_deploy/laa-court-data-adaptor/templates/_helpers.tpl
not encrypted: helm_deploy/laa-court-data-adaptor/templates/ca-secret.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/deployment-api.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/deployment-metrics.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/deployment-worker.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/hpa.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/ingress-external.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/ingress.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/network-policy.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/service.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/serviceaccount.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/tests/test-connection.yaml
not encrypted: helm_deploy/laa-court-data-adaptor/templates/webhook-secret.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/dev-live/values-dev-live.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/dev/values-dev.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/prod/ca.crt
    encrypted: helm_deploy/laa-court-data-adaptor/prod/client.crt
    encrypted: helm_deploy/laa-court-data-adaptor/prod/client.key
    encrypted: helm_deploy/laa-court-data-adaptor/prod/values-prod.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/stage/values-stage.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/test/values-test.yaml
    encrypted: helm_deploy/laa-court-data-adaptor/uat/client.crt
    encrypted: helm_deploy/laa-court-data-adaptor/uat/client.key
    encrypted: helm_deploy/laa-court-data-adaptor/uat/values-uat.yaml
```