### PR TITLE
ACD-574: Record court application body locally

### DIFF
--- a/app/controllers/api/internal/v2/court_applications_controller.rb
+++ b/app/controllers/api/internal/v2/court_applications_controller.rb
@@ -12,9 +12,9 @@ module Api
 
           case response_data.status
           when 200
-            model = HmctsCommonPlatform::CourtApplicationSummary.new(response_body)
-            CourtApplicationRecorder.call(params[:id], model)
-            render json: model.to_json, status: :ok
+            application_summary = HmctsCommonPlatform::CourtApplicationSummary.new(response_body)
+            CourtApplicationRecorder.call(params[:id], application_summary)
+            render json: application_summary.to_json, status: :ok
           when 404
             head :not_found
           else

--- a/app/controllers/api/internal/v2/court_applications_controller.rb
+++ b/app/controllers/api/internal/v2/court_applications_controller.rb
@@ -12,7 +12,9 @@ module Api
 
           case response_data.status
           when 200
-            render json: HmctsCommonPlatform::CourtApplicationSummary.new(response_body).to_json, status: :ok
+            model = HmctsCommonPlatform::CourtApplicationSummary.new(response_body)
+            CourtApplicationRecorder.call(params[:id], model)
+            render json: model.to_json, status: :ok
           when 404
             head :not_found
           else

--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -1,0 +1,2 @@
+class CourtApplication < LegalCase
+end

--- a/app/models/court_application_defendant_offence.rb
+++ b/app/models/court_application_defendant_offence.rb
@@ -1,0 +1,5 @@
+class CourtApplicationDefendantOffence < LegalCaseDefendantOffence
+  alias_attribute :court_application_id, :prosecution_case_id
+  validates :court_application_id, presence: true
+  belongs_to :court_application
+end

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -24,7 +24,7 @@ module HmctsCommonPlatform
     end
 
     def application_type
-      data[:applicationType] || application_title
+      data[:applicationType]
     end
 
     def received_date

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -24,7 +24,7 @@ module HmctsCommonPlatform
     end
 
     def application_type
-      data[:applicationType]
+      data[:applicationType] || application_title
     end
 
     def received_date

--- a/app/models/legal_case.rb
+++ b/app/models/legal_case.rb
@@ -1,0 +1,7 @@
+class LegalCase < ApplicationRecord
+  # Note that despite the table name, legal cases can be either
+  # prosecution cases OR court applications
+  self.table_name = "prosecution_cases"
+
+  validates :body, presence: true
+end

