### PR TITLE
Send one case conclusion object per SQS (API v2)

### DIFF
--- a/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
@@ -11,7 +11,7 @@ module Api
             next if laa_reference.blank?
 
             Sqs::MessagePublisher.call(
-              message: { "prosecutionConcluded" => [pc.to_h.merge("maatId" => laa_reference.maat_reference)] },
+              message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
             )
           end

--- a/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "api/external/v2/prosecution_conclusions", type: :request, swagge
             linked: true,
           )
 
-          expected_message = { "prosecutionConcluded" => [prosecution_conclusion["prosecutionConcluded"].first.merge("maatId" => "700111")] }
+          expected_message = prosecution_conclusion["prosecutionConcluded"].first.merge("maatId" => "700111")
 
           expect(Sqs::MessagePublisher).to receive(:call)
             .once


### PR DESCRIPTION
## What

Send one case conclusion object per SQS (API v2)