### PR TITLE
ACD-433: Add applicationSummary on SearchProsecutionCase.

### DIFF
--- a/app/controllers/api/internal/v2/defendants_controller.rb
+++ b/app/controllers/api/internal/v2/defendants_controller.rb
@@ -5,7 +5,7 @@ module Api
     module V2
       class DefendantsController < ApplicationController
         def show
-          response_data = CommonPlatform::Api::ProsecutionCaseSearcher.call(
+          response_data = CommonPlatform::Api::ProsecutionCaseFetcher.call(
             prosecution_case_reference: params[:prosecution_case_reference],
           ).body
 

--- a/app/models/hmcts_common_platform/application_summary.rb
+++ b/app/models/hmcts_common_platform/application_summary.rb
@@ -1,0 +1,40 @@
+module HmctsCommonPlatform
+  class ApplicationSummary
+    attr_accessor :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def id
+      data[:applicationId]
+    end
+
+    def reference
+      data[:applicationReference]
+    end
+
+    def title
+      data[:applicationTitle]
+    end
+
+    def received_date
+      data[:receivedDate]
+    end
+
+    def to_json(*_args)
+      to_builder.attributes!
+    end
+
+  private
+
+    def to_builder
+      Jbuilder.new do |application_summary|
+        application_summary.id id
+        application_summary.reference reference
+        application_summary.title title
+        application_summary.received_date received_date
+      end
+    end
+  end
+end

--- a/app/models/hmcts_common_platform/prosecution_case_summary.rb
+++ b/app/models/hmcts_common_platform/prosecution_case_summary.rb
@@ -26,6 +26,12 @@ module HmctsCommonPlatform
       end
     end
 
+    def application_summaries
+      Array(data[:applicationSummary]).map do |application_summary_data|
+        HmctsCommonPlatform::ApplicationSummary.new(application_summary_data)
+      end
+    end
+
     def to_json(*_args)
       to_builder.attributes!
     end
@@ -38,6 +44,7 @@ module HmctsCommonPlatform
         case_summary.case_status case_status
         case_summary.defendant_summaries defendant_summaries.map(&:to_json)
         case_summary.hearing_summaries hearing_summaries.map(&:to_json)
+        case_summary.application_summaries application_summaries.map(&:to_json)
       end
     end
   end

--- a/app/services/common_platform/api/prosecution_case_fetcher.rb
+++ b/app/services/common_platform/api/prosecution_case_fetcher.rb
@@ -2,7 +2,7 @@
 
 module CommonPlatform
   module Api
-    class ProsecutionCaseSearcher < ApplicationService
+    class ProsecutionCaseFetcher < ApplicationService
       URL = "prosecutionCases"
       def initialize(prosecution_case_reference: nil,
                      national_insurance_number: nil,

--- a/app/services/common_platform/api/search_prosecution_case.rb
+++ b/app/services/common_platform/api/search_prosecution_case.rb
@@ -6,7 +6,7 @@ module CommonPlatform
       include ActionView::Helpers::SanitizeHelper
 
       def initialize(params)
-        @response = ProsecutionCaseSearcher.call(**params)
+        @response = ProsecutionCaseFetcher.call(**params)
         @blank_defendants = []
       end
 

--- a/lib/schemas/global/search/apiApplicationSummary.json
+++ b/lib/schemas/global/search/apiApplicationSummary.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://justice.gov.uk/core/courts/search/external/apiApplicationSummary.json",
+  "description": "An Application Summary",
+  "type": "object",
+  "properties": {
+    "applicationId": {
+      "description": "The identifier of the application",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+    },
+    "applicationReference": {
+      "description": "The reference of the application",
+      "type": "string"
+    },
+    "applicationTitle": {
+      "description": "The title of the application",
+      "type": "string"
+    },
+    "receivedDate": {
+      "description": "The date the application was received",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    }
+  }
+}

--- a/lib/schemas/global/search/apiProsecutionCaseSummary.json
+++ b/lib/schemas/global/search/apiProsecutionCaseSummary.json
@@ -30,6 +30,14 @@
             "items": {
                 "$ref": "http://justice.gov.uk/core/courts/search/external/apiHearingSummary.json"
             }
+        },
+        "applicationSummary": {
+            "description": "The application summary for the prosecution case",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "http://justice.gov.uk/core/courts/search/external/apiApplicationSummary.json"
+            }
         }
     },
     "required": [

--- a/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success_v2.yml
+++ b/spec/cassettes/search_prosecution_case/by_prosecution_case_reference_success_v2.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=61GD7528225"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      User-Agent:
+      - Faraday v2.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2800'
+      Content-Type:
+      - application/vnd.unifiedsearch.query.laa.cases+json
+      Cppid:
+      - 848f2aca-08c3-4a38-8e3f-00c474fd044b
+      X-Envoy-Upstream-Service-Time:
+      - '504'
+      Request-Context:
+      - appId=cid-v1:97ed2df6-563c-48a2-ba7c-686e72fc0e4d
+      Date:
+      - Thu, 20 Mar 2025 15:55:19 GMT
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"cases":[{"caseStatus":"ACTIVE","prosecutionCaseId":"6fc1f2cb-4a93-4116-84db-f87cc86ec3b8","prosecutionCaseReference":"61GD7528225","defendantSummary":[{"organisationName":"HMCTS","proceedingsConcluded":false,"representationOrder":{"applicationReference":"LAA-20191601","effectiveFromDate":"2024-09-12","effectiveToDate":"2025-12-12","laaContractNumber":"80012345679"},"defendantId":"cfc4281f-cdea-494d-8179-3173d30736fd","masterDefendantId":"cfc4281f-cdea-494d-8179-3173d30736fd","offenceSummary":[{"offenceId":"997ba1dd-e1e2-46cb-ad4d-2c570af869cd","offenceCode":"TW01040","offenceTitle":"Fail
+        to carry an animal on a moving escalator on the Tyne and Wear Metro","offenceLegislation":"Contrary
+        to byelaw 16(6) and 31(1) of the Tyne and Wear Metro Byelaws made under sections
+        58 and 62 of the Tyneside Metropolitan Railway Act 1973.","proceedingsConcluded":false,"arrestDate":"2015-11-19","startDate":"2004-12-09","chargeDate":"2006-05-30","modeOfTrial":"Summary","orderIndex":551,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{"applicationReference":"SECOND-REF-TEST001","statusId":"98e86937-9652-32a3-a9fb-dbd01eda86a5","statusCode":"GRM","statusDescription":"Granted
+        (One Advocate)(Magistrates court jurisdiction)"},"plea":[]},{"offenceId":"9085871a-797b-4ab8-8072-05ca6deeaac9","offenceCode":"TW01046","offenceTitle":"Occupy
+        reserved seat / berth without a valid ticket on the Tyne and Wear Metro","offenceLegislation":"Contrary
+        to byelaw 19 and 31(1) of the Tyne and Wear Metro Byelaws made under sections
+        58 and 62 of the Tyneside Metropolitan Railway Act 1973.","proceedingsConcluded":false,"arrestDate":"2004-12-09","startDate":"2014-02-09","chargeDate":"2014-02-09","modeOfTrial":"Summary","orderIndex":502,"wording":"Has
+        a violent past and fear that he will commit further offences and\n                interfere
+        with witnesse","laaApplnReference":{},"plea":[]}]}],"hearingSummary":[{"hearingId":"0c401e0d-9d88-4cb8-8543-2090782edd32","jurisdictionType":"MAGISTRATES","defendantIds":["664ee07b-ac43-43ed-8abe-d4eb04459a6c","cfc4281f-cdea-494d-8179-3173d30736fd"],"hearingDays":[{"sittingDay":"2025-02-18T09:01:01.001Z","listingSequence":0,"listedDurationMinutes":20}],"courtCentre":{"id":"f8254db1-1683-483e-afb3-b87fde5a0a26","name":"Lavender
+        Hill Magistrates'' Court","roomId":"9e4932f7-97b2-3010-b942-ddd2624e4dd8","roomName":"Courtroom
+        01","code":"B01LY00"},"hearingType":{"id":"4a0e892d-c0c5-3c51-95b8-704d8c781776","description":"First
+        hearing"},"defenceCounsel":[]}],"applicationSummary":[{"applicationId":"0d20f357-8a08-4d73-a7c9-3a16f6b97ba3","applicationReference":"61GD7528225","receivedDate":"2025-02-13","applicationTitle":"Application
+        for a witness summons"}]}]}'
+  recorded_at: Thu, 20 Mar 2025 15:55:19 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/search_prosecution_case/server_error.yml
+++ b/spec/cassettes/search_prosecution_case/server_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=19GD1001816"
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=id-for-500-error"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/search_prosecution_case/unauthorised.yml
+++ b/spec/cassettes/search_prosecution_case/unauthorised.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=19GD1001816"
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases?prosecutionCaseReference=id-for-401-error"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/files/application_summary/all_fields.json
+++ b/spec/fixtures/files/application_summary/all_fields.json
@@ -1,0 +1,6 @@
+{
+  "applicationId": "6cd6494e-5409-420a-bd0b-f589dbb2466b",
+  "applicationReference": "CJ03511",
+  "applicationTitle": "Conviction of an offence while a community order is in force",
+  "receivedDate": "2024-12-15"
+}

--- a/spec/fixtures/files/prosecution_case_search_result_with_application_summary.json
+++ b/spec/fixtures/files/prosecution_case_search_result_with_application_summary.json
@@ -1,0 +1,495 @@
+
+{
+  "totalResults": 2,
+  "cases": [
+    {
+      "caseStatus": "ACTIVE",
+      "prosecutionCaseId": "c6d1a77f-1ff7-461b-86e4-ee89da0aa309",
+      "prosecutionCaseReference": "CPS186472",
+      "defendantSummary": [
+        {
+          "organisationName": "",
+          "proceedingsConcluded": true,
+          "representationOrder": {
+            "applicationReference": "LAA REF 809",
+            "effectiveFromDate": "2025-01-07",
+            "laaContractNumber": "LAA CONTRACT NUMBER 728"
+          },
+          "defendantId": "099664fa-555e-460f-8e97-20b99daaa442",
+          "defendantASN": "ASN 1144",
+          "defendantFirstName": "",
+          "defendantMiddleName": "",
+          "defendantLastName": "last1",
+          "offenceSummary": [
+            {
+              "offenceId": "68c9e312-b002-44f6-92a7-78f6252ac2f3",
+              "offenceCode": "OFFENCE CODE 611",
+              "offenceTitle": "OFFENCE TITLE 747",
+              "offenceLegislation": "OFFENCE LEGISLATION 854",
+              "proceedingsConcluded": true,
+              "arrestDate": "2024-11-08",
+              "dateOfInformation": "2024-10-09",
+              "endDate": "2024-10-22",
+              "startDate": "2024-11-09",
+              "chargeDate": "2024-10-22",
+              "modeOfTrial": "CROWN",
+              "orderIndex": 1,
+              "wording": "OFFENCE WORDING 813",
+              "verdict": {
+                "originatingHearingId": "0430605a-d6d3-4476-b1f0-8328b11726ae",
+                "verdictDate": "2019-01-01",
+                "verdictType": {
+                  "verdictTypeId": "c4d0986a-e82d-4890-bef1-3afb16c7d0bd",
+                  "sequence": 1,
+                  "categoryType": "CategoryType",
+                  "category": "Category",
+                  "description": "Description"
+                }
+              },
+              "laaApplnReference": {
+                "applicationReference": "LAA REF 245",
+                "statusId": "2058d5d8-1a75-4e8f-80c7-d86061934692",
+                "statusCode": "194",
+                "statusDescription": "LAA STATUS CODE 4"
+              },
+              "plea": [
+                {
+                  "originatingHearingId": "58fcfd11-41bc-48ba-b8a8-30ea5955b384",
+                  "pleaDate": "2025-01-08",
+                  "pleaValue": "Plea value 6"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "organisationName": "MOJ",
+          "proceedingsConcluded": false,
+          "representationOrder": {
+            "applicationReference": "LAA REF 466",
+            "effectiveFromDate": "2024-11-18",
+            "laaContractNumber": "LAA CONTRACT NUMBER 977"
+          },
+          "defendantId": "c4b7d054-c3eb-4cf3-9e30-80b627d1268c",
+          "defendantASN": "ASN 1759",
+          "defendantFirstName": "Joe",
+          "defendantMiddleName": "Sam",
+          "defendantLastName": "Doe",
+          "offenceSummary": [
+            {
+              "offenceId": "8c4e1c30-f6bd-4c06-9252-c6ef2ea499ab",
+              "offenceCode": "OFFENCE CODE 299",
+              "offenceTitle": "OFFENCE TITLE 363",
+              "offenceLegislation": "OFFENCE LEGISLATION 537",
+              "proceedingsConcluded": false,
+              "arrestDate": "2024-10-13",
+              "dateOfInformation": "2024-11-04",
+              "endDate": "2024-10-12",
+              "startDate": "2024-11-06",
+              "chargeDate": "2024-12-09",
+              "modeOfTrial": "CROWN",
+              "orderIndex": 1,
+              "wording": "OFFENCE WORDING 617",
+              "verdict": {
+                "originatingHearingId": "a030b74c-542a-40a4-9513-c60c70ba82ec",
+                "verdictDate": "2019-01-01",
+                "verdictType": {
+                  "verdictTypeId": "6de8fb9c-8b82-4e98-995d-49543ee5a130",
+                  "sequence": 1,
+                  "categoryType": "CategoryType",
+                  "category": "Category",
+                  "description": "Description"
+                }
+              },
+              "laaApplnReference": {
+                "applicationReference": "LAA REF 286",
+                "statusId": "f4d1934c-0395-4c3e-8cba-6a9b59789301",
+                "statusCode": "577",
+                "statusDescription": "LAA STATUS CODE 4"
+              },
+              "plea": [
+                {
+                  "originatingHearingId": "a90f5972-d044-4b31-b1ba-2016be37be87",
+                  "pleaDate": "2025-01-11",
+                  "pleaValue": "Plea value 0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hearingSummary": [
+        {
+          "hearingId": "a5167d9b-c31f-4342-be35-798a04b86f86",
+          "jurisdictionType": "19fef8fc-15d3-4e09-9f30-e5676f60a81e",
+          "defendantIds": [
+            "8a22e212-4a43-40a3-bd99-6fbba86bd066",
+            "ad9caacf-9833-47fc-b51a-65d955f083a5"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2019-04-19T12:00:00",
+              "listingSequence": 15,
+              "listedDurationMinutes": 615,
+              "hasSharedResults": true
+            },
+            {
+              "sittingDay": "2019-03-01T09:00:00",
+              "listingSequence": 1,
+              "listedDurationMinutes": 206,
+              "hasSharedResults": true
+            }
+          ],
+          "estimatedDuration": "20 Minutes",
+          "courtCentre": {
+            "id": "399fd3e4-5231-4d88-9005-314f81456a6d",
+            "name": "Exeter Crown Court",
+            "roomId": "2f66d789-87c1-45a3-b841-410558c8ee7d",
+            "roomName": "Courtroom 4",
+            "welshName": "Courtroom 1",
+            "welshRoomName": "Courtroom 4",
+            "address": {
+              "address1": "44 Noel Avenue",
+              "address2": "Southampton",
+              "address3": "Utah",
+              "postCode": "NW22 25SW"
+            },
+            "code": "COURT CENTRE CODE  5"
+          },
+          "hearingType": {
+            "id": "aaf3379d-d6a8-4380-8e1d-626a763da14f",
+            "code": "HEARING TYPE CODE  5",
+            "description": "Trial"
+          },
+          "defenceCounsel": [
+            {
+              "id": "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+              "title": "Mr",
+              "firstName": "johnny",
+              "lastName": "robber",
+              "defendants": [
+                "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+                "2ffa8961-58a3-4352-a87d-09aa45f68c8f"
+              ],
+              "attendanceDays": [
+                "2019-01-01"
+              ]
+            }
+          ]
+        },
+        {
+          "hearingId": "adb1dbf4-79e4-4642-a006-b502eba1738c",
+          "jurisdictionType": "d43fe1af-9c0f-4510-a9a6-764b69e21b5c",
+          "defendantIds": [
+            "b36f0a87-6a76-435b-af3f-747eddd1370f",
+            "baee5932-94ef-4aaf-a257-7a52dc968586"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2019-04-24T09:00:00",
+              "listingSequence": 27,
+              "listedDurationMinutes": 658,
+              "hasSharedResults": true
+            },
+            {
+              "sittingDay": "2019-04-19T13:00:00",
+              "listingSequence": 20,
+              "listedDurationMinutes": 537,
+              "hasSharedResults": true
+            }
+          ],
+          "estimatedDuration": "20 Minutes",
+          "courtCentre": {
+            "id": "703a3a57-62cf-421d-9261-96248ac50ea9",
+            "name": "Birmingham Crown Court",
+            "roomId": "bf5175a4-3bfc-4793-84a6-30da75f2117b",
+            "roomName": "Courtroom 3",
+            "welshName": "Courtroom 3",
+            "welshRoomName": "Courtroom 5",
+            "address": {
+              "address1": "137 Legion Street",
+              "address2": "London",
+              "address3": "Nebraska",
+              "postCode": "OX62 29NW"
+            },
+            "code": "COURT CENTRE CODE  5"
+          },
+          "hearingType": {
+            "id": "aaf3379d-d6a8-4380-8e1d-626a763da14f",
+            "code": "HEARING TYPE CODE 1",
+            "description": "Trial"
+          },
+          "defenceCounsel": [
+            {
+              "id": "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+              "title": "Mr",
+              "firstName": "johnny",
+              "lastName": "robber",
+              "defendants": [
+                "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+                "2ffa8961-58a3-4352-a87d-09aa45f68c8f"
+              ],
+              "attendanceDays": [
+                "2019-01-01"
+              ]
+            }
+          ]
+        }
+      ],
+      "applicationSummary": [
+        {
+          "applicationId": "62158b87-56fc-43cc-bbdc-d957d372420f",
+          "applicationReference": "CJ03512",
+          "applicationType": "Application to amend a community order on change of residence",
+          "applicationStatus": "EJECTED",
+          "applicationExternalCreatorType": "PROSECUTOR",
+          "receivedDate": "2024-12-21",
+          "decisionDate": "2025-02-11",
+          "dueDate": "2025-01-27"
+        }
+      ]
+    },
+    {
+      "caseStatus": "ACTIVE",
+      "prosecutionCaseId": "1ba707e7-e28f-4ad6-9055-e056ccca3aee",
+      "prosecutionCaseReference": "TFL204279",
+      "defendantSummary": [
+        {
+          "organisationName": "",
+          "proceedingsConcluded": true,
+          "representationOrder": {
+            "applicationReference": "LAA REF 295",
+            "effectiveFromDate": "2024-12-10",
+            "laaContractNumber": "LAA CONTRACT NUMBER 265"
+          },
+          "defendantId": "dcdc5e5e-f8a6-4387-b048-829713f09749",
+          "defendantASN": "ASN 4246",
+          "defendantFirstName": "",
+          "defendantMiddleName": "",
+          "defendantLastName": "last3",
+          "offenceSummary": [
+            {
+              "offenceId": "d18a750e-9e31-4bd9-92cc-f699d214a6c3",
+              "offenceCode": "OFFENCE CODE 953",
+              "offenceTitle": "OFFENCE TITLE 291",
+              "offenceLegislation": "OFFENCE LEGISLATION 248",
+              "proceedingsConcluded": false,
+              "arrestDate": "2024-11-02",
+              "dateOfInformation": "2024-10-09",
+              "endDate": "2024-12-12",
+              "startDate": "2024-11-16",
+              "chargeDate": "2024-12-18",
+              "modeOfTrial": "CROWN",
+              "orderIndex": 1,
+              "wording": "OFFENCE WORDING 157",
+              "verdict": {
+                "originatingHearingId": "73211702-7822-4b1d-b38c-1e2132c2c1df",
+                "verdictDate": "2019-01-01",
+                "verdictType": {
+                  "verdictTypeId": "bafc3516-c01d-4b1a-a6dd-0304e98debee",
+                  "sequence": 1,
+                  "categoryType": "CategoryType",
+                  "category": "Category",
+                  "description": "Description"
+                }
+              },
+              "laaApplnReference": {
+                "applicationReference": "LAA REF 604",
+                "statusId": "92703440-4953-4c68-a9fd-ec9a59e6afcc",
+                "statusCode": "840",
+                "statusDescription": "LAA STATUS CODE 2"
+              },
+              "plea": [
+                {
+                  "originatingHearingId": "ca53e60b-945c-4d22-916e-0c5930ea621b",
+                  "pleaDate": "2025-01-11",
+                  "pleaValue": "Plea value 7"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "organisationName": "org1",
+          "proceedingsConcluded": true,
+          "representationOrder": {
+            "applicationReference": "LAA REF 221",
+            "effectiveFromDate": "2024-10-23",
+            "laaContractNumber": "LAA CONTRACT NUMBER 61"
+          },
+          "defendantId": "11aaedab-82ab-496c-a2b3-742517c90f88",
+          "defendantASN": "ASN 8447",
+          "defendantFirstName": "",
+          "defendantMiddleName": "",
+          "defendantLastName": "",
+          "offenceSummary": [
+            {
+              "offenceId": "e39a0204-12f7-4f6c-9508-35210600b22d",
+              "offenceCode": "OFFENCE CODE 306",
+              "offenceTitle": "OFFENCE TITLE 875",
+              "offenceLegislation": "OFFENCE LEGISLATION 223",
+              "proceedingsConcluded": false,
+              "arrestDate": "2024-12-20",
+              "dateOfInformation": "2024-11-19",
+              "endDate": "2024-12-23",
+              "startDate": "2024-12-14",
+              "chargeDate": "2025-01-02",
+              "modeOfTrial": "CROWN",
+              "orderIndex": 1,
+              "wording": "OFFENCE WORDING 856",
+              "verdict": {
+                "originatingHearingId": "5574cd68-90e7-45ca-8edb-dbfe6ad40ed1",
+                "verdictDate": "2019-01-01",
+                "verdictType": {
+                  "verdictTypeId": "646f8469-e22c-4938-89f0-f65f7cadd61c",
+                  "sequence": 1,
+                  "categoryType": "CategoryType",
+                  "category": "Category",
+                  "description": "Description"
+                }
+              },
+              "laaApplnReference": {
+                "applicationReference": "LAA REF 392",
+                "statusId": "0b4a5088-6fd7-4bdf-a6ae-0206428616b0",
+                "statusCode": "619",
+                "statusDescription": "LAA STATUS CODE 3"
+              },
+              "plea": [
+                {
+                  "originatingHearingId": "41650266-375e-4cd0-8560-d9d574a2bf9b",
+                  "pleaDate": "2025-01-09",
+                  "pleaValue": "Plea value 4"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "hearingSummary": [
+        {
+          "hearingId": "c399fc48-8b20-4907-897b-be8f4b978a4f",
+          "jurisdictionType": "423ee989-539d-4d28-a1ce-39e3b374a31d",
+          "defendantIds": [
+            "5e0d75bf-7b43-4093-9f44-5edba9664b09",
+            "5b0df259-10c0-4689-8aa1-4b2a20328153"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2019-05-17T11:00:00",
+              "listingSequence": 43,
+              "listedDurationMinutes": 403,
+              "hasSharedResults": true
+            }
+          ],
+          "estimatedDuration": "20 Minutes",
+          "courtCentre": {
+            "id": "170d6af6-e07f-4efb-a560-b7da4858f14e",
+            "name": "Liverpool Magistrates Court",
+            "roomId": "bf5175a4-3bfc-4793-84a6-30da75f2117b",
+            "roomName": "Courtroom 1",
+            "welshName": "Courtroom 4",
+            "welshRoomName": "Courtroom 5",
+            "address": {
+              "address1": "166 Clinton Avenue",
+              "address2": "Guildford",
+              "address3": "Rhode",
+              "address4": "Island",
+              "postCode": "PT54 71PT"
+            },
+            "code": "COURT CENTRE CODE  3"
+          },
+          "hearingType": {
+            "id": "63af1285-36ec-4fe6-a741-43129e0f0710",
+            "code": "HEARING TYPE CODE  4",
+            "description": "Trial"
+          },
+          "defenceCounsel": [
+            {
+              "id": "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+              "title": "Mr",
+              "firstName": "johnny",
+              "lastName": "robber",
+              "defendants": [
+                "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+                "2ffa8961-58a3-4352-a87d-09aa45f68c8f"
+              ],
+              "attendanceDays": [
+                "2019-01-01"
+              ]
+            }
+          ]
+        },
+        {
+          "hearingId": "a5167d9b-c31f-4342-be35-798a04b86f86",
+          "jurisdictionType": "19fef8fc-15d3-4e09-9f30-e5676f60a81e",
+          "defendantIds": [
+            "8a22e212-4a43-40a3-bd99-6fbba86bd066",
+            "ad9caacf-9833-47fc-b51a-65d955f083a5"
+          ],
+          "hearingDays": [
+            {
+              "sittingDay": "2019-04-19T12:00:00",
+              "listingSequence": 15,
+              "listedDurationMinutes": 615,
+              "hasSharedResults": true
+            },
+            {
+              "sittingDay": "2019-03-01T09:00:00",
+              "listingSequence": 1,
+              "listedDurationMinutes": 206,
+              "hasSharedResults": true
+            }
+          ],
+          "estimatedDuration": "20 Minutes",
+          "courtCentre": {
+            "id": "399fd3e4-5231-4d88-9005-314f81456a6d",
+            "name": "Exeter Crown Court",
+            "roomId": "2f66d789-87c1-45a3-b841-410558c8ee7d",
+            "roomName": "Courtroom 4",
+            "welshName": "Courtroom 1",
+            "welshRoomName": "Courtroom 4",
+            "address": {
+              "address1": "44 Noel Avenue",
+              "address2": "Southampton",
+              "address3": "Utah",
+              "postCode": "NW22 25SW"
+            },
+            "code": "COURT CENTRE CODE  5"
+          },
+          "hearingType": {
+            "id": "aaf3379d-d6a8-4380-8e1d-626a763da14f",
+            "code": "HEARING TYPE CODE  5",
+            "description": "Trial"
+          },
+          "defenceCounsel": [
+            {
+              "id": "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+              "title": "Mr",
+              "firstName": "johnny",
+              "lastName": "robber",
+              "defendants": [
+                "2ffa8961-58a3-4352-a87d-09aa45f68c7f",
+                "2ffa8961-58a3-4352-a87d-09aa45f68c8f"
+              ],
+              "attendanceDays": [
+                "2019-01-01"
+              ]
+            }
+          ]
+        }
+      ],
+      "applicationSummary": [
+        {
+          "applicationId": "6cd6494e-5409-420a-bd0b-f589dbb2466b",
+          "applicationReference": "CJ03511",
+          "applicationType": "Conviction of an offence while a community order is in force",
+          "applicationStatus": "IN_PROGRESS",
+          "applicationExternalCreatorType": "PROSECUTOR",
+          "receivedDate": "2024-12-15",
+          "decisionDate": "2025-03-01",
+          "dueDate": "2025-02-06"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/prosecution_case_summary/all_fields.json
+++ b/spec/fixtures/files/prosecution_case_summary/all_fields.json
@@ -140,5 +140,17 @@
         "code": "C30DE00"
       }
     }
+  ],
+  "applicationSummary": [
+    {
+      "applicationId": "62158b87-56fc-43cc-bbdc-d957d372420f",
+      "applicationReference": "CJ03512",
+      "applicationType": "Application to amend a community order on change of residence",
+      "applicationStatus": "EJECTED",
+      "applicationExternalCreatorType": "PROSECUTOR",
+      "receivedDate": "2024-12-21",
+      "decisionDate": "2025-02-11",
+      "dueDate": "2025-01-27"
+    }
   ]
 }

--- a/spec/fixtures/files/prosecution_cases_v2.json
+++ b/spec/fixtures/files/prosecution_cases_v2.json
@@ -1,0 +1,98 @@
+{
+    "totalResults": 1,
+    "cases": [
+        {
+            "caseStatus": "ACTIVE",
+            "prosecutionCaseId": "6fc1f2cb-4a93-4116-84db-f87cc86ec3b8",
+            "prosecutionCaseReference": "61GD7528225",
+            "defendantSummary": [
+                {
+                    "organisationName": "HMCTS",
+                    "proceedingsConcluded": false,
+                    "representationOrder": {
+                        "applicationReference": "LAA-20191601",
+                        "effectiveFromDate": "2024-09-12",
+                        "effectiveToDate": "2025-12-12",
+                        "laaContractNumber": "80012345679"
+                    },
+                    "defendantId": "cfc4281f-cdea-494d-8179-3173d30736fd",
+                    "masterDefendantId": "cfc4281f-cdea-494d-8179-3173d30736fd",
+                    "offenceSummary": [
+                        {
+                            "offenceId": "997ba1dd-e1e2-46cb-ad4d-2c570af869cd",
+                            "offenceCode": "TW01040",
+                            "offenceTitle": "Fail to carry an animal on a moving escalator on the Tyne and Wear Metro",
+                            "offenceLegislation": "Contrary to byelaw 16(6) and 31(1) of the Tyne and Wear Metro Byelaws made under sections 58 and 62 of the Tyneside Metropolitan Railway Act 1973.",
+                            "proceedingsConcluded": false,
+                            "arrestDate": "2015-11-19",
+                            "startDate": "2004-12-09",
+                            "chargeDate": "2006-05-30",
+                            "modeOfTrial": "Summary",
+                            "orderIndex": 551,
+                            "wording": "Has a violent past and fear that he will commit further offences and\n                interfere with witnesse",
+                            "laaApplnReference": {
+                                "applicationReference": "SECOND-REF-TEST001",
+                                "statusId": "98e86937-9652-32a3-a9fb-dbd01eda86a5",
+                                "statusCode": "GRM",
+                                "statusDescription": "Granted (One Advocate)(Magistrates court jurisdiction)"
+                            },
+                            "plea": []
+                        },
+                        {
+                            "offenceId": "9085871a-797b-4ab8-8072-05ca6deeaac9",
+                            "offenceCode": "TW01046",
+                            "offenceTitle": "Occupy reserved seat / berth without a valid ticket on the Tyne and Wear Metro",
+                            "offenceLegislation": "Contrary to byelaw 19 and 31(1) of the Tyne and Wear Metro Byelaws made under sections 58 and 62 of the Tyneside Metropolitan Railway Act 1973.",
+                            "proceedingsConcluded": false,
+                            "arrestDate": "2004-12-09",
+                            "startDate": "2014-02-09",
+                            "chargeDate": "2014-02-09",
+                            "modeOfTrial": "Summary",
+                            "orderIndex": 502,
+                            "wording": "Has a violent past and fear that he will commit further offences and\n                interfere with witnesse",
+                            "laaApplnReference": {},
+                            "plea": []
+                        }
+                    ]
+                }
+            ],
+            "hearingSummary": [
+                {
+                    "hearingId": "0c401e0d-9d88-4cb8-8543-2090782edd32",
+                    "jurisdictionType": "MAGISTRATES",
+                    "defendantIds": [
+                        "664ee07b-ac43-43ed-8abe-d4eb04459a6c",
+                        "cfc4281f-cdea-494d-8179-3173d30736fd"
+                    ],
+                    "hearingDays": [
+                        {
+                            "sittingDay": "2025-02-18T09:01:01.001Z",
+                            "listingSequence": 0,
+                            "listedDurationMinutes": 20
+                        }
+                    ],
+                    "courtCentre": {
+                        "id": "f8254db1-1683-483e-afb3-b87fde5a0a26",
+                        "name": "Lavender Hill Magistrates' Court",
+                        "roomId": "9e4932f7-97b2-3010-b942-ddd2624e4dd8",
+                        "roomName": "Courtroom 01",
+                        "code": "B01LY00"
+                    },
+                    "hearingType": {
+                        "id": "4a0e892d-c0c5-3c51-95b8-704d8c781776",
+                        "description": "First hearing"
+                    },
+                    "defenceCounsel": []
+                }
+            ],
+            "applicationSummary": [
+                {
+                    "applicationId": "0d20f357-8a08-4d73-a7c9-3a16f6b97ba3",
+                    "applicationReference": "61GD7528225",
+                    "receivedDate": "2025-02-13",
+                    "applicationTitle": "Application for a witness summons"
+                }
+            ]
+        }
+    ]
+}

--- a/spec/models/hmcts_common_platform/application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/application_summary_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe HmctsCommonPlatform::ApplicationSummary, type: :model do
+  let(:application_summary) { described_class.new(data) }
+
+  let(:data) { JSON.parse(file_fixture("application_summary/all_fields.json").read) }
+
+  context "with all fields" do
+    it "matches the HMCTS Common Platform schema" do
+      expect(data).to match_json_schema(:application_summary)
+    end
+
+    it { expect(application_summary.id).to eql("6cd6494e-5409-420a-bd0b-f589dbb2466b") }
+    it { expect(application_summary.reference).to eql("CJ03511") }
+    it { expect(application_summary.title).to eql("Conviction of an offence while a community order is in force") }
+    it { expect(application_summary.received_date).to eql("2024-12-15") }
+  end
+
+  describe "#to_json" do
+    it "generates a JSON representation of the data" do
+      json = application_summary.to_json
+
+      expect(json["id"]).to eql("6cd6494e-5409-420a-bd0b-f589dbb2466b")
+      expect(json["reference"]).to eql("CJ03511")
+      expect(json["title"]).to eql("Conviction of an offence while a community order is in force")
+      expect(json["received_date"]).to eql("2024-12-15")
+    end
+  end
+end

--- a/spec/models/hmcts_common_platform/prosecution_case_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/prosecution_case_summary_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe HmctsCommonPlatform::ProsecutionCaseSummary, type: :model do
     it { expect(prosecution_case_summary.case_status).to eq("ACTIVE") }
     it { expect(prosecution_case_summary.defendant_summaries).to all be_an(HmctsCommonPlatform::DefendantSummary) }
     it { expect(prosecution_case_summary.hearing_summaries).to all be_an(HmctsCommonPlatform::HearingSummary) }
+    it { expect(prosecution_case_summary.application_summaries).to all be_an(HmctsCommonPlatform::ApplicationSummary) }
   end
 
   context "with required fields only" do
@@ -37,6 +38,7 @@ RSpec.describe HmctsCommonPlatform::ProsecutionCaseSummary, type: :model do
       expect(json["case_status"]).to eql("ACTIVE")
       expect(json["defendant_summaries"].count).to be(2)
       expect(json["hearing_summaries"].count).to be(2)
+      expect(json["application_summaries"].count).to be(1)
     end
   end
 end

--- a/spec/requests/api/internal/v2/prosecution_cases_spec.rb
+++ b/spec/requests/api/internal/v2/prosecution_cases_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "api/internal/v2/prosecution_case", swagger_doc: "v2/swagger.yaml
         end
 
         let(:Authorization) { "Bearer #{token.token}" }
-        let(:'filter[prosecution_case_reference]') { "19GD1001816" }
-        let(:cassette_name) { "search_prosecution_case/by_prosecution_case_reference_success" }
+        let(:'filter[prosecution_case_reference]') { "61GD7528225" }
+        let(:cassette_name) { "search_prosecution_case/by_prosecution_case_reference_success_v2" }
 
         produces "application/vnd.api+json"
 
@@ -50,6 +50,7 @@ RSpec.describe "api/internal/v2/prosecution_case", swagger_doc: "v2/swagger.yaml
         end
 
         context "when Common Platform API returns Server Error" do
+          let(:'filter[prosecution_case_reference]') { "id-for-500-error" }
           let(:cassette_name) { "search_prosecution_case/server_error" }
 
           response(424, "Common Platform API Error") do

--- a/spec/services/common_platform/api/prosecution_case_fetcher_spec.rb
+++ b/spec/services/common_platform/api/prosecution_case_fetcher_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::ProsecutionCaseSearcher do
-  let(:prosecution_case_reference) { "19GD1001816" }
+RSpec.describe CommonPlatform::Api::ProsecutionCaseFetcher do
+  let(:prosecution_case_reference) { "61GD7528225" }
 
   context "with an incorrect key" do
     subject(:search) { described_class.call(prosecution_case_reference:, connection:) }
 
+    let(:prosecution_case_reference) { "id-for-401-error" }
     let(:connection) { CommonPlatform::Connection.instance.call }
 
     before do
@@ -23,7 +24,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseSearcher do
     subject(:search) { described_class.call(prosecution_case_reference:) }
 
     it "returns a successful response" do
-      VCR.use_cassette("search_prosecution_case/by_prosecution_case_reference_success") do
+      VCR.use_cassette("search_prosecution_case/by_prosecution_case_reference_success_v2") do
         expect(search.status).to eq(200)
         expect(search.body["cases"][0]["prosecutionCaseReference"]).to eq(prosecution_case_reference)
         search
@@ -86,7 +87,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseSearcher do
   context "with connection" do
     subject(:search) { described_class.call(prosecution_case_reference:, connection:) }
 
-    let(:connection) { double("CommonPlatform::Connection") }
+    let(:connection) { double }
     let(:url) { "prosecutionCases" }
     let(:params) { { prosecutionCaseReference: prosecution_case_reference } }
 

--- a/spec/services/common_platform/api/search_prosecution_case_spec.rb
+++ b/spec/services/common_platform/api/search_prosecution_case_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CommonPlatform::Api::SearchProsecutionCase do
   let(:prosecution_case_id) { "5edd67eb-9d8c-44f2-a57e-c8d026defaa4" }
 
   before do
-    allow(CommonPlatform::Api::ProsecutionCaseSearcher).to receive(:call).and_return(common_platform_api_search_results)
+    allow(CommonPlatform::Api::ProsecutionCaseFetcher).to receive(:call).and_return(common_platform_api_search_results)
   end
 
   it "records ProsecutionCase" do
@@ -21,6 +21,17 @@ RSpec.describe CommonPlatform::Api::SearchProsecutionCase do
 
   it "returns the recorded ProsecutionCases" do
     expect(search_prosecution_case).to all(be_a(ProsecutionCase))
+  end
+
+  context "when the cases contain the applicationSummary" do
+    let(:response_body) do
+      JSON.parse(file_fixture("prosecution_case_search_result_with_application_summary.json").read)
+    end
+
+    it "contains applicationSummary" do
+      expect(search_prosecution_case[0].body["applicationSummary"]).to be_present
+      expect(search_prosecution_case[1].body["applicationSummary"]).to be_present
+    end
   end
 
   context "when containing multiple records" do

--- a/spec/support/json_schema_rspec.rb
+++ b/spec/support/json_schema_rspec.rb
@@ -5,6 +5,7 @@ RSpec.configure do |config|
 
   config.json_schemas[:address] = "#{schema_path}/global/apiAddress.json"
   config.json_schemas[:allocation_decision] = "#{schema_path}/global/apiAllocationDecision.json"
+  config.json_schemas[:application_summary] = "#{schema_path}/global/search/apiApplicationSummary.json"
   config.json_schemas[:attendance_day] = "#{schema_path}/global/apiAttendanceDay.json"
   config.json_schemas[:bail_status] = "#{schema_path}/global/apiBailStatus.json"
   config.json_schemas[:contact_details] = "#{schema_path}/global/apiContactNumber.json"

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -4,6 +4,7 @@ require "webmock/rspec"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
+# These are the mocks of the responses from the Common Platform API
 RSpec.configure do |config|
   config.before(:each, :stub_case_search_with_urn) do
     stub_request(:get, "#{ENV['COMMON_PLATFORM_URL']}/prosecutionCases")


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/ACD-433

## What
ACD-433: Add application summary to v2/prosecution_cases endpoint

      - Refactored spec/models/prosecution_case_spec.rb to use WebMock for improved transparency and maintainability.
      - Rename prosecution_case_searcher -> prosecution_case_fetcher, to avoid confusion and adopt an existing naming convention.
      - add new fixtures spec/fixtures/files/prosecution_cases_v2.json
      - Note: ProsecutionCase makes API calls, which should be moved to services. A larger refactor is needed.