### PR TITLE
Pass hash as Sidekiq job argument, with string keys, to avoid using symbols

### DIFF
--- a/app/services/hearing_recorder.rb
+++ b/app/services/hearing_recorder.rb
@@ -51,7 +51,7 @@ private
   def publish_hearing_to_queue
     HearingsCreatorWorker.perform_async(
       Current.request_id,
-      hearing_resulted_data.to_json,
+      hearing_resulted_data.deep_stringify_keys,
     )
   end
 

--- a/app/workers/hearings_creator_worker.rb
+++ b/app/workers/hearings_creator_worker.rb
@@ -3,10 +3,10 @@
 class HearingsCreatorWorker
   include Sidekiq::Worker
 
-  def perform(request_id, hearing_resulted_json)
+  def perform(request_id, hearing_resulted_data)
     Current.set(request_id: request_id) do
       HearingsCreator.call(
-        hearing_resulted_data: JSON.parse(hearing_resulted_json),
+        hearing_resulted_data: hearing_resulted_data,
         queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
       )
     end

--- a/spec/workers/hearings_creator_worker_spec.rb
+++ b/spec/workers/hearings_creator_worker_spec.rb
@@ -4,7 +4,7 @@ require "sidekiq/testing"
 
 RSpec.describe HearingsCreatorWorker, type: :worker do
   subject(:work) do
-    described_class.perform_async("XYZ", { data: "some data" }.to_json)
+    described_class.perform_async("XYZ", { "data" => "some data" })
   end
 
   it "queues the job" do


### PR DESCRIPTION
This is to avoid using symbols, that are not native JSON types while at the same time not converting our hashes entirely into JSON.

From the Sidekiq [Wiki](https://github.com/mperham/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple):

> The arguments you pass to perform_async must be composed of simple JSON datatypes:
string, integer, float, boolean, null(nil), array and hash. This means you must not
use ruby symbols as arguments. The Sidekiq client API uses JSON.dump to send the data
to Redis. The Sidekiq server pulls that JSON data from Redis and uses JSON.load to
convert the data back into Ruby types to pass to your perform method. Don't pass symbols,
named parameters, keyword arguments or complex Ruby objects (like Date or Time!) as those
will not survive the dump/load round trip correctly. You can use methods like
Hash#stringify_keys to convert Symbol keys when passing a Hash to perform_async.

Fixes issues https://github.com/ministryofjustice/laa-court-data-adaptor/issues/844 and https://github.com/ministryofjustice/laa-court-data-adaptor/issues/843 that were introduced by PR https://github.com/ministryofjustice/laa-court-data-adaptor/pull/841.