### PR TITLE
Fetch MAAT reference from representation order

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -41,6 +41,10 @@ class Defendant
     body["offenceSummary"].map { |offence| Offence.new(body: offence, details: offence_details[offence["offenceId"]]) }
   end
 
+  def maat_reference
+    body.dig("representationOrder", "applicationReference")
+  end
+
   def defence_organisation
     return if case_reference.blank?
 
@@ -65,10 +69,6 @@ class Defendant
     end
   end
 
-  def maat_reference
-    _maat_reference if valid_maat_reference?
-  end
-
   def post_hearing_custody_statuses
     offence_details.deep_transform_keys(&:to_sym).flat_map do |_offence_id, offence|
       PostHearingCustodyCalculator.call(offences: offence)
@@ -91,17 +91,6 @@ private
     return [] if details.blank?
 
     details.flat_map { |detail| detail["judicialResults"] }.uniq.compact
-  end
-
-  def valid_maat_reference?
-    _maat_reference.present? && !_maat_reference.start_with?("Z")
-  end
-
-  def _maat_reference
-    refs = offences.map(&:maat_reference).uniq.compact
-    raise "Too many maat references" if refs.size > 1
-
-    refs&.first
   end
 
   def case_reference

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Defendant, type: :model do
   it { expect(defendant.date_of_birth).to eq("1980-01-01") }
   it { expect(defendant.national_insurance_number).to eq("HB133542A") }
   it { expect(defendant.arrest_summons_number).to eq("ARREST123") }
+  it { expect(defendant.maat_reference).to eq("LAA-20191601") }
   it { expect(defendant.prosecution_case).to be_nil }
   it { expect(defendant.post_hearing_custody_statuses).to eq([]) }
 
@@ -77,19 +78,13 @@ RSpec.describe Defendant, type: :model do
       allow(defendant).to receive(:offences).and_return(offences)
     end
 
-    it { expect(defendant.maat_reference).to be_nil }
     it { expect(defendant.defence_organisation).to be_nil }
 
     context "when a maat_reference is linked" do
-      let(:offences) do
-        [instance_double("Offence", maat_reference: "123123")]
-      end
-
       before do
         ProsecutionCase.create!(id: prosecution_case_hash["prosecutionCaseId"], body: "{}")
       end
 
-      it { expect(defendant.maat_reference).to eq("123123") }
       it { expect(defendant.defence_organisation_id).to be_nil }
 
       context "when a representation_order is recorded" do
@@ -112,47 +107,6 @@ RSpec.describe Defendant, type: :model do
 
         it { expect(defendant.defence_organisation_id).to eq("CONTRACT REFERENCE") }
       end
-    end
-
-    context "when there are multiple offences" do
-      context "with nil and not-nil maat references" do
-        let(:offences) do
-          [instance_double("Offence", maat_reference: "123123"),
-           instance_double("Offence", maat_reference: nil)]
-        end
-
-        it { expect(defendant.maat_reference).to eq("123123") }
-      end
-
-      context "with duplicate maat references" do
-        let(:offences) do
-          [instance_double("Offence", maat_reference: "123123"),
-           instance_double("Offence", maat_reference: nil),
-           instance_double("Offence", maat_reference: "123123")]
-        end
-
-        it { expect(defendant.maat_reference).to eq("123123") }
-      end
-
-      context "with different maat references" do
-        let(:offences) do
-          [instance_double("Offence", maat_reference: "123123"),
-           instance_double("Offence", maat_reference: nil),
-           instance_double("Offence", maat_reference: "321321")]
-        end
-
-        it { expect { defendant.maat_reference }.to raise_error StandardError, "Too many maat references" }
-      end
-    end
-
-    context "when an offence has an unlinked maat reference" do
-      let(:offences) do
-        [instance_double("Offence", maat_reference: "Z123123"),
-         instance_double("Offence", maat_reference: nil)]
-      end
-
-      it { expect(defendant.maat_reference).to be_nil }
-      it { expect(defendant.defence_organisation).to be_nil }
     end
   end
 

--- a/spec/serializers/api/internal/v1/defendant_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/defendant_serializer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::Internal::V1::DefendantSerializer do
       end
 
       it "maat_reference" do
-        expect(attributes[:maat_reference]).to eq("552244")
+        expect(attributes[:maat_reference]).to eq("7555111")
       end
 
       it "prosecution_case_id" do


### PR DESCRIPTION
Fetch MAAT reference from representation order instead of computing it from the collection of defendant offences.

Remedies https://sentry.io/organizations/ministryofjustice/issues/2913986575/?environment=prod&project=5375870&query=is%3Aunresolved.