### PR TITLE
Switch k8s secret to new database URL

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
+++ b/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
@@ -7,7 +7,7 @@ env:
   - name: DATABASE_URL
     valueFrom:
       secretKeyRef:
-        name: laa-court-data-adaptor-instance-output
+        name: rds-instance-output
         key: url
   - name: REDIS_URL
     valueFrom:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1027)

Switch k8s secret for all environments to the new database URL, pointing to the new Postgres 14 instance.
