### PR TITLE
Add data points to prosecution case search endpoint v2

### DIFF
--- a/app/models/hmcts_common_platform/hearing_summary.rb
+++ b/app/models/hmcts_common_platform/hearing_summary.rb
@@ -34,6 +34,14 @@ module HmctsCommonPlatform
       defence_counsels.map(&:id)
     end
 
+    def jurisdiction_type
+      data[:jurisdictionType]
+    end
+
+    def defendant_ids
+      data[:defendantIds]
+    end
+
     def defence_counsels
       Array(data[:defenceCounsel]).map do |defence_counsel_data|
         HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
@@ -51,6 +59,8 @@ module HmctsCommonPlatform
         hearing_summary.id id
         hearing_summary.hearing_type hearing_type
         hearing_summary.estimated_duration estimated_duration
+        hearing_summary.defendant_ids defendant_ids
+        hearing_summary.jurisdiction_type jurisdiction_type
         hearing_summary.court_centre court_centre.to_json
         hearing_summary.hearing_days hearing_days.map(&:to_json)
         hearing_summary.defence_counsels defence_counsels.map(&:to_json)

--- a/spec/models/hmcts_common_platform/hearing_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_summary_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe HmctsCommonPlatform::HearingSummary, type: :model do
     it { expect(hearing_summary.id).to eql("9b8df2aa-802d-413a-82b3-89eff25cde7b") }
     it { expect(hearing_summary.hearing_type).to eql("First hearing") }
     it { expect(hearing_summary.estimated_duration).to eq("20") }
+    it { expect(hearing_summary.jurisdiction_type).to eq("MAGISTRATES") }
+    it { expect(hearing_summary.defendant_ids).to eq(%w[562dc2de-2258-4476-8be4-69cf15623f83 b760daba-0d38-4bae-ad57-fbfd8419aefe]) }
     it { expect(hearing_summary.hearing_days).to all(be_an(HmctsCommonPlatform::HearingDay)) }
     it { expect(hearing_summary.court_centre).to be_an(HmctsCommonPlatform::CourtCentre) }
     it { expect(hearing_summary.defence_counsels).to all(be_a(HmctsCommonPlatform::DefenceCounsel)) }
@@ -38,6 +40,8 @@ RSpec.describe HmctsCommonPlatform::HearingSummary, type: :model do
       expect(json["id"]).to eql("9b8df2aa-802d-413a-82b3-89eff25cde7b")
       expect(json["hearing_type"]).to eql("First hearing")
       expect(json["estimated_duration"]).to eql("20")
+      expect(json["jurisdiction_type"]).to eq("MAGISTRATES")
+      expect(json["defendant_ids"]).to eq(%w[562dc2de-2258-4476-8be4-69cf15623f83 b760daba-0d38-4bae-ad57-fbfd8419aefe])
       expect(json["court_centre"]).to be_present
       expect(json["hearing_days"].count).to be(1)
       expect(json["defence_counsels"].count).to be(1)

--- a/swagger/v2/hearing_summary.json
+++ b/swagger/v2/hearing_summary.json
@@ -22,6 +22,20 @@
       "description": "Estimated duration of the hearing",
       "type": "string"
     },
+    "defendant_ids": {
+      "readOnly": true,
+      "type": "array",
+      "description": "The identifiers of the defendants that were heard",
+      "minItems": 1,
+      "items": {
+        "$ref": "definitions.json#/definitions/uuid"
+      }
+    },
+    "jurisdiction_type": {
+      "readOnly": true,
+      "type": "string",
+      "description": "The jurisdiction of the hearing"
+    },
     "court_centre": {
       "readOnly": true,
       "description": "An object representing court centre details",
@@ -47,5 +61,12 @@
         "$ref": "defence_counsel.json#"
       }
     }
-  }
+  },
+  "required": [
+    "hearing_id",
+    "jurisdiction_type",
+    "court_centre",
+    "hearing_type",
+    "defendant_ids"
+  ]
 }

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -303,8 +303,6 @@ paths:
       - oAuth: []
       parameters:
       - "$ref": "#/components/parameters/transaction_id_header"
-      - "$ref": "#/components/parameters/transaction_id_header"
-      - "$ref": "#/components/parameters/transaction_id_header"
       responses:
         '202':
           description: Accepted


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-968)

Expose `jurisdiction_type` and `defendant_ids` data points on hearing summaries.


