### PR TITLE
Bump Rails to 6.1.4.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,16 +10,16 @@ ruby "2.7.5"
 
 # Remove dependency on Action Mailbox > Marcel > MimeMagic due to https://github.com/rails/rails/issues/41750,
 # by loading only the individual Rails modules we need:
-gem "actioncable"
-gem "actionmailer"
-gem "actionpack"
-gem "actionview"
-gem "activejob"
-gem "activemodel"
-gem "activerecord"
-gem "activesupport"
+gem "actioncable", "~> 6.1.4.6"
+gem "actionmailer", "~> 6.1.4.6"
+gem "actionpack", "~> 6.1.4.6"
+gem "actionview", "~> 6.1.4.6"
+gem "activejob", "~> 6.1.4.6"
+gem "activemodel", "~> 6.1.4.6"
+gem "activerecord", "~> 6.1.4.6"
+gem "activesupport", "~> 6.1.4.6"
 gem "bundler"
-gem "railties"
+gem "railties", "~> 6.1.4.6"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,40 +8,40 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.4.3)
-      actionpack (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
+    actioncable (6.1.4.6)
+      actionpack (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (6.1.4.3)
-      actionpack (= 6.1.4.3)
-      actionview (= 6.1.4.3)
-      activejob (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
+    actionmailer (6.1.4.6)
+      actionpack (= 6.1.4.6)
+      actionview (= 6.1.4.6)
+      activejob (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.4.3)
-      actionview (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
+    actionpack (6.1.4.6)
+      actionview (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.4.3)
-      activesupport (= 6.1.4.3)
+    actionview (6.1.4.6)
+      activesupport (= 6.1.4.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.1.4.3)
-      activesupport (= 6.1.4.3)
+    activejob (6.1.4.6)
+      activesupport (= 6.1.4.6)
       globalid (>= 0.3.6)
-    activemodel (6.1.4.3)
-      activesupport (= 6.1.4.3)
-    activerecord (6.1.4.3)
-      activemodel (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
-    activesupport (6.1.4.3)
+    activemodel (6.1.4.6)
+      activesupport (= 6.1.4.6)
+    activerecord (6.1.4.6)
+      activemodel (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
+    activesupport (6.1.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -166,7 +166,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.13.0)
+    loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -226,9 +226,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    railties (6.1.4.3)
-      actionpack (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
+    railties (6.1.4.6)
+      actionpack (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
@@ -361,14 +361,14 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  actioncable
-  actionmailer
-  actionpack
-  actionview
-  activejob
-  activemodel
-  activerecord
-  activesupport
+  actioncable (~> 6.1.4.6)
+  actionmailer (~> 6.1.4.6)
+  actionpack (~> 6.1.4.6)
+  actionview (~> 6.1.4.6)
+  activejob (~> 6.1.4.6)
+  activemodel (~> 6.1.4.6)
+  activerecord (~> 6.1.4.6)
+  activesupport (~> 6.1.4.6)
   aws-sdk-sqs
   bcrypt (~> 3.1.16)
   bootsnap (>= 1.4.2)
@@ -392,7 +392,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails (~> 0.3.9)
   puma (~> 5.6)
-  railties
+  railties (~> 6.1.4.6)
   rspec-rails (~> 5.1.0)
   rspec_junit_formatter
   rswag-api


### PR DESCRIPTION
## What

Bump Rails to 6.1.4.6, i.e. latest patch version.