### PR TITLE
Cope with unexpected HMCTS responses

### DIFF
--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -36,7 +36,7 @@ module CommonPlatform
         # fetch details needed to include plea and mode of trial reason, at least
         prosecution_case = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)&.first
 
-        prosecution_case.load_hearing_results(defendant_id)
+        prosecution_case&.load_hearing_results(defendant_id)
 
         prosecution_case
       end

--- a/app/services/common_platform/hearing_results_filter.rb
+++ b/app/services/common_platform/hearing_results_filter.rb
@@ -8,7 +8,7 @@ module CommonPlatform
     def call
       return @body unless @defendant_id
 
-      @body["hearing"]["prosecutionCases"] = @body["hearing"]["prosecutionCases"].map do |prosecution_case|
+      @body["hearing"]["prosecutionCases"] = @body["hearing"]["prosecutionCases"]&.map do |prosecution_case|
         prosecution_case.merge(
           "defendants" => prosecution_case["defendants"].select { |defendant| defendant["id"] == @defendant_id },
         )

--- a/spec/services/common_platform/api/defendant_finder_spec.rb
+++ b/spec/services/common_platform/api/defendant_finder_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe CommonPlatform::Api::DefendantFinder do
       end
     end
 
+    context "when common platform does not match local records" do
+      let(:local_prosecution_cases_json) { file_fixture("prosecution_case_search_result.json").read }
+      let(:prosecution_cases_hash) { JSON.parse(local_prosecution_cases_json) }
+      let(:prosecution_cases_json) { '{ "cases":[] }' }
+
+      it { is_expected.to be_nil }
+    end
+
     context "when defendant does not exist" do
       let(:defendant_id) { "2ecc9feb-9407-482f-b081-123456789012" }
 


### PR DESCRIPTION
## What
PR to defend against https://mojdt.slack.com/archives/C06G0PRN82U/p1745391484984169. The issue is that sometimes common platform doesn't return a matching record for a URN that we found locally. This is an edge case we handled gracefully before we made the defendant endpoint more efficient, so this PR is simply restoring the graceful behaviour we had before.
