### PR TITLE
Keep subscription keys out of logs

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,4 +1,4 @@
-HEADERS_TO_FILTER = %w[HTTP_AUTHORIZATION].freeze
+HEADERS_TO_FILTER = %w[HTTP_AUTHORIZATION HTTP_OCP_APIM_SUBSCRIPTION_KEY].freeze
 
 Rails.application.configure do
   config.lograge.enabled = true


### PR DESCRIPTION
## What
I spotted in production logs, when HMCTS calls "external" API endpoints it includes a HTTP_OCP_APIM_SUBSCRIPTION_KEY header, which I'm pretty sure is a secret credential. We log all headers that start with HTTP by default. So I've added this one to the list of headers to filter out.