### PR TITLE
Lasb 1925 fix maat link creation

### DIFF
--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -11,18 +11,14 @@ class LaaReference < ApplicationRecord
 
   def adjust_link_and_save!
     # Unlink the previous laa reference
-    laa_ref_already_liked = LaaReference.find_by(maat_reference: maat_reference, linked: true)
-    laa_ref_already_liked.unlink! if laa_ref_already_liked.present?
+    laa_ref_already_linked = LaaReference.find_by(maat_reference: maat_reference, linked: true)
+    laa_ref_already_linked.unlink! if laa_ref_already_linked.present?
 
     self.linked = true
 
     save!
   rescue ActiveRecord::ActiveRecordError => e
     Sentry.capture_exception(e)
-  end
-
-  def self.unlink_all!(maat_ref)
-    where(maat_reference: maat_ref).update_all(linked: false)
   end
 
   def dummy_maat_reference?

--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -9,6 +9,22 @@ class LaaReference < ApplicationRecord
     update!(linked: false)
   end
 
+  def adjust_link_and_save!
+    # Unlink the previous laa reference
+    laa_ref_already_liked = LaaReference.find_by(maat_reference: maat_reference, linked: true)
+    laa_ref_already_liked.unlink! if laa_ref_already_liked.present?
+
+    self.linked = true
+
+    save!
+  rescue ActiveRecord::ActiveRecordError => e
+    Sentry.capture_exception(e)
+  end
+
+  def self.unlink_all!(maat_ref)
+    where(maat_reference: maat_ref).update_all(linked: false)
+  end
+
   def dummy_maat_reference?
     return false if maat_reference.nil?
 

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -15,7 +15,8 @@ class MaatLinkCreator < ApplicationService
     post_laa_references_to_common_platform
     publish_laa_reference_to_queue unless laa_reference.dummy_maat_reference?
     fetch_past_hearings
-    persist_laa_reference
+
+    laa_reference.adjust_link_and_save!
   end
 
 private
@@ -63,18 +64,6 @@ private
     )
 
     raise StandardError, "Error posting LAA Reference to Common Platform" unless response.success?
-  end
-
-  def persist_laa_reference
-    existing_laa_ref = LaaReference.find_by(
-      defendant_id: laa_reference.defendant_id,
-      maat_reference: laa_reference.maat_reference,
-      linked: true,
-    )
-
-    existing_laa_ref.unlink! if existing_laa_ref.present?
-
-    laa_reference.save!
   end
 
   def fetch_past_hearings


### PR DESCRIPTION
## What

This PR:
-  prevents Sidekiq to retries N times the MaatLinkCreator.call.
    It does it because:
    - it ensures that the laa ref is set to unlink, regardless of the defendant_id
    - it captures possible ActiveRecords exceptions and reports them to Sentry

-  prevents retries when CP replies 200 with an empty body.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-1925)

Important: before deploying this, we must remove old jobs from Sidekiq. Ask @alexdesi for the scripts to run.

The changes in this PR have been discussed with @mtac50 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
