### PR TITLE
Retry fetching hearing results 7 times (~40 mins)

### DIFF
--- a/app/workers/hearing_result_fetcher_worker.rb
+++ b/app/workers/hearing_result_fetcher_worker.rb
@@ -2,6 +2,7 @@
 
 class HearingResultFetcherWorker
   include Sidekiq::Worker
+  sidekiq_options retry: 7 # with exponential backoff, this retries over ~40 minutes
 
   def perform(request_id, hearing_id, sitting_day)
     Current.set(request_id: request_id) do


### PR DESCRIPTION
## What

Retry fetching hearing results 7 times (~40 mins), instead of the default 25 times.

<img width="387" alt="Screenshot 2022-12-13 at 15 33 49" src="https://user-images.githubusercontent.com/3141541/207361305-a9122559-612c-48aa-9a29-7df3afb682eb.png">

https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry

## Why

We're currently hammering Common Platform with hearing result calls, and hammering Sentry with our raised errors. This PR will alleviate the issue somewhat.

It's safe to assume that if after 40 mins, the hearing results are not available, they will never be.