### PR TITLE
Show Common Platform response status error in Kibana.

### DIFF
--- a/app/services/common_platform/api/search_prosecution_case.rb
+++ b/app/services/common_platform/api/search_prosecution_case.rb
@@ -3,6 +3,8 @@
 module CommonPlatform
   module Api
     class SearchProsecutionCase < ApplicationService
+      include ActionView::Helpers::SanitizeHelper
+
       def initialize(params)
         @response = ProsecutionCaseSearcher.call(**params)
       end
@@ -32,10 +34,16 @@ module CommonPlatform
 
       def check_response_status
         if response.status != 200
-          message = "body: #{response.body}, status: #{response.status}"
+          message = "Common Platform API status: #{response.status}, body: #{sanitized_response}"
 
           raise CommonPlatform::Api::Errors::FailedDependency, message
         end
+      end
+
+      # In case of error, Common Platform API returns an HTML.
+      # This sanitizes the error message to log, to reduce HTML tag noise
+      def sanitized_response
+        strip_tags(response.body.to_s).strip
       end
 
       attr_reader :response

--- a/spec/services/common_platform/api/search_prosecution_case_spec.rb
+++ b/spec/services/common_platform/api/search_prosecution_case_spec.rb
@@ -60,12 +60,14 @@ RSpec.describe CommonPlatform::Api::SearchProsecutionCase do
 
   context "when the response is not a 200 Success" do
     let(:response_status) { 424 }
-    let(:response_body) { "error message" }
+
+    # NOTE: In case of error, Common Platform API returns an HTML.
+    let(:response_body) { "<html<body>error message<body></html>" }
 
     it "raises FailedDependency exception" do
       expect { search_prosecution_case }.to raise_error(
         CommonPlatform::Api::Errors::FailedDependency,
-        "body: error message, status: 424",
+        "Common Platform API status: 424, body: error message",
       )
     end
   end


### PR DESCRIPTION
## What

Strip all the HTML tags from the reply before logging it.
Move the response status to the first position so it is more visible.


[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2039)
