### PR TITLE
ACD-647 and ACD-636: Short ID and subject summary are in both application payloads

### DIFF
--- a/app/models/hmcts_common_platform/application_summary.rb
+++ b/app/models/hmcts_common_platform/application_summary.rb
@@ -10,6 +10,10 @@ module HmctsCommonPlatform
       data[:applicationId]
     end
 
+    def short_id
+      data[:applicationShortId]
+    end
+
     def reference
       data[:applicationReference]
     end
@@ -22,6 +26,10 @@ module HmctsCommonPlatform
       data[:receivedDate]
     end
 
+    def subject_summary
+      HmctsCommonPlatform::SubjectSummary.new(data[:subjectSummary]) if data[:subjectSummary]
+    end
+
     def to_json(*_args)
       to_builder.attributes!
     end
@@ -31,9 +39,11 @@ module HmctsCommonPlatform
     def to_builder
       Jbuilder.new do |application_summary|
         application_summary.id id
+        application_summary.short_id short_id
         application_summary.reference reference
         application_summary.title title
         application_summary.received_date received_date
+        application_summary.subject_summary subject_summary.to_json
       end
     end
   end

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -11,6 +11,10 @@ module HmctsCommonPlatform
       data[:applicationId]
     end
 
+    def short_id
+      data[:applicationShortId]
+    end
+
     def application_reference
       data[:applicationReference]
     end
@@ -58,6 +62,7 @@ module HmctsCommonPlatform
     def to_builder
       Jbuilder.new do |summary|
         summary.application_id application_id
+        summary.short_id short_id
         summary.application_reference application_reference
         summary.application_status application_status
         summary.application_title application_title

--- a/lib/schemas/api/progression.query.laa.application-laa.json
+++ b/lib/schemas/api/progression.query.laa.application-laa.json
@@ -10,6 +10,10 @@
       "description": "The LAA issued reference to the application.  Currently known as the MAAT Id",
       "type": "string"
     },
+    "applicationShortId": {
+      "description": "An HMCTS-generated unique string identifying the application",
+      "type": "string"
+    },
     "applicationStatus": {
       "description": "Indicates if the application is draft, listed or finalised",
       "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/courtApplicationStatus"

--- a/lib/schemas/global/search/apiApplicationSummary.json
+++ b/lib/schemas/global/search/apiApplicationSummary.json
@@ -19,6 +19,156 @@
     "receivedDate": {
       "description": "The date the application was received",
       "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+    },
+    "applicationShortId": {
+      "description": "An HMCTS-generated unique string identifying the application",
+      "type": "string"
+    },
+    "subjectSummary":  {
+      "id": "http://justice.gov.uk/progression/query/laa/subject-summary.json",
+      "type": "object",
+      "properties": {
+        "proceedingsConcluded": {
+          "type": "boolean"
+        },
+        "subjectId": {
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "masterDefendantId": {
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "defendantASN": {
+          "type": "string"
+        },
+        "defendantFirstName": {
+          "type": "string"
+        },
+        "defendantMiddleName": {
+          "type": "string"
+        },
+        "defendantLastName": {
+          "type": "string"
+        },
+        "defendantDOB": {
+          "type": "string"
+        },
+        "defendantNINO": {
+          "type": "string"
+        },
+        "dateOfNextHearing": {
+          "type": "string"
+        },
+        "representationOrder": {
+          "id": "http://justice.gov.uk/progression/query/laa/representation-order.json",
+          "type": "object",
+          "properties": {
+            "applicationReference": {
+              "type": "string"
+            },
+            "effectiveFromDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "effectiveToDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "laaContractNumber": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationReference"
+          ],
+          "additionalProperties": true
+        },
+        "offenceSummary": {
+          "type": "array",
+          "items": [
+            {
+              "id": "http://justice.gov.uk/progression/query/laa/offence-summary.json",
+              "type": "object",
+              "properties": {
+                "offenceId": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+                },
+                "offenceCode": {
+                  "type": "string"
+                },
+                "offenceTitle": {
+                  "type": "string"
+                },
+                "offenceLegislation": {
+                  "type": "string"
+                },
+                "proceedingsConcluded": {
+                  "type": "boolean"
+                },
+                "arrestDate": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+                },
+                "dateOfInformation": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+                },
+                "endDate": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+                },
+                "startDate": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+                },
+                "chargeDate": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
+                },
+                "modeOfTrial": {
+                  "type": "string"
+                },
+                "orderIndex": {
+                  "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/positiveInteger"
+                },
+                "wording": {
+                  "type": "string"
+                },
+                "laaApplnReference": {
+                  "id": "http://justice.gov.uk/progression/query/laa/laa-appln-reference.json",
+                  "type": "object",
+                  "properties": {
+                    "applicationReference": {
+                      "type": "string"
+                    },
+                    "statusId": {
+                      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+                    },
+                    "statusCode": {
+                      "type": "string"
+                    },
+                    "statusDescription": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applicationReference",
+                    "statusId",
+                    "statusCode",
+                    "statusDescription"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "offenceId",
+                "offenceCode",
+                "offenceTitle"
+              ],
+              "additionalProperties": true
+            }
+          ]
+        }
+      },
+      "required": [
+        "subjectId",
+        "defendantFirstName"
+      ],
+      "additionalProperties": true
     }
   }
 }

