### PR TITLE
Lasb 2034 add missing rspec to test SQS messages

### DIFF
--- a/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
@@ -8,12 +8,12 @@ module Api
           prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
             laa_reference = LaaReference.find_by(defendant_id: pc["defendantId"], linked: true)
 
-            if laa_reference
-              Sqs::MessagePublisher.call(
-                message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
-                queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
-              )
-            end
+            next unless laa_reference
+
+            Sqs::MessagePublisher.call(
+              message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
+              queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+            )
           end
 
           head :accepted

--- a/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
@@ -8,12 +8,12 @@ module Api
           prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
             laa_reference = LaaReference.find_by(defendant_id: pc["defendantId"], linked: true)
 
-            if laa_reference
-              Sqs::MessagePublisher.call(
-                message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
-                queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
-              )
-            end
+            next unless laa_reference
+
+            Sqs::MessagePublisher.call(
+              message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
+              queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+            )
           end
 
           head :accepted

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -90,7 +90,32 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service once" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a888", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
+        expect(Sqs::MessagePublisher).to receive(:call).once do |arg|
+          expect(arg).to include(
+            queue_url: "url",
+          )
+
+          expect(arg[:message]).to include(
+            maatId: 123,
+            caseUrn: "12345",
+            caseCreationDate: "2018-10-25",
+          )
+
+          expect(arg[:message].keys).to include(
+            :maatId,
+            :caseUrn,
+            :jurisdictionType,
+            :cjsAreaCode,
+            :caseCreationDate,
+            :cjsLocation,
+            :docLanguage,
+            :proceedingsConcluded,
+            :inActive,
+            :functionType,
+            :defendant,
+            :session,
+          )
+        end
 
         create_hearings
       end
@@ -200,7 +225,30 @@ RSpec.describe HearingsCreator do
       it "calls the Sqs::MessagePublisher service once" do
         LaaReference.create!(defendant_id: "dd22b110-7fbc-3036-a076-e4bb40d0a666", linked: true, maat_reference: "123", user_name: "Bob")
 
-        expect(Sqs::MessagePublisher).to receive(:call).once.with(hash_including(queue_url: "url"))
+        expect(Sqs::MessagePublisher).to receive(:call).once do |arg|
+          expect(arg).to include(
+            queue_url: "url",
+          )
+
+          expect(arg[:message]).to include(
+            maatId: 123,
+            caseCreationDate: "2018-10-25",
+          )
+
+          expect(arg[:message].keys).to include(
+            :maatId,
+            :jurisdictionType,
+            :cjsAreaCode,
+            :caseCreationDate,
+            :cjsLocation,
+            :docLanguage,
+            :proceedingsConcluded,
+            :inActive,
+            :functionType,
+            :defendant,
+            :session,
+          )
+        end
 
         create_hearings
       end

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -69,7 +69,15 @@ RSpec.describe MaatLinkCreator do
       .once.with(hash_including(application_reference: "12345678"))
       .and_return(response)
 
-    expect(Sqs::MessagePublisher).to receive(:call).once
+    expect(Sqs::MessagePublisher).to receive(:call).once do |arg|
+      expect(arg[:message]).to include(
+        asn: "ARREST123",
+        caseUrn: "20GD0217100",
+        cjsAreaCode: "1",
+        cjsLocation: "B01LY",
+        createdUser: "bob-smith",
+      )
+    end
 
     create_maat_link
   end


### PR DESCRIPTION
## What

Add missing rspec to test that **HearingsCreator** and **MaatLinkCreator** publish the proper messages to SQS.
[Link to story](https://dsdmoj.atlassian.net/browse/Lasb2034)

