### PR TITLE
Log HTTP headers of incoming requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::API
   before_action :set_transaction_id
   before_action :doorkeeper_authorize!
+  before_action :log_http_request_headers
 
   ERROR_MAPPINGS = {
     ActionController::ParameterMissing => :bad_request,
@@ -25,6 +26,16 @@ class ApplicationController < ActionController::API
   end
 
 private
+
+  def log_http_request_headers
+    http_request_headers = {}.tap do |envs|
+      request.headers.each do |key, value|
+        envs[key] = value if key.downcase.starts_with?("http")
+      end
+    end
+
+    Rails.logger.info(http_request_headers)
+  end
 
   def set_transaction_id
     Current.request_id = request.headers["Laa-Transaction-Id"] || request.request_id


### PR DESCRIPTION
## What

This PR adds logging for the headers of all incoming HTTP requests. The main goal is to check for the presence of the `HTTP_X_REQUEST_ID` and `HTTP_LAA_TRANSACTION_ID` from VCD and more importantly, from HMCTS.

If we realise `HTTP_LAA_TRANSACTION_ID` is never included by HMCTS in their requests, then we can use the more standard `HTTP_X_REQUEST_ID` and raise a ticket with HMCTS for them to pass a request UUID to us as part of that header.

JIRA ticket: https://dsdmoj.atlassian.net/browse/LASB-1244.