### PR TITLE
LASB-3086: Replace aws-ecr executor with default machine image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
           command: bundle exec rubocop
 
   build-and-push-app:
-    executor: aws-ecr/default
+    machine:
+      image: default
     steps:
       - checkout
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3086)

- [x] Removed the use of the aws-ecr executor as this was using an outdated machine image.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
