### PR TITLE
ACD-437: Accept new application concluded payload to prosecution conclusion endpoint

### DIFF
--- a/app/contracts/prosecution_conclusion_contract.rb
+++ b/app/contracts/prosecution_conclusion_contract.rb
@@ -1,12 +1,12 @@
 class ProsecutionConclusionContract < Dry::Validation::Contract
   json do
     required(:prosecutionConcluded).array(:hash) do
-      required(:prosecutionCaseId).value(:string)
-      required(:defendantId).value(:string)
+      optional(:prosecutionCaseId).value(:string)
+      optional(:defendantId).value(:string)
       required(:isConcluded).value(:bool)
       required(:hearingIdWhereChangeOccurred).value(:string)
 
-      required(:offenceSummary).array(:hash) do
+      optional(:offenceSummary).array(:hash) do
         required(:offenceId).value(:string)
         required(:offenceCode).value(:string)
         required(:proceedingsConcluded).value(:bool)
@@ -30,6 +30,12 @@ class ProsecutionConclusionContract < Dry::Validation::Contract
             required(:verdictTypeId).value(:string)
           end
         end
+      end
+
+      optional(:applicationConcluded).value(:hash) do
+        required(:applicationId).value(:string)
+        required(:applicationResultCode).value(:string)
+        required(:subjectId).value(:string)
       end
     end
   end

--- a/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v1/prosecution_conclusions_controller.rb
@@ -2,75 +2,7 @@ module Api
   module External
     module V1
       class ProsecutionConclusionsController < ApplicationController
