### PR TITLE
Log request ID when a message is posted to SQS

### DIFF
--- a/app/services/sqs/message_publisher.rb
+++ b/app/services/sqs/message_publisher.rb
@@ -10,7 +10,7 @@ module Sqs
 
     def call
       if messaging_enabled?
-        Rails.logger.info("Sending message to queue: queue_url: #{queue_url}")
+        Rails.logger.info("Sending message to queue: #{queue_url}, from request_id: #{Current.request_id}")
         sqs_client.send_message(queue_url: queue_url, message_body: message.to_json)
       end
     end


### PR DESCRIPTION
## What
Currently when the Court Data Adapter posts a message to the HearingResulted queue it writes a message to the log, however it does not log the LAA Transaction Id which is used to trace the message through other apps/microservices.

This PR makes sure the request ID (formerly known as LAA Transaction id) is logged when the application posts a message to all queues, including the hearing resulted queue.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1244)