### PR TITLE
LASB-2170: Fix search for LaaReference in unlink.

### DIFF
--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -7,14 +7,12 @@ class LaaReferenceUnlinker < ApplicationService
     @unlink_reason_code = unlink_reason_code
     @unlink_other_reason_text = unlink_other_reason_text
 
-    @laa_reference = LaaReference.find_by(defendant_id: defendant_id)
-
-    unless laa_reference.linked
-      Rails.logger.warn("LaaReferenceUnlinker: the defendant '#{defendant_id}' is already unlinked.")
-    end
+    @laa_reference = LaaReference.find_by(defendant_id: defendant_id, linked: true)
   end
 
   def call
+    return unless laa_reference
+
     push_to_queue unless laa_reference.dummy_maat_reference?
     update_offences_on_common_platform
     unlink_maat_reference!

--- a/spec/services/laa_reference_unlinker_spec.rb
+++ b/spec/services/laa_reference_unlinker_spec.rb
@@ -44,15 +44,13 @@ RSpec.describe LaaReferenceUnlinker do
     expect(linked_laa_reference.reload).not_to be_linked
   end
 
-  context "when LaaReference is unlinked" do
+  context "when LaaReference is already unlinked" do
     before do
       linked_laa_reference.update(linked: false)
     end
 
     it "logs a 'already unlinked' warning message" do
-      create_unlinker
-
-      expect(Rails.logger).to have_received(:warn)
+      expect(create_unlinker).to eq(nil)
     end
   end
 


### PR DESCRIPTION
## What
The error is explained here
[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2170:)

Now the LaaReference search only for defendant_id thatare linked.
