### PR TITLE
Fix Swagger for GET /internal/hearing_results/id

### DIFF
--- a/spec/requests/api/internal/v2/hearing_results_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearing_results_request_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "api/internal/v2/hearing_results", type: :request, swagger_doc: "
 
         describe "response" do
           response(404, "Not found") do
-            schema "$ref" => "hearing_result.json#"
             run_test!
           end
         end

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -154,10 +154,6 @@ paths:
           description: Unauthorized
         '404':
           description: Not found
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": hearing_result.json#
   "/api/internal/v2/laa_references":
     post:
       summary: post laa_reference


### PR DESCRIPTION
## What

The 404 response does not return a hearing result in the body, so Swagger should not document it as such.