### PR TITLE
Small refactor: remove alias + Comments

### DIFF
--- a/app/controllers/api/internal/v2/laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/laa_references_controller.rb
@@ -4,6 +4,7 @@ module Api
   module Internal
     module V2
       class LaaReferencesController < ApplicationController
+        # Create link to court data
         def create
           contract = NewLaaReferenceContract.new.call(**transformed_params)
           enforce_contract!(contract)

--- a/app/controllers/api/internal/v2/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_cases_controller.rb
@@ -4,6 +4,7 @@ module Api
   module Internal
     module V2
       class ProsecutionCasesController < ApplicationController
+        # Get /api/internal/v2/prosecution_cases
         def index
           case_summaries = CommonPlatform::Api::SearchProsecutionCase.call(transformed_params)
 

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -30,7 +30,6 @@ class ProsecutionCase < ApplicationRecord
   def hearings
     hearing_results.map(&:hearing)
   end
-  alias_method :fetch_details, :hearings
 
   def hearing_ids
     hearings.map(&:id)

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -34,9 +34,13 @@ module CommonPlatform
         return unless urn
 
         # fetch details needed to include plea and mode of trial reason, at least
-        CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)
-                                              &.first
-                                              &.tap(&:fetch_details)
+        prosecution_case = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)&.first
+
+        # This makes many calls to /LAA/v1/hearing/results (Common Platform)
+        # TODO: check if this is needed
+        prosecution_case&.hearings
+
+        prosecution_case
       end
 
       def prosecution_case_urns

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -85,10 +85,6 @@ RSpec.describe ProsecutionCase, type: :model do
 
         it { expect(hearings.first.id).to eq(hearing_result_body["hearing"]["id"]) }
 
-        it "is_expected to have alias #fetch_details" do
-          expect(prosecution_case.method(:hearings)).to eq(prosecution_case.method(:fetch_details))
-        end
-
         context "with no prosecution_case reference" do
           let(:hearing_result_body) do
             HearingResult.new({ "sharedTime" => "", "hearing" => { "id" => "311bb2df-4df5-4abe-bae3-82f144e1e5c5" } })


### PR DESCRIPTION
## What
to make it more explicit the calls to /LAA/v1/hearing/results (CP) which are obscured by an alias.
