### PR TITLE
Record a 5% sample of errors in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
 if ENV["SENTRY_DSN"].present?
   Sentry.init do |config|
+    config.sample_rate = 0.05
     config.dsn = ENV["SENTRY_DSN"]
     config.breadcrumbs_logger = [:active_support_logger]
   end


### PR DESCRIPTION
Record 5% of errors in Sentry to avoid consuming all MOJ Sentry allowances. You can find more contexts here -
[https://mojdt.slack.com/archives/C02](https://mojdt.slack.com/archives/C02BC9EP3H7/p1672311298031719)