### PR TITLE
Replace Laa-Transaction-Id with the more standard X-Request-ID

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def set_transaction_id
-    Current.request_id = request.headers["Laa-Transaction-Id"] || request.request_id
-    response.set_header("Laa-Transaction-Id", Current.request_id)
+    Current.request_id = request.headers["X-Request-ID"] || request.request_id
+    response.set_header("X-Request-ID", Current.request_id)
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe ApplicationController, type: :controller do
 
   it_behaves_like "an unauthorised request"
 
-  it "returns an Laa-Transaction-Id on every request" do
+  it "returns an X-Request-ID on every request" do
     get :index
-    expect(response.headers).to include("Laa-Transaction-Id")
+    expect(response.headers).to include("X-Request-ID")
   end
 
-  context "when the Laa-Transaction-Id is included by an external service" do
+  context "when the X-Request-ID is included by an external service" do
     before do
-      request.headers["Laa-Transaction-Id"] = "XYZ"
+      request.headers["X-Request-ID"] = "XYZ"
     end
 
-    it "returns an Laa-Transaction-Id on every request" do
+    it "returns an X-Request-ID on every request" do
       get :index
-      expect(response.headers["Laa-Transaction-Id"]).to eq("XYZ")
+      expect(response.headers["X-Request-ID"]).to eq("XYZ")
     end
   end
 end


### PR DESCRIPTION
Our Rails logger tags each log entry with the `X-Request-ID` it generates for each request. Incoming (custom) `Laa-Transaction-Id` header values don't override this configuration,
which makes it less useful for debugging/tracking.

Replacing this custom HTTP header with the more standard `X-Request-ID` means we can properly tag log entries with incoming values set for this header by the client.

As an added bonus,  the purpose of `X-Request-ID` is well-known and documented standard, as per its definition: (_Correlates HTTP requests between a client and server_.

Docs: https://guides.rubyonrails.org/debugging_rails_applications.html#tagged-logging