--- a/spec/fixtures/files/application_summary/all_fields.json
+++ b/spec/fixtures/files/application_summary/all_fields.json
@@ -1,6 +1,18 @@
 {
   "applicationId": "6cd6494e-5409-420a-bd0b-f589dbb2466b",
+  "applicationShortId": "A25ABCDE1234",
   "applicationReference": "CJ03511",
   "applicationTitle": "Conviction of an offence while a community order is in force",
-  "receivedDate": "2024-12-15"
+  "receivedDate": "2024-12-15",
+  "subjectSummary": {
+      "dateOfNextHearing": "2025-02-07T10:00:00.000Z",
+      "defendantASN": "2391NX0000489661589D",
+      "defendantDOB": "1999-02-06",
+      "defendantFirstName": "Naida",
+      "defendantLastName": "Daniel",
+      "masterDefendantId": "a86c42dc-6566-4076-9655-b3a53cd58566",
+      "offenceSummary": [],
+      "proceedingsConcluded": false,
+      "subjectId": "4b463e6a-105b-433b-a88d-057d6e645bfb"
+    }
 }

--- a/spec/fixtures/files/court_application_details/all_fields.json
+++ b/spec/fixtures/files/court_application_details/all_fields.json
@@ -1,5 +1,6 @@
 {
     "applicationId": "4362f2bc-7aff-462a-a242-0db421aa6a96",
+    "applicationShortId": "A25ABCDE1234",
     "applicationReference": "RQ249717027",
     "applicationStatus": "FINALISED",
     "applicationTitle": "Appeal against conviction by a Magistrates' Court to the Crown Court",

--- a/spec/fixtures/files/court_application_summary.json
+++ b/spec/fixtures/files/court_application_summary.json
@@ -1,5 +1,6 @@
 {
   "applicationId": "00004c9f-af9f-401a-b88b-78a4f0e08163",
+  "applicationShortId": "A25ABCDE1234",
   "applicationReference": "29GD7216523",
   "applicationStatus": "FINALISED",
   "applicationTitle": "Appeal against conviction by a Magistrates' Court to the Crown Court",

--- a/spec/models/hmcts_common_platform/application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/application_summary_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe HmctsCommonPlatform::ApplicationSummary, type: :model do
     it { expect(application_summary.reference).to eql("CJ03511") }
     it { expect(application_summary.title).to eql("Conviction of an offence while a community order is in force") }
     it { expect(application_summary.received_date).to eql("2024-12-15") }
+    it { expect(application_summary.short_id).to eql("A25ABCDE1234") }
+    it { expect(application_summary.subject_summary).to be_a(HmctsCommonPlatform::SubjectSummary) }
   end
 
   describe "#to_json" do
@@ -22,6 +24,8 @@ RSpec.describe HmctsCommonPlatform::ApplicationSummary, type: :model do
       expect(json["reference"]).to eql("CJ03511")
       expect(json["title"]).to eql("Conviction of an offence while a community order is in force")
       expect(json["received_date"]).to eql("2024-12-15")
+      expect(json["short_id"]).to eql("A25ABCDE1234")
+      expect(json["subject_summary"]).to be_a(Hash)
     end
   end
 end

--- a/spec/models/hmcts_common_platform/court_application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_summary_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
     expect(court_application_summary.to_json["application_title"]).to eql("Appeal against conviction by a Magistrates' Court to the Crown Court")
     expect(court_application_summary.to_json["application_type"]).to eql("Appeal against conviction by a Magistrates' Court to the Crown Court")
     expect(court_application_summary.to_json["received_date"]).to eql("2023-06-27")
+    expect(court_application_summary.to_json["short_id"]).to eql("A25ABCDE1234")
     expect(court_application_summary.to_json["case_summary"]).to be_a(Array)
     expect(court_application_summary.to_json["hearing_summary"]).to be_a(Array)
     expect(court_application_summary.to_json["subject_summary"]).to be_a(Hash)
@@ -20,6 +21,7 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
   it { expect(court_application_summary.application_title).to eql("Appeal against conviction by a Magistrates' Court to the Crown Court") }
   it { expect(court_application_summary.application_type).to eql("Appeal against conviction by a Magistrates' Court to the Crown Court") }
   it { expect(court_application_summary.received_date).to eql("2023-06-27") }
+  it { expect(court_application_summary.short_id).to eql("A25ABCDE1234") }
   it { expect(court_application_summary.case_summary.first).to be_a(HmctsCommonPlatform::CaseSummary) }
   it { expect(court_application_summary.hearing_summary.first).to be_a(HmctsCommonPlatform::HearingSummary) }
   it { expect(court_application_summary.subject_summary).to be_a(HmctsCommonPlatform::SubjectSummary) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-647)
[Link to story](https://dsdmoj.atlassian.net/browse/ACD-636)

Pass on to client the application short ID and the subject summary in both application payloads - the application summary in the prosecution cases search endpoint and the 'get court application' endpoint.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
