### PR TITLE
Remove deprecated ingress APIs for Cloud Platform - k8s v1.22

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/ingress-external.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/ingress-external.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "laa-court-data-adaptor.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-external
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/helm_deploy/laa-court-data-adaptor/templates/ingress.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "laa-court-data-adaptor.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
## What

Change to the stable Ingress API version, as per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-ingress-k8s-1-22.html#removing-deprecated-ingress-apis-for-cloud-platform-kubernetes-v1-22.

Required step for Switching ingress to the new nginx-ingress-controller v1.2: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2.

---

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1201)

---

### Context

To improve security of the Cloud Platform we have introduced new v1 Ingress Controllers.

The purpose of this message is to explain the benefits of the new versions and to provide instructions on how Service Teams can start using the controllers.

Why new Ingress Controllers?

There are a number of benefits to using the new controllers:

Security updates (The current controllers are no longer getting security patches. The new versions already have patches for the 3 latest CVEs)

Introducing support for TLS 1.3 (new feature)

Retiring support for TLS 1.0 and 1.1 (mitigate security risks, address Service Team ITHC report and to align to [NCSC recommendations](https://www.ncsc.gov.uk/guidance/using-tls-to-protect-data))

It's a Prerequisite for the Kubernetes 1.22 upgrade

How do we start using the new controllers?

To help you start using the new controllers we have created a helpful step by step guide to  [switch ingress to the new nginx ingress controller](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2).

We ask that Service Teams schedule the changes into their backlog as soon as possible.

We are intending to retire the old controllers at the end of August to reduce risk of security vulnerabilities.

If you have any queries or need assistance with moving to the new Ingress Controllers please contact us over at [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)