### PR TITLE
Revert metrics change

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/deployment-metrics.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/deployment-metrics.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: laa-court-data-adaptor-metrics
+      {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        app: laa-court-data-adaptor-metrics
+        {{- include "laa-court-data-adaptor.selectorLabels" . | nindent 8 }}
     spec:
      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
My last PR broke prometheus metrics collection, because our code expects to be able to make HTTP requests to the metrics pods. I _think_ that because metrics pods only expose a different port to normal pods, normal HTTP requests won't be routed to metrics pods. So I'm reverting the metrics deployment part of my last PR (but keeping the worker deployment bit, as that was I think the most problematic part).