### PR TITLE
Filter the messages that are sent to the AWS_HEARING_RESULTED_QUEUE_URL

### DIFF
--- a/app/services/common_platform/hearing_results_filter.rb
+++ b/app/services/common_platform/hearing_results_filter.rb
@@ -1,0 +1,20 @@
+module CommonPlatform
+  class HearingResultsFilter < ApplicationService
+    def initialize(hearing_results_body, defendant_id: nil)
+      @body = hearing_results_body.deep_stringify_keys
+      @defendant_id = defendant_id
+    end
+
+    def call
+      return @body unless @defendant_id
+
+      @body["hearing"]["prosecutionCases"] = @body["hearing"]["prosecutionCases"].map do |prosecution_case|
+        prosecution_case.merge(
+          "defendants" => prosecution_case["defendants"].select { |defendant| defendant["id"] == @defendant_id },
+        )
+      end
+
+      @body
+    end
+  end
+end

--- a/app/services/hearing_result_fetcher.rb
+++ b/app/services/hearing_result_fetcher.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class HearingResultFetcher < ApplicationService
-  attr_reader :hearing_id, :sitting_day
+  attr_reader :hearing_id, :sitting_day, :defendant_id
 
-  def initialize(hearing_id, sitting_day)
+  def initialize(hearing_id, sitting_day, defendant_id)
     @hearing_id = hearing_id
     @sitting_day = sitting_day
+    @defendant_id = defendant_id
   end
 
   def call
@@ -17,7 +18,7 @@ class HearingResultFetcher < ApplicationService
     if response.success?
       if response.body.present?
         HearingsCreator.call(
-          hearing_resulted_data: response.body.deep_stringify_keys,
+          hearing_resulted_data: CommonPlatform::HearingResultsFilter.call(response.body, defendant_id: defendant_id),
           queue_url: Rails.configuration.x.aws.sqs_url_hearing_resulted,
         )
       else

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MaatLinkCreator < ApplicationService
-  attr_reader :laa_reference
+  attr_reader :laa_reference, :defendant_id
 
   def initialize(defendant_id, user_name, maat_reference)
     @laa_reference = LaaReference.new(
@@ -9,6 +9,7 @@ class MaatLinkCreator < ApplicationService
       user_name: user_name,
       maat_reference: maat_reference.presence || LaaReference.generate_linking_dummy_maat_reference,
     )
+    @defendant_id = defendant_id
   end
 
   def call
@@ -74,6 +75,7 @@ private
           Current.request_id,
           hearing_summary.id,
           hearing_day.sitting_day,
+          defendant_id,
         )
       end
     end

--- a/app/workers/hearing_result_fetcher_worker.rb
+++ b/app/workers/hearing_result_fetcher_worker.rb
@@ -4,9 +4,9 @@ class HearingResultFetcherWorker
   include Sidekiq::Worker
   sidekiq_options retry: 7 # with exponential backoff, this retries over ~40 minutes
 
-  def perform(request_id, hearing_id, sitting_day)
+  def perform(request_id, hearing_id, sitting_day, defendant_id)
     Current.set(request_id: request_id) do
-      HearingResultFetcher.call(hearing_id, sitting_day)
+      HearingResultFetcher.call(hearing_id, sitting_day, defendant_id)
     end
   end
 end

--- a/spec/services/common_platform/hearing_results_filter_spec.rb
+++ b/spec/services/common_platform/hearing_results_filter_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe CommonPlatform::HearingResultsFilter do
+  describe "#call" do
+    subject(:filter_call) do
+      described_class.new(body, defendant_id: defendant_id).call
+    end
+
+    let(:body) do
+      {
+        "hearing" => {
+          "prosecutionCases" => [
+            {
+              "defendants" => [
+                { "id" => 1, "name" => "Defendant 1" },
+                { "id" => 2, "name" => "Defendant 2" },
+              ],
+            },
+            {
+              "defendants" => [
+                { "id" => 3, "name" => "Defendant 3" },
+              ],
+            },
+          ],
+        },
+      }
+    end
+
+    context "when defendant_id is nil" do
+      let(:defendant_id) { nil }
+
+      it { is_expected.to eq(body) }
+    end
+
+    context "when defendant_id is provided" do
+      let(:defendant_id) { 2 }
+
+      it "filters the defendants by defendant_id" do
+        expect(filter_call).to eq(
+          {
+            "hearing" => {
+              "prosecutionCases" => [
+                {
+                  "defendants" => [
+                    { "id" => 2, "name" => "Defendant 2" },
+                  ],
+                },
+                {
+                  "defendants" => [],
+                },
+              ],
+            },
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/services/hearing_result_fetcher_spec.rb
+++ b/spec/services/hearing_result_fetcher_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe HearingResultFetcher do
     described_class.call(
       hearing_id,
       sitting_day,
+      defendant_id,
     )
   end
 
   let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing_resulted.json").read) }
   let(:hearing_id) { hearing_resulted_data["hearing"]["id"] }
   let(:sitting_day) { "2022-12-05" }
+  let(:defendant_id) { hearing_resulted_data["hearing"]["prosecutionCases"].first["defendants"].first["id"] }
 
   let(:response) do
     instance_double(

--- a/spec/workers/hearing_result_fetcher_worker_spec.rb
+++ b/spec/workers/hearing_result_fetcher_worker_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe HearingResultFetcherWorker, type: :worker do
       "XYZ",
       "99c753e2-9c89-4c1a-b191-4f73084721b4",
       "2022-11-05",
+      nil,
     )
   end
 
@@ -32,6 +33,7 @@ RSpec.describe HearingResultFetcherWorker, type: :worker do
         .with(
           "99c753e2-9c89-4c1a-b191-4f73084721b4",
           "2022-11-05",
+          nil,
         )
 
       fetch_hearing_result


### PR DESCRIPTION
## What
Filter the messages that are sent to the AWS_HEARING_RESUTTED_QUEUE_URL queue defendant_id.

I've added a new class to filter out the defendants that are not relevant.

## Why

Context is provided in the ticket: [Link to story](https://dsdmoj.atlassian.net/browse/LASB-1946)


## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ x] You should have checked that the commit messages say why the change was made.
