### PR TITLE
add sitting_day param to hearing request made to Common Platform

### DIFF
--- a/app/controllers/api/internal/v1/hearing_results_controller.rb
+++ b/app/controllers/api/internal/v1/hearing_results_controller.rb
@@ -5,20 +5,30 @@ module Api
     module V1
       class HearingResultsController < ApplicationController
         def show
-          @hearing = CommonPlatform::Api::GetHearingResults.call(hearing_id: params[:id])
+          @hearing = CommonPlatform::Api::GetHearingResults.call(
+            hearing_id: permitted_params[:id],
+            sitting_day: permitted_params[:sitting_day],
+          )
+
           render json: HearingSerializer.new(@hearing, serialization_options)
         end
 
       private
 
         def serialization_options
-          return { include: inclusions } if inclusions.present?
-
-          {}
+          { include: inclusions }.compact
         end
 
         def inclusions
-          params[:include]&.split(",")
+          permitted_params[:include]&.split(",")
+        end
+
+        def permitted_params
+          params.permit(
+            :id,
+            :sitting_day,
+            :include,
+          )
         end
       end
     end

--- a/app/controllers/api/internal/v2/hearing_results_controller.rb
+++ b/app/controllers/api/internal/v2/hearing_results_controller.rb
@@ -5,13 +5,26 @@ module Api
     module V2
       class HearingResultsController < ApplicationController
         def show
-          hearing_result = CommonPlatform::Api::GetHearingResults.call(hearing_id: params[:hearing_id])
+          hearing_result = CommonPlatform::Api::GetHearingResults.call(
+            hearing_id: permitted_params[:hearing_id],
+            sitting_day: permitted_params[:sitting_day],
+          )
 
           if hearing_result.present?
-            render json: HmctsCommonPlatform::HearingResulted.new(hearing_result&.body).to_json, status: :ok
+            render json: HmctsCommonPlatform::HearingResulted.new(hearing_result&.body).to_json,
+                   status: :ok
           else
             render json: {}, status: :not_found
           end
+        end
+
+      private
+
+        def permitted_params
+          params.permit(
+            :hearing_id,
+            :sitting_day,
+          )
         end
       end
     end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -59,8 +59,15 @@ private
   end
 
   def hearing_results
