### PR TITLE
Only run test-branch on branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,10 +263,10 @@ workflows:
   test-branch:
     jobs:
       - test:
-        filters:
-          branches:
-            ignore:
-              - main
+          filters:
+            branches:
+              ignore:
+                - main
 
   build-deploy-branch-to-live-cluster:
     jobs:


### PR DESCRIPTION
## What

`test-branch` is currently running after we merge to main, even though `test-build-deploy-main-to-live-cluster` also runs, which does exactly the same things. This looks to me unintentional, and I think it's an indentation error in the directive that tells `test-branch` _not_ to run on merge to main.