### PR TITLE
Update path to Helm values file in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           update-repositories: false
           chart: ./helm_deploy/laa-court-data-adaptor
           release-name: laa-court-data-adaptor
-          values: ./helm_deploy/laa-court-data-adaptor/dev/values-dev.yaml
+          values: ./helm_deploy/laa-court-data-adaptor/live-1/dev/values-dev.yaml
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_test:
@@ -124,7 +124,7 @@ jobs:
           update-repositories: false
           chart: ./helm_deploy/laa-court-data-adaptor
           release-name: laa-court-data-adaptor
-          values: ./helm_deploy/laa-court-data-adaptor/test/values-test.yaml
+          values: ./helm_deploy/laa-court-data-adaptor/live-1/test/values-test.yaml
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_uat:
@@ -141,7 +141,7 @@ jobs:
           update-repositories: false
           chart: ./helm_deploy/laa-court-data-adaptor
           release-name: laa-court-data-adaptor
-          values: ./helm_deploy/laa-court-data-adaptor/uat/values-uat.yaml
+          values: ./helm_deploy/laa-court-data-adaptor/live-1/uat/values-uat.yaml
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_stage:
@@ -158,7 +158,7 @@ jobs:
           update-repositories: false
           chart: ./helm_deploy/laa-court-data-adaptor
           release-name: laa-court-data-adaptor
-          values: ./helm_deploy/laa-court-data-adaptor/stage/values-stage.yaml
+          values: ./helm_deploy/laa-court-data-adaptor/live-1/stage/values-stage.yaml
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_prod:
@@ -175,7 +175,7 @@ jobs:
           update-repositories: false
           chart: ./helm_deploy/laa-court-data-adaptor
           release-name: laa-court-data-adaptor
-          values: ./helm_deploy/laa-court-data-adaptor/prod/values-prod.yaml
+          values: ./helm_deploy/laa-court-data-adaptor/live-1/prod/values-prod.yaml
           values-to-override: image.tag=$CIRCLE_SHA1
 
 workflows:


### PR DESCRIPTION
CI fails because it cannot find the values file at the path specified in .circleci/config file.

This updates the paths and fixes CI. 

https://app.circleci.com/pipelines/github/ministryofjustice/laa-court-data-adaptor/2537/workflows/f6765910-6bff-4da2-a160-cabd86d1130f/jobs/6479