### PR TITLE
Don't log full message (sensitive info)

### DIFF
--- a/app/services/sqs/message_publisher.rb
+++ b/app/services/sqs/message_publisher.rb
@@ -9,7 +9,10 @@ module Sqs
     end
 
     def call
-      sqs_client.send_message(queue_url: queue_url, message_body: message.to_json) if messaging_enabled?
+      if messaging_enabled?
+        Rails.logger.info("Sending message to queue: queue_url: #{queue_url}")
+        sqs_client.send_message(queue_url: queue_url, message_body: message.to_json)
+      end
     end
 
   private


### PR DESCRIPTION
## What

Don't log full message that gets posted to the queue to avoid posting too much PII to Kibana.