--- a/app/models/legal_case_defendant_offence.rb
+++ b/app/models/legal_case_defendant_offence.rb
@@ -1,0 +1,8 @@
+class LegalCaseDefendantOffence < ApplicationRecord
+  # Note that despite the table name, these records can link either
+  # prosecution cases OR court applications
+  self.table_name = "prosecution_case_defendant_offences"
+
+  validates :defendant_id, presence: true
+  validates :offence_id, presence: true
+end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-# WARNING! Despite the name, a ProsecutionCase DB record can contain _either_
-# a prosecution case our a court application record
-class ProsecutionCase < ApplicationRecord
-  validates :body, presence: true
-
+class ProsecutionCase < LegalCase
   def defendants
     body["defendantSummary"].map do |defendant|
       Defendant.new(

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# WARNING! Despite the name, a ProsecutionCase DB record can contain _either_
+# a prosecution case our a court application record
 class ProsecutionCase < ApplicationRecord
   validates :body, presence: true
 

--- a/app/models/prosecution_case_defendant_offence.rb
+++ b/app/models/prosecution_case_defendant_offence.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ProsecutionCaseDefendantOffence < ApplicationRecord
+class ProsecutionCaseDefendantOffence < LegalCaseDefendantOffence
   validates :prosecution_case_id, presence: true
-  validates :defendant_id, presence: true
-  validates :offence_id, presence: true
   belongs_to :prosecution_case
 end

--- a/app/services/court_application_recorder.rb
+++ b/app/services/court_application_recorder.rb
@@ -2,28 +2,26 @@
 
 class CourtApplicationRecorder < ApplicationService
   def initialize(court_application_id, model)
-    @prosecution_case = ProsecutionCase.find_or_initialize_by(id: court_application_id)
+    @court_application = CourtApplication.find_or_initialize_by(id: court_application_id)
     @model = model
   end
 
   def call
-    # Yes, court applications are not prosecution cases, but the prosecution_cases
-    # table is where we are storing court application payloads, for reasons.
-    prosecution_case.update!(body: model.data)
+    court_application.update!(body: model.data)
 
     model.subject_summary.offence_summary.each do |offence|
-      ProsecutionCaseDefendantOffence.find_or_create_by!(
-        prosecution_case_id: prosecution_case.id,
+      CourtApplicationDefendantOffence.find_or_create_by!(
+        court_application_id: court_application.id,
         defendant_id: model.subject_summary.subject_id,
         offence_id: offence.offence_id,
         application_type: model.application_type,
       )
     end
 
-    prosecution_case
+    court_application
   end
 
 private
 
-  attr_reader :prosecution_case, :model
+  attr_reader :court_application, :model
 end

--- a/app/services/court_application_recorder.rb
+++ b/app/services/court_application_recorder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CourtApplicationRecorder < ApplicationService
+  def initialize(court_application_id, model)
+    @prosecution_case = ProsecutionCase.find_or_initialize_by(id: court_application_id)
+    @model = model
+  end
+
+  def call
+    # Yes, court applications are not prosecution cases, but the prosecution_cases
+    # table is where we are storing court application payloads, for reasons.
+    prosecution_case.update!(body: model.data)
+
+    model.subject_summary.offence_summary.each do |offence|
+      ProsecutionCaseDefendantOffence.find_or_create_by!(
+        prosecution_case_id: prosecution_case.id,
+        defendant_id: model.subject_summary.subject_id,
+        offence_id: offence.offence_id,
+        application_type: model.application_type,
+      )
+    end
+
+    prosecution_case
+  end
+
+private
+
+  attr_reader :prosecution_case, :model
+end

--- a/app/services/prosecution_case_recorder.rb
+++ b/app/services/prosecution_case_recorder.rb
@@ -15,6 +15,7 @@ class ProsecutionCaseRecorder < ApplicationService
           prosecution_case_id: prosecution_case.id,
           defendant_id: defendant.id,
           offence_id: offence.id,
+          application_type: nil,
         )
       end
     end

--- a/db/migrate/20250327104429_add_application_type_to_prosecution_case_defendant_offence.rb
+++ b/db/migrate/20250327104429_add_application_type_to_prosecution_case_defendant_offence.rb
@@ -1,5 +1,5 @@
 class AddApplicationTypeToProsecutionCaseDefendantOffence < ActiveRecord::Migration[8.0]
   def change
-    add_column :prosecution_case_defendant_offences, :application_type, :string
+    add_column :prosecution_case_defendant_offences, :application_type, :string, limit: 255
   end
 end

--- a/db/migrate/20250327104429_add_application_type_to_prosecution_case_defendant_offence.rb
+++ b/db/migrate/20250327104429_add_application_type_to_prosecution_case_defendant_offence.rb
@@ -1,0 +1,5 @@
+class AddApplicationTypeToProsecutionCaseDefendantOffence < ActiveRecord::Migration[8.0]
+  def change
+    add_column :prosecution_case_defendant_offences, :application_type, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -198,7 +198,8 @@ CREATE TABLE public.prosecution_case_defendant_offences (
     status_date timestamp without time zone,
     effective_start_date timestamp without time zone,
     effective_end_date timestamp without time zone,
-    defence_organisation json
+    defence_organisation json,
+    application_type character varying
 );
 
 
@@ -475,6 +476,7 @@ ALTER TABLE ONLY public.oauth_access_grants
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250327104429'),
 ('20220815120308'),
 ('20220815115514'),
 ('20220801171207'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -199,7 +199,7 @@ CREATE TABLE public.prosecution_case_defendant_offences (
     effective_start_date timestamp without time zone,
     effective_end_date timestamp without time zone,
     defence_organisation json,
-    application_type character varying
+    application_type character varying(255)
 );
 
 

--- a/spec/requests/api/internal/v2/court_applications_request_spec.rb
+++ b/spec/requests/api/internal/v2/court_applications_request_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe "api/internal/v2/court_applications", type: :request do
       it "returns payload" do
         expect(response.parsed_body["application_id"]).to eq("00004c9f-af9f-401a-b88b-78a4f0e08163")
       end
+
+      it "persists a 'prosecution_case'" do
+        expect(ProsecutionCase.find_by(id: court_application_id)).not_to be_nil
+      end
     end
 
     context "when HMCTS request is unsuccessful" do

--- a/spec/services/court_application_recorder_spec.rb
+++ b/spec/services/court_application_recorder_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe CourtApplicationRecorder do
+  subject(:record) { described_class.call(court_application_id, model) }
+
+  let(:body) { JSON.parse(file_fixture("court_application_summary.json").read) }
+  let(:model) { HmctsCommonPlatform::CourtApplicationSummary.new(body) }
+
+  let(:court_application_id) { model.application_id }
+  let(:defendant_id) { model.subject_summary.subject_id }
+  let(:offence_id) { model.subject_summary.offence_summary.first.offence_id }
+  let(:prosecution_case_id) { court_application_id }
+
+  it "creates a Prosecution Case" do
+    expect {
+      record
+    }.to change(ProsecutionCase, :count).by(1)
+  end
+
+  it "creates a ProsecutionCaseDefendantOffence record" do
+    expect {
+      record
+    }.to change(ProsecutionCaseDefendantOffence, :count).by(1)
+  end
+
+  it "returns the created Prosecution Case" do
+    expect(record).to be_a(ProsecutionCase)
+  end
+
+  it "saves the body on the Prosecution Case" do
+    expect(record.body).to eq(body)
+  end
+
+  context "when the Prosecution Case exists" do
+    let!(:prosecution_case) do
+      ProsecutionCase.create!(
+        id: prosecution_case_id,
+        body: "old body",
+      )
+    end
+
+    before do
+      ProsecutionCaseDefendantOffence.create!(
+        prosecution_case_id:,
+        defendant_id:,
+        offence_id:,
+        application_type: model.application_type,
+      )
+    end
+
+    it "does not create a new record" do
+      expect {
+        record
+      }.not_to change(ProsecutionCase, :count)
+    end
+
+    it "does not create a new ProsecutionCaseDefendantOffence record" do
+      expect {
+        record
+      }.not_to change(ProsecutionCaseDefendantOffence, :count)
+    end
+
+    it "updates Prosecution Case with new response" do
+      record
+      expect(prosecution_case.reload.body).to eq(body)
+    end
+  end
+end

--- a/spec/services/court_application_recorder_spec.rb
+++ b/spec/services/court_application_recorder_spec.rb
@@ -9,39 +9,38 @@ RSpec.describe CourtApplicationRecorder do
   let(:court_application_id) { model.application_id }
   let(:defendant_id) { model.subject_summary.subject_id }
   let(:offence_id) { model.subject_summary.offence_summary.first.offence_id }
-  let(:prosecution_case_id) { court_application_id }
 
-  it "creates a Prosecution Case" do
+  it "creates a Court Application" do
     expect {
       record
-    }.to change(ProsecutionCase, :count).by(1)
+    }.to change(CourtApplication, :count).by(1)
   end
 
-  it "creates a ProsecutionCaseDefendantOffence record" do
+  it "creates a CourtApplicationDefendantOffence record" do
     expect {
       record
-    }.to change(ProsecutionCaseDefendantOffence, :count).by(1)
+    }.to change(CourtApplicationDefendantOffence, :count).by(1)
   end
 
