### PR TITLE
LABS-2037: Improve logging for SQS in Kibana and add maat_reference

### DIFF
--- a/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
@@ -13,6 +13,7 @@ module Api
             Sqs::MessagePublisher.call(
               message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+              log_info: { maat_reference: laa_reference.maat_reference },
             )
           end
 

--- a/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
@@ -13,6 +13,7 @@ module Api
             Sqs::MessagePublisher.call(
               message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+              log_info: { maat_reference: laa_reference.maat_reference },
             )
           end
 

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -36,6 +36,7 @@ private
         Sqs::MessagePublisher.call(
           message: MaatApi::Message.new(maat_api_prosecution_case).generate,
           queue_url: queue_url,
+          log_info: { maat_reference: laa_reference.maat_reference },
         )
       end
     end
@@ -57,6 +58,7 @@ private
         Sqs::MessagePublisher.call(
           message: MaatApi::Message.new(maat_api_court_application).generate,
           queue_url: queue_url,
+          log_info: { maat_reference: laa_reference.maat_reference },
         )
       end
     end

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -31,6 +31,7 @@ private
         otherReasonText: unlink_other_reason_text,
       },
       queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+      log_info: { maat_reference: laa_reference.maat_reference },
     )
   end
 

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -33,6 +33,7 @@ private
     Sqs::MessagePublisher.call(
       message: MaatApi::LaaReferenceMessage.new(maat_api_laa_reference).generate,
       queue_url: Rails.configuration.x.aws.sqs_url_link,
+      log_info: { maat_reference: laa_reference.maat_reference },
     )
   end
 

--- a/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "api/external/v1/prosecution_conclusions", type: :request, swagge
             .with(
               message: expected_message,
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+              log_info: { maat_reference: "700111" },
             )
         end
 

--- a/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "api/external/v2/prosecution_conclusions", type: :request, swagge
             .with(
               message: expected_message,
               queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+              log_info: { maat_reference: "700111" },
             )
         end
 

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe HearingsCreator do
             :defendant,
             :session,
           )
+
+          expect(arg[:log_info]).to include(
+            maat_reference: "123",
+          )
         end
 
         create_hearings

--- a/spec/services/laa_reference_unlinker_spec.rb
+++ b/spec/services/laa_reference_unlinker_spec.rb
@@ -43,7 +43,11 @@ RSpec.describe LaaReferenceUnlinker do
 
     expect(Sqs::MessagePublisher).to receive(:call)
       .once
-      .with(message: message, queue_url: Rails.configuration.x.aws.sqs_url_unlink)
+      .with(
+        message: message,
+        queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+        log_info: { maat_reference: "101010" },
+      )
 
     create_unlinker
   end
@@ -66,7 +70,11 @@ RSpec.describe LaaReferenceUnlinker do
 
       expect(Sqs::MessagePublisher).to receive(:call)
         .once
-        .with(message: message, queue_url: Rails.configuration.x.aws.sqs_url_unlink)
+        .with(
+          message: message,
+          queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+          log_info: { maat_reference: message[:maatId] },
+        )
 
       create_unlinker
     end

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe MaatLinkCreator do
         cjsLocation: "B01LY",
         createdUser: "bob-smith",
       )
+
+      expect(arg[:log_info]).to include(
+        maat_reference: "12345678",
+      )
     end
 
     create_maat_link


### PR DESCRIPTION
## What

This PR adds support for additional params for the SQS logging on Kibana.
Log maat_reference to the log on publish messages.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB2037)