-    @hearing_results ||= hearing_summary_ids.map { |hearing_id|
-      CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id)
+    @hearing_results ||= hearing_summaries.flat_map { |hearing_summary|
+      hearing_summary.hearing_days.map do |hearing_day|
+        next unless hearing_day.has_shared_results
+
+        CommonPlatform::Api::GetHearingResults.call(
+          hearing_id: hearing_summary.id,
+          sitting_day: hearing_day.sitting_day,
+        )
+      end
     }.compact
   end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -60,9 +60,7 @@ private
 
   def hearing_results
     @hearing_results ||= hearing_summaries.flat_map { |hearing_summary|
-      hearing_summary.hearing_days.map do |hearing_day|
-        next unless hearing_day.has_shared_results
-
+      hearing_summary.hearing_days.select(&:has_shared_results).map do |hearing_day|
         CommonPlatform::Api::GetHearingResults.call(
           hearing_id: hearing_summary.id,
           sitting_day: hearing_day.sitting_day,

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -60,7 +60,7 @@ private
 
   def hearing_results
     @hearing_results ||= hearing_summaries.flat_map { |hearing_summary|
-      hearing_summary.hearing_days.select(&:has_shared_results).map do |hearing_day|
+      hearing_summary.hearing_days.map do |hearing_day|
         CommonPlatform::Api::GetHearingResults.call(
           hearing_id: hearing_summary.id,
           sitting_day: hearing_day.sitting_day,

--- a/app/services/common_platform/api/get_hearing_results.rb
+++ b/app/services/common_platform/api/get_hearing_results.rb
@@ -3,10 +3,10 @@
 module CommonPlatform
   module Api
     class GetHearingResults < ApplicationService
-      def initialize(hearing_id:, publish_to_queue: false)
+      def initialize(hearing_id:, sitting_day: nil, publish_to_queue: false)
         @hearing_id = hearing_id
         @publish_to_queue = publish_to_queue
-        @response = HearingFetcher.call(hearing_id: hearing_id)
+        @response = HearingFetcher.call(hearing_id: hearing_id, sitting_day: sitting_day)
       end
 
       def call

--- a/app/services/common_platform/api/hearing_fetcher.rb
+++ b/app/services/common_platform/api/hearing_fetcher.rb
@@ -5,8 +5,8 @@ module CommonPlatform
     class HearingFetcher < ApplicationService
       URL = "hearing/results"
 
-      def initialize(hearing_id:, connection: CommonPlatform::Connection.call)
-        @params = { hearingId: hearing_id }
+      def initialize(hearing_id:, sitting_day:, connection: CommonPlatform::Connection.call)
+        @params = { hearingId: hearing_id, sittingDay: sitting_day }.compact
         @connection = connection
       end
 

--- a/app/services/common_platform/api/hearing_fetcher.rb
+++ b/app/services/common_platform/api/hearing_fetcher.rb
@@ -6,7 +6,7 @@ module CommonPlatform
       URL = "hearing/results"
 
       def initialize(hearing_id:, sitting_day:, connection: CommonPlatform::Connection.call)
-        @params = { hearingId: hearing_id, sittingDay: sitting_day }.compact
+        @params = { hearingId: hearing_id, sittingDay: sitting_day }.reject { |_k, v| v.blank? }
         @connection = connection
       end
 

--- a/spec/cassettes/hearing_result_fetcher/success_specified_sitting_day.yml
+++ b/spec/cassettes/hearing_result_fetcher/success_specified_sitting_day.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/hearing/results?hearingId=4d01840d-5959-4539-a450-d39f57171037&sittingDay=2021-05-21"
+    uri: "<COMMON_PLATFORM_URL>/hearing/results?hearingId=4d01840d-5959-4539-a450-d39f57171036&sittingDay=2020-08-17"
     body:
       encoding: US-ASCII
       string: ''
@@ -28,7 +28,7 @@ http_interactions:
       - SAMEORIGIN
     body:
       encoding: UTF-8
-      string: "{\r\n  \"hearing\": {\r\n    \"id\": \"4d01840d-5959-4539-a450-d39f57171037\",\r\n
+      string: "{\r\n  \"hearing\": {\r\n    \"id\": \"4d01840d-5959-4539-a450-d39f57171036\",\r\n
         \   \"jurisdictionType\": \"MAGISTRATES\",\r\n    \"courtCentre\": {\r\n      \"address\":
         {\r\n        \"address1\": \"176A Lavender Hill\",\r\n        \"address2\":
         \"London\",\r\n        \"address3\": \"\",\r\n        \"address4\": \"\",\r\n
@@ -39,7 +39,7 @@ http_interactions:
         Hill Magistrates' Court\",\r\n      \"roomId\": \"9e4932f7-97b2-3010-b942-ddd2624e4dd8\",\r\n
         \     \"roomName\": \"Courtroom 01\"\r\n    },\r\n    \"hearingDays\": [\r\n
         \     {\r\n        \"listedDurationMinutes\": 20,\r\n        \"listingSequence\":
-        0,\r\n        \"sittingDay\": \"2021-05-21T09:01:01.001Z\"\r\n      }\r\n
+        0,\r\n        \"sittingDay\": \"2020-08-17T09:01:01.001Z\"\r\n      }\r\n
         \   ],\r\n    \"type\": {\r\n      \"description\": \"First hearing\",\r\n
         \     \"id\": \"4a0e892d-c0c5-3c51-95b8-704d8c781776\"\r\n    },\r\n    \"hearingLanguage\":
         \"ENGLISH\",\r\n    \"prosecutionCases\": [\r\n      {\r\n        \"id\":

--- a/spec/cassettes/hearing_result_fetcher/success_specified_sitting_day.yml
+++ b/spec/cassettes/hearing_result_fetcher/success_specified_sitting_day.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/hearing/results?hearingId=4d01840d-5959-4539-a450-d39f57171037&sittingDay=2021-05-21"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v1.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      transfer-encoding:
+      - chunked
+      content-type:
+      - text/plain; charset=utf-8
+      request-context:
+      - appId=cid-v1:e7545c86-6eab-4a30-bf6d-7ed8b5691e3f
+      date:
+      - Fri, 04 Sep 2020 11:01:36 GMT
+      x-frame-options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"hearing\": {\r\n    \"id\": \"4d01840d-5959-4539-a450-d39f57171037\",\r\n
+        \   \"jurisdictionType\": \"MAGISTRATES\",\r\n    \"courtCentre\": {\r\n      \"address\":
+        {\r\n        \"address1\": \"176A Lavender Hill\",\r\n        \"address2\":
+        \"London\",\r\n        \"address3\": \"\",\r\n        \"address4\": \"\",\r\n
+        \       \"address5\": \"\",\r\n        \"postcode\": \"SW11 1JU\"\r\n      },\r\n
+        \     \"code\": \"B01LY00\",\r\n      \"id\": \"f8254db1-1683-483e-afb3-b87fde5a0a26\",\r\n
+        \     \"lja\": {\r\n        \"ljaCode\": \"2577\",\r\n        \"ljaName\":
+        \"South West London Magistrates' Court\"\r\n      },\r\n      \"name\": \"Lavender
+        Hill Magistrates' Court\",\r\n      \"roomId\": \"9e4932f7-97b2-3010-b942-ddd2624e4dd8\",\r\n
+        \     \"roomName\": \"Courtroom 01\"\r\n    },\r\n    \"hearingDays\": [\r\n
+        \     {\r\n        \"listedDurationMinutes\": 20,\r\n        \"listingSequence\":
+        0,\r\n        \"sittingDay\": \"2021-05-21T09:01:01.001Z\"\r\n      }\r\n
+        \   ],\r\n    \"type\": {\r\n      \"description\": \"First hearing\",\r\n
+        \     \"id\": \"4a0e892d-c0c5-3c51-95b8-704d8c781776\"\r\n    },\r\n    \"hearingLanguage\":
+        \"ENGLISH\",\r\n    \"prosecutionCases\": [\r\n      {\r\n        \"id\":
+        \"0895325e-b6a2-4eb2-8544-500bed1e57a0\",\r\n        \"prosecutionCaseIdentifier\":
+        {\r\n          \"majorCreditorCode\": \"PF45\",\r\n          \"prosecutionAuthorityCode\":
+        \"SURRPF\",\r\n          \"prosecutionAuthorityId\": \"764bff92-a135-34cb-b858-8bb6b4b66301\",\r\n
+        \         \"prosecutionAuthorityName\": \"Surrey Police\",\r\n          \"prosecutionAuthorityOUCode\":
+        \"0450000\",\r\n          \"caseURN\": \"90GD9123LAA\"\r\n        },\r\n        \"initiationCode\":
+        \"C\",\r\n        \"defendants\": [\r\n          {\r\n            \"id\":
+        \"93908d1c-2cca-4c26-a068-d0bb8d3f8332\",\r\n            \"prosecutionCaseId\":
+        \"0895325e-b6a2-4eb2-8544-500bed1e57a0\",\r\n            \"offences\": [\r\n
+        \             {\r\n                \"id\": \"7c9c2f4f-f917-4f1a-a2e8-e665127e6ba3\",\r\n
+        \               \"offenceDefinitionId\": \"9c225a5d-e7e1-447f-bb1b-62c265b662ed\",\r\n
+        \               \"offenceCode\": \"AA06007\",\r\n                \"offenceTitle\":
+        \"Operate an unapproved quarantine centre / facility for captive birds\",\r\n
+        \               \"wording\": \"Has a violent past and fear that he will commit
+        further offences and\\n                interfere with witnesse\",\r\n                \"startDate\":
+        \"2020-02-09\",\r\n                \"offenceLegislation\": \"Contrary to regulations
+        19(1) & 34(4) of the Animals and Animal Products (Import and Export) (England)
+        Regulations 2006\",\r\n                \"modeOfTrial\": \"Either Way\",\r\n
+        \               \"arrestDate\": \"2020-02-09\",\r\n                \"chargeDate\":
+        \"2020-02-09\",\r\n                \"orderIndex\": 2,\r\n                \"count\":
+        0,\r\n                \"judicialResults\": [\r\n                  {\r\n                    \"alwaysPublished\":
+        false,\r\n                    \"category\": \"FINAL\",\r\n                    \"cjsCode\":
+        \"1017\",\r\n                    \"courtClerk\": {\r\n                      \"firstName\":
+        \"Erica\",\r\n                      \"lastName\": \"Wilson\",\r\n                      \"userId\":
+        \"31ec3a16-8721-498c-8da5-f099390ee254\"\r\n                    },\r\n                    \"d20\":
+        false,\r\n                    \"excludedFromResults\": false,\r\n                    \"isAdjournmentResult\":
+        false,\r\n                    \"isAvailableForCourtExtract\": true,\r\n                    \"isConvictedResult\":
+        true,\r\n                    \"isDeleted\": false,\r\n                    \"isFinancialResult\":
+        false,\r\n                    \"isUnscheduled\": false,\r\n                    \"judicialResultId\":
+        \"ad6ea38f-bf6c-42e1-8a3e-9d3d5dcc68bf\",\r\n                    \"judicialResultTypeId\":
+        \"b9c6047b-fb84-4b12-97a1-2175e4b8bbac\",\r\n                    \"label\":
+        \"Absolute discharge\",\r\n                    \"lastSharedDateTime\": \"2020-08-17\",\r\n
+        \                   \"lifeDuration\": false,\r\n                    \"orderedDate\":
+        \"2020-08-17\",\r\n                    \"orderedHearingId\": \"4d01840d-5959-4539-a450-d39f57171036\",\r\n
+        \                   \"postHearingCustodyStatus\": \"A\",\r\n                    \"publishedAsAPrompt\":
+        false,\r\n                    \"publishedForNows\": false,\r\n                    \"rank\":
+        13300,\r\n                    \"resultText\": \"Absolute discharge\\n\",\r\n
+        \                   \"rollUpPrompts\": true,\r\n                    \"terminatesOffenceProceedings\":
+        false,\r\n                    \"urgent\": false,\r\n                    \"usergroups\":
+        [],\r\n                    \"welshLabel\": \"Rhyddhad diamod\"\r\n                  }\r\n
+        \               ]\r\n              }\r\n            ],\r\n            \"prosecutionAuthorityReference\":
+        \"TFL\",\r\n            \"personDefendant\": {\r\n              \"arrestSummonsNumber\":
+        \"TFL\",\r\n              \"bailConditions\": \"\",\r\n              \"bailStatus\":
+        {\r\n                \"code\": \"A\",\r\n                \"description\":
+        \"Not applicable\",\r\n                \"id\": \"86009c70-759d-3308-8de4-194886ff9a77\"\r\n
+        \             },\r\n              \"personDetails\": {\r\n                \"address\":
+        {\r\n                  \"address1\": \"1234\",\r\n                  \"address2\":
+        \"StreetDescription\",\r\n                  \"address3\": \"Locality2O\"\r\n
+        \               },\r\n                \"dateOfBirth\": \"1990-01-01\",\r\n
+        \               \"documentationLanguageNeeds\": \"ENGLISH\",\r\n                \"firstName\":
+        \"Kole\",\r\n                \"gender\": \"MALE\",\r\n                \"lastName\":
+        \"Jaskolski\",\r\n                \"title\": \"Mr\"\r\n              }\r\n
+        \           }\r\n          }\r\n        ],\r\n        \"originatingOrganisation\":
+        \"0450000\"\r\n      }\r\n    ],\r\n    \"hasSharedResults\": true\r\n  },\r\n
+        \ \"sharedTime\": \"2020-08-17T13:17:16.544Z\"\r\n}"
+  recorded_at: Fri, 04 Sep 2020 11:01:36 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success.yml
@@ -54,10 +54,69 @@ http_interactions:
         refuse give assistance to person executing Communications Act search warrant","offenceLegislation":"Contrary
         to section 366(8)(b) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
-        hearing"},"estimatedDuration":"20","courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
-        Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
-        01"}}]}]}'
+        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[
+          {
+            "hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b",
+            "jurisdictionType":"MAGISTRATES",
+            "defendantIds":[
+              "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+              "b70a36e5-13d3-4bb3-bb24-94db79b7708b"
+              ],
+            "hearingDays":[
+              {
+                "sittingDay":"2020-05-07T09:01:01.001Z",
+                "listingSequence":0,
+                "listedDurationMinutes":20,
+                "hasSharedResults": true
+              }
+            ],
+            "hearingType":{
+              "id":"4a0e892d-c0c5-3c51-95b8-704d8c781776",
+              "description":"First hearing"
+            },
+            "courtCentre":{
+              "id":"f8254db1-1683-483e-afb3-b87fde5a0a26",
+              "name":"Lavender Hill Magistrates'' Court",
+              "roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8",
+              "roomName":"Courtroom 01"
+            }
+          },
+          {
+            "hearingId":"311bb2df-4df5-4abe-bae3-82f144e1e5c5",
+            "jurisdictionType":"MAGISTRATES",
+            "defendantIds":[
+              "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+              "b70a36e5-13d3-4bb3-bb24-94db79b7708b"
+              ],
+            "hearingDays":[
+              {
+                "sittingDay":"2020-05-15T09:01:01.001Z",
+                "listingSequence":0,
+                "listedDurationMinutes":20,
+                "hasSharedResults": true
+              },
+              {
+                "sittingDay":"2020-05-16T09:01:01.001Z",
+                "listingSequence":0,
+                "listedDurationMinutes":20,
+                "hasSharedResults": true
+              }
+            ],
+            "hearingType":{
+              "id":"4a0e892d-c0c5-3c51-95b8-704d8c781776",
+              "description":"First hearing"
+            },
+            "courtCentre":{
+              "id":"f8254db1-1683-483e-afb3-b87fde5a0a26",
+              "name":"Lavender Hill Magistrates'' Court",
+              "roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8",
+              "roomName":"Courtroom 01"
+            }
+          }
+        ]
+      }
+    ]
+  }'
   recorded_at: Mon, 09 Nov 2020 17:51:50 GMT
 - request:
     method: get
