### PR TITLE
GET /api/internal/v2/court_applications returns a sample in case of  200 success

### DIFF
--- a/app/controllers/api/internal/v2/court_applications_controller.rb
+++ b/app/controllers/api/internal/v2/court_applications_controller.rb
@@ -5,8 +5,13 @@ module Api
     module V2
       class CourtApplicationsController < ApplicationController
         def show
-          # TODO: this will be the new application details endpoint
-          raise NotImplementedError
+          # TODO: this is a temporary implementation
+          # the real implementation will return the court application details
+          # retrieved from the Common Platform API
+          court_application_details_sample = JSON.parse(
+            File.read("spec/fixtures/files/court_application_details/all_fields.json"),
+          )
+          render json: court_application_details_sample
         end
       end
     end

--- a/spec/requests/api/internal/v2/court_applications_request_spec.rb
+++ b/spec/requests/api/internal/v2/court_applications_request_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "api/internal/v2/court_applications", type: :request do
   let(:court_application_id) { SecureRandom.uuid }
 
   describe "GET /api/internal/v2/court_applications/{court_application_id}" do
-    it "raises NotImplementedError" do
-      expect {
-        get "/api/internal/v2/court_applications/#{court_application_id}", headers: { "Authorization" => "Bearer #{token.token}" }
-      }.to raise_error(NotImplementedError)
+    it "return 200 succeess" do
+      get "/api/internal/v2/court_applications/#{court_application_id}", headers: { "Authorization" => "Bearer #{token.token}" }
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/ACD-596

## What
GET /api/internal/v2/court_applications returns a sample in case of  200 success

This is only the first part, which acually was partialli implemented.
The goals were:
- to expose the endpoint
- return fake data on the happy path (200 success)

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
