### PR TITLE
Make proceedingsConcludedChangedDate field optional

### DIFF
--- a/app/contracts/prosecution_conclusion_contract.rb
+++ b/app/contracts/prosecution_conclusion_contract.rb
@@ -10,7 +10,7 @@ class ProsecutionConclusionContract < Dry::Validation::Contract
         required(:offenceId).value(:string)
         required(:offenceCode).value(:string)
         required(:proceedingsConcluded).value(:bool)
-        required(:proceedingsConcludedChangedDate).value(:string)
+        optional(:proceedingsConcludedChangedDate).value(:string)
 
         optional(:plea).value(:hash) do
           required(:originatingHearingId).value(:string)

--- a/lib/schemas/api/progression.api.prosecutionConcludedRequest.json
+++ b/lib/schemas/api/progression.api.prosecutionConcludedRequest.json
@@ -85,8 +85,7 @@
       "required": [
         "offenceId",
         "offenceCode",
-        "proceedingsConcluded",
-        "proceedingsConcludedChangedDate"
+        "proceedingsConcluded"
       ],
       "additionalProperties": false
     },

--- a/spec/contracts/prosecution_conclusion_contract_spec.rb
+++ b/spec/contracts/prosecution_conclusion_contract_spec.rb
@@ -1,7 +1,19 @@
 RSpec.describe ProsecutionConclusionContract, type: :model do
-  let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
-
   context "with all fields" do
+    let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/all_fields.json").read) }
+
+    it "matches the HMCTS Common Platform schema" do
+      expect(prosecution_conclusion).to match_json_schema(:prosecution_conclusion)
+    end
+
+    it "is valid" do
+      expect(described_class.new.call(prosecution_conclusion)).to be_a_success
+    end
+  end
+
+  context "with required fields only" do
+    let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/required_fields.json").read) }
+
     it "matches the HMCTS Common Platform schema" do
       expect(prosecution_conclusion).to match_json_schema(:prosecution_conclusion)
     end

--- a/spec/fixtures/files/prosecution_conclusion/all_fields.json
+++ b/spec/fixtures/files/prosecution_conclusion/all_fields.json
@@ -1,0 +1,34 @@
+{
+  "prosecutionConcluded": [
+    {
+      "prosecutionCaseId": "dc7d0f3e-6316-4d5e-8827-3e6a3ddfdebb",
+      "defendantId": "67d948d1-1792-4565-a522-8ab2425827e8",
+      "isConcluded": true,
+      "hearingIdWhereChangeOccurred": "96095df2-b66b-421d-881e-c45fd267e751",
+      "offenceSummary": [
+        {
+          "offenceId": "fb2a3ecb-fc1a-4a80-88ac-222478bc4a92",
+          "offenceCode": "PT00011",
+          "proceedingsConcluded": true,
+          "proceedingsConcludedChangedDate": "2021-01-01",
+          "plea": {
+            "originatingHearingId": "a6b07866-faa0-48d5-9faf-c18121e49aaf",
+            "pleaDate": "2021-03-01",
+            "value": "GUILTY"
+          },
+          "verdict": {
+            "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+            "verdictDate": "2021-04-10",
+            "verdictType": {
+              "description": "Verdict type description",
+              "category": "A",
+              "categoryType": "Type A",
+              "sequence": 1,
+              "verdictTypeId": "ebb53996-e8f1-4363-95a0-34c663ce6f9a"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/prosecution_conclusion/required_fields.json
+++ b/spec/fixtures/files/prosecution_conclusion/required_fields.json
@@ -1,0 +1,17 @@
+{
+  "prosecutionConcluded": [
+    {
+      "prosecutionCaseId": "dc7d0f3e-6316-4d5e-8827-3e6a3ddfdebb",
+      "defendantId": "67d948d1-1792-4565-a522-8ab2425827e8",
+      "isConcluded": true,
+      "hearingIdWhereChangeOccurred": "96095df2-b66b-421d-881e-c45fd267e751",
+      "offenceSummary": [
+        {
+          "offenceId": "fb2a3ecb-fc1a-4a80-88ac-222478bc4a92",
+          "offenceCode": "PT00011",
+          "proceedingsConcluded": true
+        }
+      ]
+    }
+  ]
+}

--- a/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "api/external/v2/prosecution_conclusions", type: :request, swagge
                   description: "The minimal prosecution concluded payload"
 
         let(:Authorization) { "Bearer #{token.token}" }
-        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
+        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/all_fields.json").read) }
 
         before do
           LaaReference.create!(

--- a/swagger/v1/prosecution_conclusion.json
+++ b/swagger/v1/prosecution_conclusion.json
@@ -70,8 +70,7 @@
       "required": [
         "offenceId",
         "offenceCode",
-        "proceedingsConcluded",
-        "proceedingsConcludedChangedDate"
+        "proceedingsConcluded"
       ],
       "additionalProperties": false
     },

--- a/swagger/v2/prosecution_conclusion.json
+++ b/swagger/v2/prosecution_conclusion.json
@@ -70,8 +70,7 @@
       "required": [
         "offenceId",
         "offenceCode",
-        "proceedingsConcluded",
-        "proceedingsConcludedChangedDate"
+        "proceedingsConcluded"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
## What

Make `offenceSummary.proceedingsConcludedChangedDate` field optional on the prosecution conclusion payloads.

Fixes https://github.com/ministryofjustice/laa-court-data-adaptor/issues/859.