@@ -113,7 +172,7 @@ http_interactions:
         refuse give assistance to person executing Communications Act search warrant","offenceLegislation":"Contrary
         to section 366(8)(b) and    (9) of the Communications Act 2003.","proceedingsConcluded":false,"arrestDate":"2006-05-04","endDate":"2005-05-05","startDate":"1996-05-04","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":500,"wording":"Has
         a violent past and fear that he will commit further offences and\n                interfere
-        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
+        with witnesse","laaApplnReference":{}}]}],"hearingSummary":[{"hearingId":"e8d88eaa-e73f-4b59-8148-d0cfbbd3520b","jurisdictionType":"MAGISTRATES","defendantIds":["c6cf04b5-901d-4a89-a9ab-767eb57306e4","b70a36e5-13d3-4bb3-bb24-94db79b7708b"],"hearingDays":[{"sittingDay":"2020-05-07T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20,"hasSharedResults": true}],"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
         hearing"},"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
         Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
         01"}}]}]}'

--- a/spec/fixtures/files/prosecution_case_search_result.json
+++ b/spec/fixtures/files/prosecution_case_search_result.json
@@ -55,7 +55,8 @@
             {
               "sittingDay": "2020-02-17T15:00:00Z",
               "listingSequence": 0,
-              "listedDurationMinutes": 20
+              "listedDurationMinutes": 20,
+              "hasSharedResults": true
             }
           ],
           "hearingType": {
@@ -80,7 +81,8 @@
             {
               "sittingDay": "2020-08-04T08:00:00Z",
               "listingSequence": 2,
-              "listedDurationMinutes": 30
+              "listedDurationMinutes": 30,
+              "hasSharedResults": true
             }
           ],
           "courtCentre": {
@@ -104,7 +106,8 @@
             {
               "sittingDay": "2020-09-05T08:00:00Z",
               "listingSequence": 1,
-              "listedDurationMinutes": 720
+              "listedDurationMinutes": 720,
+              "hasSharedResults": true
             }
           ],
           "courtCentre": {

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
       let(:hearing) do
         VCR.use_cassette("hearing_result_fetcher/success") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id, sitting_day: nil)
         end
       end
 