-        def create
-          enforce_contract!
-
-          prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
-            laa_reference = LaaReference.find_by(defendant_id: pc["defendantId"], linked: true)
-
-            next unless laa_reference
-
-            Sqs::MessagePublisher.call(
-              message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
-              queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
-              log_info: { maat_reference: laa_reference.maat_reference },
-            )
-          end
-
-          head :accepted
-        end
-
-      private
-
-        def enforce_contract!
-          unless contract.success?
-            message = "Prosecution conclusion contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
-          end
-        end
-
-        def contract
-          ProsecutionConclusionContract.new.call(prosecution_conclusion_params.to_hash)
-        end
-
-        def prosecution_conclusion_params
-          params.require(:prosecution_conclusion).permit(
-            prosecutionConcluded: [
-              :prosecutionCaseId,
-              :defendantId,
-              :isConcluded,
-              :hearingIdWhereChangeOccurred,
-              {
-                offenceSummary: [
-                  :offenceId,
-                  :offenceCode,
-                  :proceedingsConcluded,
-                  :proceedingsConcludedChangedDate,
-                  {
-                    plea: %i[
-                      originatingHearingId
-                      value
-                      pleaDate
-                    ],
-                    verdict: [
-                      :verdictDate,
-                      :originatingHearingId,
-                      {
-                        verdictType: %i[
-                          description
-                          category
-                          categoryType
-                          sequence
-                          verdictTypeId
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          )
-        end
+        include ProsecutionConcludable
       end
     end
   end

--- a/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
+++ b/app/controllers/api/external/v2/prosecution_conclusions_controller.rb
@@ -2,75 +2,7 @@ module Api
   module External
     module V2
       class ProsecutionConclusionsController < ApplicationController
-        def create
-          enforce_contract!
-
-          prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
-            laa_reference = LaaReference.find_by(defendant_id: pc["defendantId"], linked: true)
-
-            next unless laa_reference
-
-            Sqs::MessagePublisher.call(
-              message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
-              queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
-              log_info: { maat_reference: laa_reference.maat_reference },
-            )
-          end
-
-          head :accepted
-        end
-
-      private
-
-        def enforce_contract!
-          unless contract.success?
-            message = "Prosecution conclusion contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
-          end
-        end
-
-        def contract
-          ProsecutionConclusionContract.new.call(prosecution_conclusion_params.to_hash)
-        end
-
-        def prosecution_conclusion_params
-          params.require(:prosecution_conclusion).permit(
-            prosecutionConcluded: [
-              :prosecutionCaseId,
-              :defendantId,
-              :isConcluded,
-              :hearingIdWhereChangeOccurred,
-              {
-                offenceSummary: [
-                  :offenceId,
-                  :offenceCode,
-                  :proceedingsConcluded,
-                  :proceedingsConcludedChangedDate,
-                  {
-                    plea: %i[
-                      originatingHearingId
-                      value
-                      pleaDate
-                    ],
-                    verdict: [
-                      :verdictDate,
-                      :originatingHearingId,
-                      {
-                        verdictType: %i[
-                          description
-                          category
-                          categoryType
-                          sequence
-                          verdictTypeId
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          )
-        end
+        include ProsecutionConcludable
       end
     end
   end

--- a/app/controllers/concerns/prosecution_concludable.rb
+++ b/app/controllers/concerns/prosecution_concludable.rb
@@ -1,0 +1,83 @@
+module ProsecutionConcludable
+  extend ActiveSupport::Concern
+
+  def create
+    enforce_contract!
+
+    prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
+      laa_reference = retrieve_laa_reference(pc)
+
+      next unless laa_reference
+
+      Sqs::MessagePublisher.call(
+        message: pc.to_h.merge("maatId" => laa_reference.maat_reference),
+        queue_url: Rails.configuration.x.aws.sqs_url_prosecution_concluded,
+        log_info: { maat_reference: laa_reference.maat_reference },
+      )
+    end
+
+    head :accepted
+  end
+
+private
+
+  def enforce_contract!
+    unless contract.success?
+      message = "Prosecution conclusion contract failed with: #{contract.errors.to_hash}"
+      raise Errors::ContractError, message
+    end
+  end
+
+  def contract
+    ProsecutionConclusionContract.new.call(prosecution_conclusion_params.to_hash)
+  end
+
+  def retrieve_laa_reference(param_set)
+    defendant_id = param_set["defendantId"] || param_set.dig("applicationConcluded", "subjectId")
+    LaaReference.find_by(defendant_id:, linked: true)
+  end
+
+  def prosecution_conclusion_params
+    params.require(:prosecution_conclusion).permit(
+      prosecutionConcluded: [
+        :prosecutionCaseId,
+        :defendantId,
+        :isConcluded,
+        :hearingIdWhereChangeOccurred,
+        {
+          applicationConcluded: %i[
+            applicationId
+            applicationResultCode
+            subjectId
+          ],
+          offenceSummary: [
+            :offenceId,
+            :offenceCode,
+            :proceedingsConcluded,
+            :proceedingsConcludedChangedDate,
+            {
+              plea: %i[
+                originatingHearingId
+                value
+                pleaDate
+              ],
+              verdict: [
+                :verdictDate,
+                :originatingHearingId,
+                {
+                  verdictType: %i[
+                    description
+                    category
+                    categoryType
+                    sequence
+                    verdictTypeId
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    )
+  end
+end

--- a/app/controllers/concerns/prosecution_concludable.rb
+++ b/app/controllers/concerns/prosecution_concludable.rb
@@ -5,7 +5,7 @@ module ProsecutionConcludable
     enforce_contract!
 
     prosecution_conclusion_params["prosecutionConcluded"].each do |pc|
-      laa_reference = retrieve_laa_reference(pc)
+      laa_reference = get_linked_laa_reference(pc)
 
       next unless laa_reference
 
@@ -32,7 +32,7 @@ private
     ProsecutionConclusionContract.new.call(prosecution_conclusion_params.to_hash)
   end
 
-  def retrieve_laa_reference(param_set)
+  def get_linked_laa_reference(param_set)
     defendant_id = param_set["defendantId"] || param_set.dig("applicationConcluded", "subjectId")
     LaaReference.find_by(defendant_id:, linked: true)
   end

--- a/lib/schemas/api/progression.api.prosecutionConcludedRequest.json
+++ b/lib/schemas/api/progression.api.prosecutionConcludedRequest.json
@@ -43,14 +43,15 @@
           "items": {
             "$ref": "#/definitions/offenceSummary"
           }
+        },
+        "applicationConcluded": {
+          "description": "The details of the conclusion of a court application if relevant",
+          "$ref": "#/definitions/applicationConcluded"
         }
       },
       "required": [
-        "prosecutionCaseId",
-        "defendantId",
         "isConcluded",
-        "hearingIdWhereChangeOccurred",
-        "offenceSummary"
+        "hearingIdWhereChangeOccurred"
       ],
       "additionalProperties": false
     },
@@ -167,6 +168,29 @@
         "category",
         "categoryType",
         "sequence"
+      ],
+      "additionalProperties": false
+    },
+    "applicationConcluded": {
+      "type": "object",
+      "properties": {
+        "applicationId": {
+          "description": "The identifier of the court application",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "subjectId": {
+          "description": "The identifier of the subject (defendant)",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "applicationResultCode": {
+          "description": "A code indicating the result of the court application",
+          "type": "string"
+        }
+      },
+      "required": [
+        "applicationId",
+        "subjectId",
+        "applicationResultCode"
       ],
       "additionalProperties": false
     }

--- a/spec/contracts/prosecution_conclusion_contract_spec.rb
+++ b/spec/contracts/prosecution_conclusion_contract_spec.rb
@@ -22,4 +22,28 @@ RSpec.describe ProsecutionConclusionContract, type: :model do
       expect(described_class.new.call(prosecution_conclusion)).to be_a_success
     end
   end
+
+  context "with valid application conclusion payload" do
+    let(:prosecution_conclusion) { JSON.parse(file_fixture("application_conclusion/valid.json").read) }
+
+    it "matches the HMCTS Common Platform schema" do
+      expect(prosecution_conclusion).to match_json_schema(:prosecution_conclusion)
+    end
+
+    it "is valid" do
+      expect(described_class.new.call(prosecution_conclusion)).to be_a_success
+    end
+  end
+
+  context "with invalid application conclusion payload" do
+    let(:prosecution_conclusion) { JSON.parse(file_fixture("application_conclusion/invalid.json").read) }
+
+    it "does not match the HMCTS Common Platform schema" do
+      expect(prosecution_conclusion).not_to match_json_schema(:prosecution_conclusion)
+    end
+
+    it "is invalid" do
+      expect(described_class.new.call(prosecution_conclusion)).not_to be_a_success
+    end
+  end
 end

--- a/spec/fixtures/files/application_conclusion/invalid.json
+++ b/spec/fixtures/files/application_conclusion/invalid.json
@@ -1,0 +1,12 @@
+{
+  "prosecutionConcluded": [
+    {
+      "isConcluded": true,
+      "hearingIdWhereChangeOccurred": "96095df2-b66b-421d-881e-c45fd267e751",
+      "applicationConcluded": {
+        "applicationId": 32,
+        "subjectId": "02013b5c-11dd-43fd-b0a8-e87bd229b272"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/application_conclusion/valid.json
+++ b/spec/fixtures/files/application_conclusion/valid.json
@@ -1,0 +1,37 @@
+{
+  "prosecutionConcluded": [
+    {
+      "isConcluded": true,
+      "hearingIdWhereChangeOccurred": "96095df2-b66b-421d-881e-c45fd267e751",
+      "applicationConcluded": {
+        "applicationId": "b4d151a2-1bc8-4c74-81d0-697e2dbb937c",
+        "applicationResultCode": "G",
+        "subjectId": "67d948d1-1792-4565-a522-8ab2425827e8"
+      },
+      "offenceSummary": [
+        {
+          "offenceId": "fb2a3ecb-fc1a-4a80-88ac-222478bc4a92",
+          "offenceCode": "PT00011",
+          "proceedingsConcluded": true,
+          "proceedingsConcludedChangedDate": "2021-01-01",
+          "plea": {
+            "originatingHearingId": "a6b07866-faa0-48d5-9faf-c18121e49aaf",
+            "pleaDate": "2021-03-01",
+            "value": "GUILTY"
+          },
+          "verdict": {
+            "originatingHearingId": "7084b980-d09d-40bc-b856-ea1fafd401bf",
+            "verdictDate": "2021-04-10",
+            "verdictType": {
+              "description": "Verdict type description",
+              "category": "A",
+              "categoryType": "Type A",
+              "sequence": 1,
+              "verdictTypeId": "ebb53996-e8f1-4363-95a0-34c663ce6f9a"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v1/prosecution_conclusion_request_spec.rb
@@ -14,17 +14,9 @@ RSpec.describe "api/external/v1/prosecution_conclusions", swagger_doc: "v1/swagg
       tags "External - available to Common Platform"
       security [{ oAuth: [] }]
 
-      response(202, "Accepted") do
-        parameter name: :prosecution_conclusion,
-                  in: :body,
-                  required: true,
-                  type: :object,
-                  schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
-                  description: "The minimal prosecution concluded payload"
+      let(:Authorization) { "Bearer #{token.token}" }
 
-        let(:Authorization) { "Bearer #{token.token}" }
-        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
-
+      context "when sending a valid payload" do
         before do
           LaaReference.create!(
             user_name: "test-user",
@@ -44,13 +36,40 @@ RSpec.describe "api/external/v1/prosecution_conclusions", swagger_doc: "v1/swagg
             )
         end
 
-        run_test!
+        context "when sending a valid prosecution case payload" do
+          let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
+
+          response(202, "Accepted") do
+            parameter name: :prosecution_conclusion,
+                      in: :body,
+                      required: true,
+                      type: :object,
+                      schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
+                      description: "The minimal prosecution concluded payload"
+            run_test!
+          end
+        end
+
+        context "when sending a valid application case payload" do
+          let(:prosecution_conclusion) { JSON.parse(file_fixture("application_conclusion/valid.json").read) }
+
+          response(202, "Accepted") do
+            parameter name: :prosecution_conclusion,
+                      in: :body,
+                      required: true,
+                      type: :object,
+                      schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
+                      description: "The court application concluded payload"
+            run_test!
+          end
+        end
       end
 
       context "when entity is unprocessable" do
+        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/unprocessable.json").read) }
+
         response("422", "Unprocessable Entity") do
           let(:Authorization) { "Bearer #{token.token}" }
-          let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/unprocessable.json").read) }
 
           run_test!
         end

--- a/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
+++ b/spec/requests/api/external/v2/prosecution_conclusion_request_spec.rb
@@ -14,17 +14,9 @@ RSpec.describe "api/external/v2/prosecution_conclusions", swagger_doc: "v2/swagg
       tags "External - available to Common Platform"
       security [{ oAuth: [] }]
 
-      response(202, "Accepted") do
-        parameter name: :prosecution_conclusion,
-                  in: :body,
-                  required: true,
-                  type: :object,
-                  schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
-                  description: "The minimal prosecution concluded payload"
+      let(:Authorization) { "Bearer #{token.token}" }
 
-        let(:Authorization) { "Bearer #{token.token}" }
-        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/all_fields.json").read) }
-
+      context "when sending a valid payload" do
         before do
           LaaReference.create!(
             user_name: "test-user",
@@ -44,13 +36,40 @@ RSpec.describe "api/external/v2/prosecution_conclusions", swagger_doc: "v2/swagg
             )
         end
 
-        run_test!
+        context "when sending a valid prosecution case payload" do
+          let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/valid.json").read) }
+
+          response(202, "Accepted") do
+            parameter name: :prosecution_conclusion,
+                      in: :body,
+                      required: true,
+                      type: :object,
+                      schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
+                      description: "The minimal prosecution concluded payload"
+            run_test!
+          end
+        end
+
+        context "when sending a valid application case payload" do
+          let(:prosecution_conclusion) { JSON.parse(file_fixture("application_conclusion/valid.json").read) }
+
+          response(202, "Accepted") do
+            parameter name: :prosecution_conclusion,
+                      in: :body,
+                      required: true,
+                      type: :object,
+                      schema: { "$ref" => "prosecution_concluded_request.json#/definitions/resource" },
+                      description: "The court application concluded payload"
+            run_test!
+          end
+        end
       end
 
       context "when entity is unprocessable" do
+        let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/unprocessable.json").read) }
+
         response("422", "Unprocessable Entity") do
           let(:Authorization) { "Bearer #{token.token}" }
-          let(:prosecution_conclusion) { JSON.parse(file_fixture("prosecution_conclusion/unprocessable.json").read) }
 
           run_test!
         end

--- a/swagger/v1/prosecution_conclusion.json
+++ b/swagger/v1/prosecution_conclusion.json
@@ -29,14 +29,15 @@
           "items": {
             "$ref": "#/definitions/offenceSummary"
           }
+        },
+        "applicationConcluded": {
+          "description": "The details of the conclusion of a court application if relevant",
+          "$ref": "#/definitions/applicationConcluded"
         }
       },
       "required": [
-        "prosecutionCaseId",
-        "defendantId",
         "isConcluded",
-        "hearingIdWhereChangeOccurred",
-        "offenceSummary"
+        "hearingIdWhereChangeOccurred"
       ],
       "additionalProperties": false
     },
@@ -151,6 +152,29 @@
         "category",
         "categoryType",
         "sequence"
+      ],
+      "additionalProperties": false
+    },
+    "applicationConcluded": {
+      "type": "object",
+      "properties": {
+        "applicationId": {
+          "description": "The identifier of the court application",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "subjectId": {
+          "description": "The identifier of the subject (defendant)",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "applicationResultCode": {
+          "description": "A code indicating the result of the court application",
+          "type": "string"
+        }
+      },
+      "required": [
+        "applicationId",
+        "subjectId",
+        "applicationResultCode"
       ],
       "additionalProperties": false
     }

--- a/swagger/v2/prosecution_conclusion.json
+++ b/swagger/v2/prosecution_conclusion.json
@@ -29,14 +29,15 @@
           "items": {
             "$ref": "#/definitions/offenceSummary"
           }
+        },
+        "applicationConcluded": {
+          "description": "The details of the conclusion of a court application if relevant",
+          "$ref": "#/definitions/applicationConcluded"
         }
       },
       "required": [
-        "prosecutionCaseId",
-        "defendantId",
         "isConcluded",
-        "hearingIdWhereChangeOccurred",
-        "offenceSummary"
+        "hearingIdWhereChangeOccurred"
       ],
       "additionalProperties": false
     },
@@ -151,6 +152,29 @@
         "category",
         "categoryType",
         "sequence"
+      ],
+      "additionalProperties": false
+    },
+    "applicationConcluded": {
+      "type": "object",
+      "properties": {
+        "applicationId": {
+          "description": "The identifier of the court application",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "subjectId": {
+          "description": "The identifier of the subject (defendant)",
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "applicationResultCode": {
+          "description": "A code indicating the result of the court application",
+          "type": "string"
+        }
+      },
+      "required": [
+        "applicationId",
+        "subjectId",
+        "applicationResultCode"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-437)

When a court application is concluded the payload from HMCTS gets sent to the existing prosecution_concluded endpoint. Currently only the v1 endpoint is used. A v2 endpoint exists but is a copy-paste of the code of v1.

- Turn controller logic into a concern that is shared by both v1 and v2 so we can update logic in both at the same time
- Change param whitelisting and contract enforcement logic to accept new params and allow old params to be missing
- Retrieve LAA reference using subjectId if defendantId is not available
- Send the message on to MAAT

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
