### PR TITLE
ACD-358: Stop requiring branch build approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,15 +270,11 @@ workflows:
 
   build-deploy-branch-to-live-cluster:
     jobs:
-      - branch-build-approval:
-          type: approval
+      - build-and-push-app:
           filters:
             branches:
               ignore:
                 - main
-      - build-and-push-app:
-          requires:
-            - branch-build-approval
       - hold_install_on_dev:
           type: approval
           requires:


### PR DESCRIPTION
## What
When we create a PR, the CI pipeline needs an approval even to build the image. This is redundant, as a second approval is needed to do anything with that image, and it makes getting stuff onto dev very tedious with multiple manual interventions. So we're removing the first approval.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-358)
