### PR TITLE
Add Rubocop to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,11 @@ jobs:
       - run: sudo apt-get install postgresql-client
 
       - run:
+          name: Lint
+          command: |
+            bundle exec rubocop
+
+      - run:
           name: Database Setup
           command: |
             bundle exec rake db:migrate


### PR DESCRIPTION
At the moment we're not catching linter errors in CI