### PR TITLE
Enable Sidekiq Web UI

### DIFF
--- a/app/controllers/api/external/v1/hearing_results_controller.rb
+++ b/app/controllers/api/external/v1/hearing_results_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# api/external/v1/hearings
 module Api
   module External
     module V1

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,10 @@ module LaaCourtDataAdaptor
 
     config.autoload_paths << config.root.join("lib")
     config.active_record.legacy_connection_handling = false
+
+    config.session_store :cookie_store, key: '_interslice_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+require 'sidekiq/web'
 
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
+
+  mount Sidekiq::Web => "/sidekiq"
 
   api_version(module: "V1", path: { value: "v1" }, default: true) do
     use_doorkeeper


### PR DESCRIPTION
## What
Enable Sidekiq Web UI

IMPORTANT: not for production. To deploy on prod. Add an authentication mechanism to protect/sidekiq endpoint.


This helps to debug the behaviour of the queue, in particular, to debug the duplication issue.


