### PR TITLE
Add optional query param to /hearing_results endpoint to trigger processing

### DIFF
--- a/app/controllers/api/internal/v2/hearing_results_controller.rb
+++ b/app/controllers/api/internal/v2/hearing_results_controller.rb
@@ -8,6 +8,7 @@ module Api
           hearing_result = CommonPlatform::Api::GetHearingResults.call(
             hearing_id: permitted_params[:hearing_id],
             sitting_day: permitted_params[:sitting_day],
+            publish_to_queue: permitted_params[:publish_to_queue],
           )
 
           if hearing_result.present?
@@ -24,6 +25,7 @@ module Api
           params.permit(
             :hearing_id,
             :sitting_day,
+            :publish_to_queue,
           )
         end
       end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -88,7 +88,7 @@ ALTER SEQUENCE public.feature_flags_id_seq OWNED BY public.feature_flags.id;
 --
 
 CREATE TABLE public.hearing_event_recordings (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     hearing_id uuid,
     hearing_date date,
     body jsonb NOT NULL,
@@ -102,7 +102,7 @@ CREATE TABLE public.hearing_event_recordings (
 --
 
 CREATE TABLE public.hearings (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     body jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -114,7 +114,7 @@ CREATE TABLE public.hearings (
 --
 
 CREATE TABLE public.laa_references (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     defendant_id uuid NOT NULL,
     maat_reference character varying NOT NULL,
     linked boolean DEFAULT true NOT NULL,
@@ -129,7 +129,7 @@ CREATE TABLE public.laa_references (
 --
 
 CREATE TABLE public.oauth_access_grants (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     resource_owner_id uuid NOT NULL,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE public.oauth_access_grants (
 --
 
 CREATE TABLE public.oauth_access_tokens (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     resource_owner_id uuid,
     application_id uuid NOT NULL,
     token character varying NOT NULL,
@@ -164,7 +164,7 @@ CREATE TABLE public.oauth_access_tokens (
 --
 
 CREATE TABLE public.oauth_applications (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying NOT NULL,
     uid character varying NOT NULL,
     secret character varying NOT NULL,
@@ -172,7 +172,10 @@ CREATE TABLE public.oauth_applications (
     scopes character varying DEFAULT ''::character varying NOT NULL,
     confidential boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    contact_email character varying,
+    requester_email character varying,
+    requestee_email character varying
 );
 
 
@@ -181,7 +184,7 @@ CREATE TABLE public.oauth_applications (
 --
 
 CREATE TABLE public.prosecution_case_defendant_offences (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     prosecution_case_id uuid NOT NULL,
     defendant_id uuid NOT NULL,
     offence_id uuid NOT NULL,
@@ -204,7 +207,7 @@ CREATE TABLE public.prosecution_case_defendant_offences (
 --
 
 CREATE TABLE public.prosecution_cases (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     body jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -225,7 +228,7 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.users (
-    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying,
     auth_token_digest character varying,
     created_at timestamp(6) without time zone NOT NULL,
@@ -487,6 +490,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200720123025'),
 ('20200723141728'),
 ('20210311145419'),
-('20210427164141');
+('20210427164141'),
+('20220801171207'),
+('20220815115514'),
+('20220815120308');
 
 

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -151,6 +151,12 @@ paths:
         schema:
           "$ref": definitions.json#/definitions/datePattern
         description: The sitting day of the hearing
+      - name: publish_to_queue
+        in: query
+        required: false
+        description: Publish hearing results to MAAT API
+        schema:
+          type: boolean
       responses:
         '200':
           description: Success


### PR DESCRIPTION
## What

Enable the caller to get Court Data Adaptor to send hearing result data to the SQS queue.

## Why

MAAT API sometimes receives prosecution conclusion messages before receiving hearing result data for  that originated the conclusion, so it needs to be able to re-fetch and process them on demand.

## How

By adding an optional publish_to_queue query parameter to the GET /api/internal/v1/hearings/:hearing_id endpoint. If the query param value is true, then send HMCTS hearing result data to the SQS Queue for MAAT API to process.

---

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1292)