### PR TITLE
Configure Sentry to record 5% of the transactions.

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,5 +3,8 @@ if ENV["SENTRY_DSN"].present?
     config.sample_rate = 0.05
     config.dsn = ENV["SENTRY_DSN"]
     config.breadcrumbs_logger = [:active_support_logger]
+
+    # Approximately 5% of the transactions will get recorded by Sentry
+    config.traces_sample_rate = 0.05
   end
 end


### PR DESCRIPTION
## What
To have an accurate view of the slow API calls, we need to activate "Sentry performance" to track the slow calls and the associated parameters.

Configure Sentry to record Approximately 10% of the transactions.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2119)

No data for CDA:
<img width="1006" alt="Screenshot 2023-06-21 at 17 21 12" src="https://github.com/ministryofjustice/laa-court-data-adaptor/assets/58971/44c72bb9-5fa5-4f2c-a106-e85387ff36c7">

It is active on VCD:
![Uploading Screenshot 2023-06-21 at 17.23.12.png…]()
