### PR TITLE
Serialize defendant attendance as an array

### DIFF
--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -87,7 +87,9 @@ module HmctsCommonPlatform
     end
 
     def defendant_attendance
-      HmctsCommonPlatform::DefendantAttendance.new(data[:defendantAttendance])
+      Array(data[:defendantAttendance]).map do |defendant_attendance_data|
+        HmctsCommonPlatform::DefendantAttendance.new(defendant_attendance_data)
+      end
     end
 
     def to_json(*_args)
@@ -112,7 +114,7 @@ module HmctsCommonPlatform
         hearing.prosecution_counsels prosecution_counsels.map(&:to_json)
         hearing.defence_counsels defence_counsels.map(&:to_json)
         hearing.cracked_ineffective_trial cracked_ineffective_trial.to_json
-        hearing.defendant_attendance defendant_attendance.to_json
+        hearing.defendant_attendance defendant_attendance.map(&:to_json)
       end
     end
   end

--- a/spec/models/hmcts_common_platform/hearing_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_spec.rb
@@ -40,5 +40,5 @@ RSpec.describe HmctsCommonPlatform::Hearing, type: :model do
   it { expect(hearing.hearing_type).to be_an(HmctsCommonPlatform::HearingType) }
   it { expect(hearing.cracked_ineffective_trial).to be_an(HmctsCommonPlatform::CrackedIneffectiveTrial) }
   it { expect(hearing.court_centre).to be_an(HmctsCommonPlatform::CourtCentre) }
-  it { expect(hearing.defendant_attendance).to be_an(HmctsCommonPlatform::DefendantAttendance) }
+  it { expect(hearing.defendant_attendance).to all be_an(HmctsCommonPlatform::DefendantAttendance) }
 end


### PR DESCRIPTION
## What

Serialize defendant attendance as an array


### Before

```
"defendant_attendance": {
      "defendant_id": [
        {
          "attendanceDays": [
            {
              "attendanceType": "IN_PERSON",
              "day": "2021-03-30"
            }
          ],
          "defendantId": "8bee24f9-e2ac-4d31-b88c-78ad60f4bec7"
        }
      ],
      "attendance_days": [
        {
          "type": null,
          "day": null
        }
      ]
    }
```

### After

```
"defendant_attendance": [
  {
    "defendant_id": "8bee24f9-e2ac-4d31-b88c-78ad60f4bec7",
    "attendance_days": [
      {
        "type": "IN_PERSON",
        "day": "2021-03-30"
      }
    ]
  }
]
```