-  it "returns the created Prosecution Case" do
-    expect(record).to be_a(ProsecutionCase)
+  it "returns the created Court Application" do
+    expect(record).to be_a(CourtApplication)
   end
 
-  it "saves the body on the Prosecution Case" do
+  it "saves the body on the Court Application" do
     expect(record.body).to eq(body)
   end
 
-  context "when the Prosecution Case exists" do
+  context "when the Court Application exists" do
     let!(:prosecution_case) do
-      ProsecutionCase.create!(
-        id: prosecution_case_id,
+      CourtApplication.create!(
+        id: court_application_id,
         body: "old body",
       )
     end
 
     before do
-      ProsecutionCaseDefendantOffence.create!(
-        prosecution_case_id:,
+      CourtApplicationDefendantOffence.create!(
+        court_application_id:,
         defendant_id:,
         offence_id:,
         application_type: model.application_type,
@@ -51,16 +50,16 @@ RSpec.describe CourtApplicationRecorder do
     it "does not create a new record" do
       expect {
         record
-      }.not_to change(ProsecutionCase, :count)
+      }.not_to change(CourtApplication, :count)
     end
 
-    it "does not create a new ProsecutionCaseDefendantOffence record" do
+    it "does not create a new CourtApplicationDefendantOffence record" do
       expect {
         record
-      }.not_to change(ProsecutionCaseDefendantOffence, :count)
+      }.not_to change(CourtApplicationDefendantOffence, :count)
     end
 
-    it "updates Prosecution Case with new response" do
+    it "updates Court Application with new response" do
       record
       expect(prosecution_case.reload.body).to eq(body)
     end

--- a/spec/services/prosecution_case_recorder_spec.rb
+++ b/spec/services/prosecution_case_recorder_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ProsecutionCaseRecorder do
         prosecution_case_id:,
         defendant_id:,
         offence_id:,
+        application_type: nil,
       )
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-574)

- When a court application is retrieved, store it in the `prosecution_cases` table
- For each offence, store a row in the `prosecution_cases_defendant_offences` table along with the application type (in a new column)
- Add a warning to the code acknowledging that a "ProsecutionCase" may not actually be a prosecution case.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
