### PR TITLE
Stop routing web requests to worker/metrics pods

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/deployment-metrics.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/deployment-metrics.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 6 }}
+      app: laa-court-data-adaptor-metrics
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 8 }}
+        app: laa-court-data-adaptor-metrics
     spec:
      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm_deploy/laa-court-data-adaptor/templates/deployment-worker.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/deployment-worker.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 6 }}
+      app: laa-court-data-adaptor-worker
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 8 }}
+        app: laa-court-data-adaptor-worker
     spec:
      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## What
Switch labels on non-web pods so we stop routing HTTP requests to them