### PR TITLE
Automatically deploy master to production on live cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,13 +393,9 @@ workflows:
       - install_on_stage_live:
           requires:
           - hold_install_on_stage
-      - hold_install_on_prod:
-          type: approval
-          requires:
-          - build-and-push-app
       - install_on_prod_live:
           requires:
-          - hold_install_on_prod
+          - build-and-push-app
 
   test-branch:
     jobs:


### PR DESCRIPTION
Now that we've migrated to the live cluster, we can have CI deploy to production automatically, with no manual approval from a developer.