### PR TITLE
Remove use of custom method to determine empty array.

### DIFF
--- a/app/services/common_platform/api/search_prosecution_case.rb
+++ b/app/services/common_platform/api/search_prosecution_case.rb
@@ -17,49 +17,41 @@ module CommonPlatform
       end
 
       def check_for_blank_defendants(prosecution_cases)
-        if array_not_empty(prosecution_cases)
-          prosecution_cases.each do |prosecution_case|
-            if array_not_empty(prosecution_case["defendantSummary"])
-              prosecution_case["defendantSummary"].each do |defendant|
-                if defendant_is_blank(defendant)
-                  # Add this defendant to an array of empty defendants (we need to also verify they don't have a hearing summary further down)
-                  @blank_defendants.push(defendant["defendantId"])
-                end
-              end
-            end
+        return if prosecution_cases.nil?
 
-            remove_defendant_with_hearing_summary_from_blank_defendants(prosecution_case["hearingSummary"])
-            log_error_for_blank_defendants
+        prosecution_cases.each do |prosecution_case|
+          prosecution_case["defendantSummary"]&.each do |defendant|
+            if defendant_is_blank(defendant)
+              # Add this defendant to an array of empty defendants (we need to also verify they don't have a hearing summary further down)
+              @blank_defendants.push(defendant["defendantId"])
+            end
           end
+
+          remove_defendant_with_hearing_summary_from_blank_defendants(prosecution_case["hearingSummary"])
+          log_error_for_blank_defendants
         end
       end
 
       def remove_defendant_with_hearing_summary_from_blank_defendants(hearing_summaries)
-        if array_not_empty(hearing_summaries)
-          hearing_summaries.each do |hearing_summary|
-            hearing_summary["defendantIds"].each do |defendant_id|
-              # If this defendant_id matches one of the blank defendants already found
-              if @blank_defendants.try(:include?, defendant_id)
-                # Remove them from the blank defendants array
-                @blank_defendants.delete(defendant_id)
-              end
+        return if hearing_summaries.nil?
+
+        hearing_summaries.each do |hearing_summary|
+          hearing_summary["defendantIds"].each do |defendant_id|
+            # If this defendant_id matches one of the blank defendants already found
+            if @blank_defendants.try(:include?, defendant_id)
+              # Remove them from the blank defendants array
+              @blank_defendants.delete(defendant_id)
             end
           end
         end
       end
 
       def log_error_for_blank_defendants
-        if array_not_empty(@blank_defendants)
-          @blank_defendants.each do |blank_defendant|
-            Rails.logger.error("The defendant with the defendantId [#{blank_defendant}] is blank (missing defendantFirstName, defendantLastName, defendantDOB, defendantNINO and hearingSummary)")
-            # Send an alert to sentry
-            Sentry.capture_message("The defendant with the defendantId [#{blank_defendant}] is blank (missing defendantFirstName, defendantLastName, defendantDOB, defendantNINO and hearingSummary)")
-          end
+        @blank_defendants.each do |blank_defendant|
+          Rails.logger.error("The defendant with the defendantId [#{blank_defendant}] is blank (missing defendantFirstName, defendantLastName, defendantDOB, defendantNINO and hearingSummary)")
+          # Send an alert to sentry
+          Sentry.capture_message("The defendant with the defendantId [#{blank_defendant}] is blank (missing defendantFirstName, defendantLastName, defendantDOB, defendantNINO and hearingSummary)")
         end
-      end
-
-      def array_not_empty(array)
-        array.present?
       end
 
       def defendant_is_blank(defendant)


### PR DESCRIPTION
## What
This is a small refactor, not linked to any ticket.
It remove the redundant method `array_not_empty(array)`.
It adds a couple of guard condition, and remove the reduntand check for @blank_defendants.


## Checklist

Before you ask people to review this PR:

- [x ] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
