### PR TITLE
Fix Brakeman in the github action pipeline.

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -4,10 +4,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Brakeman
-      uses: devmasx/brakeman-linter-action@v1.0.0
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+    - run: gem install brakeman --version 6
+    - run: brakeman
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## What
Brakeman doesn't work in github action pipeline.
Cause of failures: a new version of Brakeman has been released, and it supports only ruby ver. >= 3, but brakeman-linter-action (which is based on 2.6.5-alpine) uses ruby 2.6.5 .

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2068)

