### PR TITLE
Fix error: Prometheus Exporter Failed To Collect Stats uninitialized constant Sidekiq::ProcessSet

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,6 +14,7 @@ Sidekiq.strict_args!
 
 unless Rails.env.test?
   Sidekiq.configure_server do |config|
+    require "sidekiq/api"
     require "prometheus_exporter/instrumentation"
     config.server_middleware do |chain|
       chain.add PrometheusExporter::Instrumentation::Sidekiq


### PR DESCRIPTION
## What

Attempt to fix error:

`ERROR -- : PrometheusExporter::Instrumentation::SidekiqProcess Prometheus Exporter Failed To Collect Stats uninitialized constant Sidekiq::ProcessSet`