### PR TITLE
Make sure Sidekiq args are always native JSON

### DIFF
--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -51,7 +51,7 @@ private
   def publish_hearing_to_queue
     HearingsCreatorWorker.perform_async(
       Current.request_id,
-      hearing_resulted_data,
+      hearing_resulted_data.to_json,
     )
   end
 

--- a/app/workers/hearings_creator_worker.rb
+++ b/app/workers/hearings_creator_worker.rb
@@ -3,10 +3,10 @@
 class HearingsCreatorWorker
   include Sidekiq::Worker
 
-  def perform(request_id, hearing_resulted_data)
+  def perform(request_id, hearing_resulted_json)
     Current.set(request_id: request_id) do
       HearingsCreator.call(
-        hearing_resulted_data: hearing_resulted_data,
+        hearing_resulted_data: JSON.parse(hearing_resulted_json),
         queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
       )
     end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,6 +12,8 @@ end
 
 require "prometheus_exporter/instrumentation"
 
+Sidekiq.strict_args!
+
 unless Rails.env.test?
   Sidekiq.configure_server do |config|
     config.server_middleware do |chain|

--- a/spec/services/hearing_recorder_spec.rb
+++ b/spec/services/hearing_recorder_spec.rb
@@ -22,10 +22,13 @@ RSpec.describe HearingRecorder do
     expect(record_hearing.body).to eq(hearing_resulted_data.stringify_keys)
   end
 
-  it "enqueues a HearingsCreatorWorker" do
+  it "enqueues a HearingsCreatorWorker job with a JSON payload" do
     Sidekiq::Testing.fake! do
       Current.set(request_id: "XYZ") do
-        expect(HearingsCreatorWorker).to receive(:perform_async).with("XYZ", hearing_resulted_data).and_call_original
+        expect(HearingsCreatorWorker)
+          .to receive(:perform_async)
+          .with("XYZ", hearing_resulted_data.to_json)
+
         record_hearing
       end
     end


### PR DESCRIPTION
Add `Sidekiq.strict_args!` to the Sidekiq initializer to make sure
that our workers always use native JSON as arguments.

This is to avoid accidentally passing Ruby objects as arguments, which are
unsafe to serialize.

Note: The next version of Sidekiq 7.0 will raise an error, regardless of the presence
of `Sidekiq.strict_args!`.

This suppresses the warning:

"Job arguments to HearingsCreatorWorker must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices"