### PR TITLE
Fix bug on Defendant serializer when the option include was used.

### DIFF
--- a/app/models/hmcts_common_platform/prosecution_case.rb
+++ b/app/models/hmcts_common_platform/prosecution_case.rb
@@ -16,6 +16,10 @@ module HmctsCommonPlatform
       prosecution_case_identifier.case_urn
     end
 
+    def prosecution_case_reference
+      urn
+    end
+
     def prosecution_case_identifier
       HmctsCommonPlatform::ProsecutionCaseIdentifier.new(data[:prosecutionCaseIdentifier])
     end

--- a/app/serializers/api/internal/v1/prosecution_case_serializer.rb
+++ b/app/serializers/api/internal/v1/prosecution_case_serializer.rb
@@ -7,7 +7,7 @@ module Api
         include JSONAPI::Serializer
         set_type :prosecution_cases
 
-        attribute :prosecution_case_reference, &:urn
+        attribute :prosecution_case_reference
 
         has_many :defendants, record_type: :defendants
       end


### PR DESCRIPTION
## What
The V1 Defendant serializer triggers an error when `include` (the json-api option) is used in the API.

Fixed.