@@ -36,11 +36,9 @@ RSpec.describe Hearing, type: :model do
       it { expect(hearing.prosecution_cases).to all(be_an(HmctsCommonPlatform::ProsecutionCase)) }
 
       context "with hearing events" do
-        let(:hearing_day) { "2020-08-17" }
-
         let(:hearing_event_recording) do
           VCR.use_cassette("hearing_logs_fetcher/success") do
-            CommonPlatform::Api::GetHearingEvents.call(hearing_id: hearing_id, hearing_date: hearing_day)
+            CommonPlatform::Api::GetHearingEvents.call(hearing_id: hearing_id, hearing_date: "2020-08-17")
           end
         end
 
@@ -71,7 +69,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "29b73d8f-7683-4e27-9069-f7a031672c35" }
       let(:hearing) do
         VCR.use_cassette("hearing_result_fetcher/success_hearing_attendees") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id, sitting_day: nil)
         end
       end
 
@@ -105,7 +103,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "da124701-048f-408c-85b4-81138316ddce" }
       let(:hearing) do
         VCR.use_cassette("hearing_result_fetcher/success_hearing_cracked_trial") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id: hearing_id, sitting_day: nil)
         end
       end
 

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ProsecutionCase, type: :model do
   let(:hearing_one) do
-    Hearing.create(
+    Hearing.new(
       body: {
         "hearing" => {
           "id" => "HWLLOOEOEO",
@@ -24,7 +24,7 @@ RSpec.describe ProsecutionCase, type: :model do
   end
 
   let(:hearing_two_day_one) do
-    Hearing.create(
+    Hearing.new(
       body: {
         "hearing" => {
           "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b",
@@ -54,7 +54,7 @@ RSpec.describe ProsecutionCase, type: :model do
   end
 
   let(:hearing_two_day_two) do
-    Hearing.create(
+    Hearing.new(
       body: {
         "hearing" => {
           "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b",
@@ -94,7 +94,7 @@ RSpec.describe ProsecutionCase, type: :model do
       end
     end
 
-    let(:prosecution_case) { described_class.create(id: prosecution_case_id, body: prosecution_case_result.body["cases"][0]) }
+    let(:prosecution_case) { described_class.new(id: prosecution_case_id, body: prosecution_case_result.body["cases"][0]) }
     let(:prosecution_case_id) { "31cbe62d-b1ec-4e82-89f7-99dced834900" }
 
     describe "#prosecution_case_reference" do
@@ -186,9 +186,9 @@ RSpec.describe ProsecutionCase, type: :model do
           end
 
           context "with no prosecution_case reference" do
-            let(:hearing_one)         { Hearing.create(body: { "hearing" => { "id" => "311bb2df-4df5-4abe-bae3-82f144e1e5c5" } }) }
-            let(:hearing_two_day_one) { Hearing.create(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
-            let(:hearing_two_day_two) { Hearing.create(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
+            let(:hearing_one)         { Hearing.new(body: { "hearing" => { "id" => "311bb2df-4df5-4abe-bae3-82f144e1e5c5" } }) }
+            let(:hearing_two_day_one) { Hearing.new(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
+            let(:hearing_two_day_two) { Hearing.new(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
 
             it "initialises Defendants without details" do
               expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -3,10 +3,9 @@
 RSpec.describe ProsecutionCase, type: :model do
   let(:hearing_one) do
     Hearing.create(
-      id: hearing_ids[0],
       body: {
         "hearing" => {
-          "id" => hearing_ids[0],
+          "id" => "HWLLOOEOEO",
           "prosecutionCases" => [{
             "id" => "31cbe62d-b1ec-4e82-89f7-99dced834900",
             "defendants" => [{
@@ -24,13 +23,11 @@ RSpec.describe ProsecutionCase, type: :model do
     )
   end
 
-  let(:hearing_two) do
+  let(:hearing_two_day_one) do
     Hearing.create(
-      id: hearing_ids[1],
       body: {
-
         "hearing" => {
-          "id" => hearing_ids[1],
+          "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b",
           "prosecutionCases" => [{
             "id" => "31cbe62d-b1ec-4e82-89f7-99dced834900",
             "defendants" => [{
@@ -46,6 +43,36 @@ RSpec.describe ProsecutionCase, type: :model do
                                "offences": [
                                  {
                                    "id": "offence-three-id",
+                                 },
+                               ],
+                             }],
+          }],
+        },
+        "sharedTime" => "2020-10-20",
+      },
+    )
+  end
+
+  let(:hearing_two_day_two) do
+    Hearing.create(
+      body: {
+        "hearing" => {
+          "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b",
+          "prosecutionCases" => [{
+            "id" => "31cbe62d-b1ec-4e82-89f7-99dced834900",
+            "defendants" => [{
+              "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+              "offences": [
+                {
+                  "id": "offence-four-id",
+                },
+              ],
+            },
+                             {
+                               "id" => "b70a36e5-13d3-4bb3-bb24-94db79b7708b",
+                               "offences": [
+                                 {
+                                   "id": "offence-five-id",
                                  },
                                ],
                              }],
@@ -88,18 +115,18 @@ RSpec.describe ProsecutionCase, type: :model do
     end
 
     context "when requesting hearing resulted" do
-      let(:hearing_ids) { %w[311bb2df-4df5-4abe-bae3-82f144e1e5c5 e8d88eaa-e73f-4b59-8148-d0cfbbd3520b] }
-
       before do
-        allow(prosecution_case).to receive(:hearing_summary_ids).and_return(hearing_ids)
-        allow(CommonPlatform::Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_ids[0]).and_return(hearing_one)
-        allow(CommonPlatform::Api::GetHearingResults).to receive(:call).with(hearing_id: hearing_ids[1]).and_return(hearing_two)
-      end
+        allow(CommonPlatform::Api::GetHearingResults).to receive(:call)
+          .with(hearing_id: "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b", sitting_day: "2020-05-07T09:01:01.001Z")
+          .and_return(hearing_one)
 
-      describe "#hearing_ids" do
-        subject { prosecution_case.hearing_ids }
+        allow(CommonPlatform::Api::GetHearingResults).to receive(:call)
+          .with(hearing_id: "311bb2df-4df5-4abe-bae3-82f144e1e5c5", sitting_day: "2020-05-15T09:01:01.001Z")
+          .and_return(hearing_two_day_one)
 
-        it { is_expected.to eq(hearing_ids) }
+        allow(CommonPlatform::Api::GetHearingResults).to receive(:call)
+          .with(hearing_id: "311bb2df-4df5-4abe-bae3-82f144e1e5c5", sitting_day: "2020-05-16T09:01:01.001Z")
+          .and_return(hearing_two_day_two)
       end
 
       describe "#hearings" do
@@ -113,41 +140,55 @@ RSpec.describe ProsecutionCase, type: :model do
 
         context "when a hearing has not resulted" do
           let(:hearing_one) { nil }
-          let(:hearing_two) { nil }
+          let(:hearing_two_day_one) { nil }
+          let(:hearing_two_day_two) { nil }
 
           it { is_expected.to be_empty }
         end
 
         context "when hearings are loaded" do
           let(:defendant_one_details) do
-            [{
-              "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
-              "offences" => [{ "id" => "offence-one-id" }],
-            },
-             {
-               "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
-               "offences" => [{ "id" => "offence-two-id" }],
-             }]
+            [
+              {
+                "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+                "offences" => [{ "id" => "offence-one-id" }],
+              },
+              {
+                "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+                "offences" => [{ "id" => "offence-two-id" }],
+              },
+              {
+                "id" => "c6cf04b5-901d-4a89-a9ab-767eb57306e4",
+                "offences" => [{ "id" => "offence-four-id" }],
+              },
+            ]
           end
 
           let(:defendant_two_details) do
-            [{
-              "id" => "b70a36e5-13d3-4bb3-bb24-94db79b7708b",
-              "offences" => [{ "id" => "offence-three-id" }],
-            }]
+            [
+              {
+                "id" => "b70a36e5-13d3-4bb3-bb24-94db79b7708b",
+                "offences" => [{ "id" => "offence-three-id" }],
+              },
+              {
+                "id" => "b70a36e5-13d3-4bb3-bb24-94db79b7708b",
+                "offences" => [{ "id" => "offence-five-id" }],
+              },
+            ]
           end
 
           before { prosecution_case.hearings }
 
-          it "initialises Defendants with detail fetched from hearing" do
+          it "initialises Defendants with detail fetched from hearings" do
             expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: defendant_one_details, prosecution_case_id: prosecution_case_id).once
             expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: defendant_two_details, prosecution_case_id: prosecution_case_id).once
             prosecution_case.defendants
           end
 
           context "with no prosecution_case reference" do
-            let(:hearing_one) { Hearing.create(id: hearing_ids[0], body: { "hearing" => { "id" => hearing_ids[0] } }) }
-            let(:hearing_two) { Hearing.create(id: hearing_ids[1], body: { "hearing" => { "id" => hearing_ids[1] } }) }
+            let(:hearing_one)         { Hearing.create(body: { "hearing" => { "id" => "311bb2df-4df5-4abe-bae3-82f144e1e5c5" } }) }
+            let(:hearing_two_day_one) { Hearing.create(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
+            let(:hearing_two_day_two) { Hearing.create(body: { "hearing" => { "id" => "e8d88eaa-e73f-4b59-8148-d0cfbbd3520b" } }) }
 
             it "initialises Defendants without details" do
               expect(Defendant).to receive(:new).with(body: an_instance_of(Hash), details: nil, prosecution_case_id: prosecution_case_id).twice

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe "Api::Internal::V1::Defendants", type: :request, swagger_doc: "v1
     }
   end
 
+  before do
+    allow(CommonPlatform::Api::GetHearingResults).to receive(:call)
+  end
+
   around do |example|
     Sidekiq::Testing.fake! do
       example.run

--- a/spec/requests/api/internal/v2/hearing_results_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearing_results_request_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "api/internal/v2/hearing_results", type: :request, swagger_doc: "
       parameter "$ref" => "#/components/parameters/transaction_id_header"
 
       let(:Authorization) { "Bearer #{access_token.token}" }
+      let(:sitting_day) { nil }
 
       context "when Hearing Result exists on Common Platform" do
         let(:hearing_id) { "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4" }
@@ -68,6 +69,32 @@ RSpec.describe "api/internal/v2/hearing_results", type: :request, swagger_doc: "
 
         describe "response" do
           response(404, "Not found") do
+            run_test!
+          end
+        end
+      end
+
+      context "with sitting day query parameter" do
+        let(:hearing_id) { "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4" }
+        let(:sitting_day) { "2020-08-17" }
+
+        parameter name: :sitting_day, in: :query, required: false, type: :string, format: :datetime,
+                  schema: {
+                    "$ref": "hearing_day.json#/properties/sitting_day",
+                  },
+                  description: "The sitting day of the hearing"
+
+        before do
+          stub_request(:get, "#{ENV['COMMON_PLATFORM_URL']}/hearing/results?hearingId=#{hearing_id}&sittingDay=#{sitting_day}")
+            .to_return(
+              status: 200,
+              headers: { content_type: "application/json" },
+              body: file_fixture("hearing_resulted.json").read,
+            )
+        end
+
+        describe "response" do
+          response(200, "Success") do
             run_test!
           end
         end

--- a/spec/services/common_platform/api/get_hearing_results_spec.rb
+++ b/spec/services/common_platform/api/get_hearing_results_spec.rb
@@ -1,45 +1,91 @@
 # frozen_string_literal: true
 
 RSpec.describe CommonPlatform::Api::GetHearingResults do
-  subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id) }
+  context "when getting result by hearing id only" do
+    subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, sitting_day: nil) }
 
-  let(:hearing_id) { "ceb158e3-7171-40ce-915b-441e2c4e3f75" }
+    let(:hearing_id) { "ceb158e3-7171-40ce-915b-441e2c4e3f75" }
 
-  let(:response) { double(body: { amazing_body: true }, status: 200) }
+    let(:response) { double(body: { amazing_body: true }, status: 200) }
 
-  before do
-    allow(CommonPlatform::Api::HearingFetcher).to receive(:call).with(hearing_id: hearing_id).and_return(response)
-  end
-
-  it "calls the HearingRecorder service" do
-    expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: false)
-    get_hearing_results
-  end
-
-  context "when publish_to_queue is enabled" do
-    subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, publish_to_queue: true) }
+    before do
+      allow(CommonPlatform::Api::HearingFetcher).to receive(:call).with(hearing_id: hearing_id, sitting_day: nil).and_return(response)
+    end
 
     it "calls the HearingRecorder service" do
-      expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: true)
+      expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: false)
       get_hearing_results
+    end
+
+    context "when publish_to_queue is enabled" do
+      subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, publish_to_queue: true) }
+
+      it "calls the HearingRecorder service" do
+        expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: true)
+        get_hearing_results
+      end
+    end
+
+    context "when the body is blank" do
+      let(:response) { double(body: {}, status: 200) }
+
+      it "does not record the result" do
+        expect(HearingRecorder).not_to receive(:call)
+        get_hearing_results
+      end
+    end
+
+    context "when the status is a 404" do
+      let(:response) { double(body: {}, status: 404) }
+
+      it "does not record the result" do
+        expect(HearingRecorder).not_to receive(:call)
+        get_hearing_results
+      end
     end
   end
 
-  context "when the body is blank" do
-    let(:response) { double(body: {}, status: 200) }
+  context "when getting results by hearing id and hearing date" do
+    subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, sitting_day: sitting_day) }
 
-    it "does not record the result" do
-      expect(HearingRecorder).not_to receive(:call)
+    let(:hearing_id) { "ceb158e3-7171-40ce-915b-441e2c4e3f75" }
+    let(:sitting_day) { "2021-05-20" }
+    let(:response) { double(body: { amazing_body: true }, status: 200) }
+
+    before do
+      allow(CommonPlatform::Api::HearingFetcher).to receive(:call).with(hearing_id: hearing_id, sitting_day: sitting_day).and_return(response)
+    end
+
+    it "calls the HearingRecorder service" do
+      expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: false)
       get_hearing_results
     end
-  end
 
-  context "when the status is a 404" do
-    let(:response) { double(body: {}, status: 404) }
+    context "when publish_to_queue is enabled" do
+      subject(:get_hearing_results) { described_class.call(hearing_id: hearing_id, sitting_day: sitting_day, publish_to_queue: true) }
 
-    it "does not record the result" do
-      expect(HearingRecorder).not_to receive(:call)
-      get_hearing_results
+      it "calls the HearingRecorder service" do
+        expect(HearingRecorder).to receive(:call).with(hearing_id: hearing_id, hearing_resulted_data: response.body, publish_to_queue: true)
+        get_hearing_results
+      end
+    end
+
+    context "when the body is blank" do
+      let(:response) { double(body: {}, status: 200) }
+
+      it "does not record the result" do
+        expect(HearingRecorder).not_to receive(:call)
+        get_hearing_results
+      end
+    end
+
+    context "when the status is a 404" do
+      let(:response) { double(body: {}, status: 404) }
+
+      it "does not record the result" do
+        expect(HearingRecorder).not_to receive(:call)
+        get_hearing_results
+      end
     end
   end
 end

--- a/spec/services/common_platform/api/hearing_fetcher_spec.rb
+++ b/spec/services/common_platform/api/hearing_fetcher_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe CommonPlatform::Api::HearingFetcher do
   context "when fetching result with hearing_id and hearing_day query params" do
     subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: sitting_day) }
 
-    let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171037" }
-    let(:sitting_day) { "2021-05-21" }
+    let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
+    let(:sitting_day) { "2020-08-17" }
 
     let(:connection) { double("CommonPlatform::Connection") }
     let(:url) { "hearing/results" }
@@ -60,7 +60,7 @@ RSpec.describe CommonPlatform::Api::HearingFetcher do
 
     it "returns the requested hearing date" do
       VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
-        expect(fetch_hearing.body["hearing"]["hearingDays"][0]["sittingDay"]).to eq("2021-05-21T09:01:01.001Z")
+        expect(fetch_hearing.body["hearing"]["hearingDays"][0]["sittingDay"]).to eq("2020-08-17T09:01:01.001Z")
       end
     end
 

--- a/spec/services/common_platform/api/hearing_fetcher_spec.rb
+++ b/spec/services/common_platform/api/hearing_fetcher_spec.rb
@@ -1,42 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe CommonPlatform::Api::HearingFetcher do
-  subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id) }
+  context "when fetching result by hearing id only" do
+    subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: nil) }
 
-  let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
+    let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
 
-  it "returns the requested hearing info" do
-    VCR.use_cassette("hearing_result_fetcher/success") do
-      expect(fetch_hearing.body["hearing"]["id"]).to eq(hearing_id)
-    end
-  end
-
-  context "with a incorrect key" do
-    subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, connection: connection) }
-
-    let(:connection) { CommonPlatform::Connection.call }
-
-    before do
-      connection.headers["Ocp-Apim-Subscription-Key"] = "INCORRECT KEY"
+    it "returns the requested hearing info" do
+      VCR.use_cassette("hearing_result_fetcher/success") do
+        expect(fetch_hearing.body["hearing"]["id"]).to eq(hearing_id)
+      end
     end
 
-    it "returns an unauthorised response" do
-      VCR.use_cassette("hearing_result_fetcher/unauthorised") do
-        expect(fetch_hearing.status).to eq(401)
+    context "with a incorrect key" do
+      subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: nil, connection: connection) }
+
+      let(:connection) { CommonPlatform::Connection.call }
+
+      before do
+        connection.headers["Ocp-Apim-Subscription-Key"] = "INCORRECT KEY"
+      end
+
+      it "returns an unauthorised response" do
+        VCR.use_cassette("hearing_result_fetcher/unauthorised") do
+          expect(fetch_hearing.status).to eq(401)
+        end
+      end
+    end
+
+    context "with connection" do
+      subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: nil, connection: connection) }
+
+      let(:connection) { double("CommonPlatformConnection") }
+      let(:url) { "hearing/results" }
+      let(:params) { { hearingId: hearing_id } }
+
+      it "makes a get request" do
+        expect(connection).to receive(:get).with(url, params)
+        fetch_hearing
       end
     end
   end
 
-  context "with connection" do
-    subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, connection: connection) }
+  context "when fetching result with hearing_id and hearing_day query params" do
+    subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: sitting_day) }
+
+    let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171037" }
+    let(:sitting_day) { "2021-05-21" }
 
     let(:connection) { double("CommonPlatform::Connection") }
     let(:url) { "hearing/results" }
     let(:params) { { hearingId: hearing_id } }
 
