### PR TITLE
ACD-618: Deal with situation where defendant ID spans multiple cases

### DIFF
--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -5,7 +5,6 @@ module CommonPlatform
     class DefendantFinder < ApplicationService
       def initialize(defendant_id:)
         @defendant_id = defendant_id
-        @prosecution_case_defendant = ProsecutionCaseDefendantOffence.find_by(defendant_id:)
       end
 
       def call
@@ -15,30 +14,50 @@ module CommonPlatform
     private
 
       def common_platform_defendant
-        @common_platform_defendant ||= common_platform_prosecution_case&.defendants&.find { |d| d.id.eql?(defendant_id) }
+        return @common_platform_defendant if @common_platform_defendant
+        return unless prosecution_case_urns
+
+        prosecution_case_urns.each do |urn|
+          prosecution_case = common_platform_prosecution_case(urn)
+
+          next unless prosecution_case
+
+          @common_platform_defendant ||= prosecution_case&.defendants&.find { |d| d.id.eql?(defendant_id) }
+
+          break if @common_platform_defendant
+        end
+
+        @common_platform_defendant
       end
 
-      def common_platform_prosecution_case
-        return unless prosecution_case_urn
+      def common_platform_prosecution_case(urn)
+        return unless urn
 
         # fetch details needed to include plea and mode of trial reason, at least
-        @common_platform_prosecution_case ||= CommonPlatform::Api::SearchProsecutionCase
-                                              .call(prosecution_case_reference: prosecution_case_urn)
+        CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)
                                               &.first
                                               &.tap(&:fetch_details)
       end
 
-      def prosecution_case_urn
-        @prosecution_case_urn ||= prosecution_case&.body&.fetch("prosecutionCaseReference", nil)
+      def prosecution_case_urns
+        return unless prosecution_cases
+
+        @prosecution_case_urns ||= prosecution_cases.map { |p_case| p_case.body&.fetch("prosecutionCaseReference", nil) }
       end
 
-      def prosecution_case
-        return unless prosecution_case_defendant
+      def prosecution_cases
+        return unless defendant_id
 
-        @prosecution_case ||= prosecution_case_defendant.prosecution_case
+        @prosecution_cases ||= begin
+          prosecution_case_ids = ProsecutionCaseDefendantOffence.joins(:prosecution_case)
+                                                                .where(defendant_id:)
+                                                                .pluck(:prosecution_case_id)
+
+          ProsecutionCase.where(id: prosecution_case_ids)
+        end
       end
 
-      attr_reader :defendant_id, :prosecution_case_defendant
+      attr_reader :defendant_id
     end
   end
 end

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -24,10 +24,10 @@ module CommonPlatform
 
           @common_platform_defendant ||= prosecution_case.defendants&.find { |d| d.id.eql?(defendant_id) }
 
-          break if @common_platform_defendant
+          return @common_platform_defendant if @common_platform_defendant
         end
 
-        @common_platform_defendant
+        nil
       end
 
       def common_platform_prosecution_case(urn)

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -22,7 +22,7 @@ module CommonPlatform
 
           next unless prosecution_case
 
-          @common_platform_defendant ||= prosecution_case&.defendants&.find { |d| d.id.eql?(defendant_id) }
+          @common_platform_defendant ||= prosecution_case.defendants&.find { |d| d.id.eql?(defendant_id) }
 
           break if @common_platform_defendant
         end


### PR DESCRIPTION
## What

Bug outline:

VCD user looks up case `CaseC` featuring defendant B, who has defendantID `B1` and masterDefendantId `B2`. ID `B1` gets sent to VCD as part of the `CaseC` payload. When the user clicks on defendant B, VCD makes a request for details to CDA using ID `B1`.

CDA then looks up the first local prosecution case record linked locally to ID `B1`. But sometimes this is not case `CaseC` but rather case `CaseD`. When CDA then pulls defendant details for `CaseD` from HMCTS, defendant B is listed as having ID `B2`, not `B1`. This means that, searching in the context of CaseB, no details associated with ID B1 are found. So CDA returns a 404, which results in a `JsonApiClient::Errors::NotFound` being recorded [to Sentry](https://ministryofjustice.sentry.io/issues/2066105222/?project=5428270&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=4) by VCD

Because, when we search for defendant details, we don't send the case identifier from VCD to CDA, when there are multiple local cases associated with a defendant ID in CDA we can't specify which local case to look up. BUT we can effectively work around this issue by iterating through them until we find one associated with an HMCTS case that lists the defendant ID we have.

There is some suggestion that defendant IDs shouldn't be duplicated across cases. However, given they _are_ duplicated, and this issue affects around 10 VCD interactions a day, working around this weirdness of the data is more pragmatic than ignoring it.
