### PR TITLE
Log when message is posted to queue

### DIFF
--- a/app/services/sqs/message_publisher.rb
+++ b/app/services/sqs/message_publisher.rb
@@ -9,7 +9,10 @@ module Sqs
     end
 
     def call
-      sqs_client.send_message(queue_url: queue_url, message_body: message.to_json) if messaging_enabled?
+      if messaging_enabled?
+        Rails.logger.info("Sending message to queue: queue_url: #{queue_url}, message: #{message.to_json}")
+        sqs_client.send_message(queue_url: queue_url, message_body: message.to_json)
+      end
     end
 
   private


### PR DESCRIPTION
## What

Log when message is posted to queue, in order to make it easier to diagnostic whether a particular message (e.g. a hearing result) has been forwarded onto MAAT API.