-    it "makes a get request" do
-      expect(connection).to receive(:get).with(url, params)
-      fetch_hearing
+    it "returns the requested hearing info" do
+      VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
+        expect(fetch_hearing.body["hearing"]["id"]).to eq(hearing_id)
+      end
+    end
+
+    it "returns the requested hearing date" do
+      VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
+        expect(fetch_hearing.body["hearing"]["hearingDays"][0]["sittingDay"]).to eq("2021-05-21T09:01:01.001Z")
+      end
+    end
+
+    context "with connection" do
+      subject(:fetch_hearing) { described_class.call(hearing_id: hearing_id, sitting_day: sitting_day, connection: connection) }
+
+      let(:connection) { double("CommonPlatformConnection") }
+      let(:url) { "hearing/results" }
+      let(:params) { { hearingId: hearing_id, sittingDay: sitting_day } }
+
+      it "makes a get request" do
+        expect(connection).to receive(:get).with(url, params)
+        fetch_hearing
+      end
     end
   end
 end

--- a/swagger/v1/hearing.json
+++ b/swagger/v1/hearing.json
@@ -344,7 +344,7 @@
       "properties": {
         "sittingDay": {
           "description": "The date and time the hearing was held",
-          "example": "2018-10-24 10:00:00",
+          "example": "2022-03-10T14:00:00.000Z",
           "format": "date-time",
           "type": "string"
         },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -151,7 +151,14 @@ paths:
                                               All top-level and nested associations available for inclusion are listed under the relationships keys of the response body.
                                               For example to include hearing events, providers, prosecution cases, cracked ineffective trial as well as court applications and associated judicial results:
                                               include=hearing_events,providers,court_applications,prosecution_cases,cracked_ineffective_trial,court_applications.judicial_results
-      - "$ref": "#/components/parameters/transaction_id_header"
+      - name: sitting_day
+        in: query
+        required: false
+        type: string
+        format: datetime
+        schema:
+          "$ref": hearing.json#/definitions/hearingDay/properties/sittingDay
+        description: The sitting day of the hearing
       responses:
         '200':
           description: Success

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -143,6 +143,14 @@ paths:
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
       - "$ref": "#/components/parameters/transaction_id_header"
+      - name: sitting_day
+        in: query
+        required: false
+        type: string
+        format: datetime
+        schema:
+          "$ref": hearing_day.json#/properties/sitting_day
+        description: The sitting day of the hearing
       responses:
         '200':
           description: Success


### PR DESCRIPTION
* Add sitting_day param to hearing request made to Common Platform as part of CDA's Get Prosecution Case endpoint
* Add conditional logic to only make request for resulted hearings
* Update Swagger Docs
* Update both API v1 and v2
