### PR TITLE
ACD-669: Adjust to match HMCTS schema/param differences

### DIFF
--- a/app/controllers/api/internal/v1/hearing_results_controller.rb
+++ b/app/controllers/api/internal/v1/hearing_results_controller.rb
@@ -7,7 +7,6 @@ module Api
         def show
           hearing_result_data = CommonPlatform::Api::GetHearingResults.call(
             hearing_id: permitted_params[:id],
-            sitting_day: permitted_params[:sitting_day],
           )
 
           hearing_result = HearingResult.new(hearing_result_data)
@@ -33,7 +32,6 @@ module Api
         def permitted_params
           params.permit(
             :id,
-            :sitting_day,
             :include,
           )
         end

--- a/app/controllers/api/internal/v2/hearing_results_controller.rb
+++ b/app/controllers/api/internal/v2/hearing_results_controller.rb
@@ -7,7 +7,6 @@ module Api
         def show
           hearing_result_data = CommonPlatform::Api::GetHearingResults.call(
             hearing_id: permitted_params[:hearing_id],
-            sitting_day: permitted_params[:sitting_day],
             publish_to_queue: permitted_params[:publish_to_queue],
           )
 
@@ -26,7 +25,6 @@ module Api
         def permitted_params
           params.permit(
             :hearing_id,
-            :sitting_day,
             :publish_to_queue,
           )
         end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class Hearing
-  attr_reader :data, :skip_events
+  attr_reader :data, :load_events
 
   delegate :blank?, to: :data
 
-  def initialize(data, skip_events: false)
+  def initialize(data, load_events: true)
     @data = HashWithIndifferentAccess.new(data || {})
-    @skip_events = skip_events
+    @load_events = load_events
   end
 
   def id
@@ -117,7 +117,7 @@ private
   end
 
   def hearing_event_recordings
-    return [] if skip_events
+    return [] unless load_events
 
     @hearing_event_recordings ||= Array(data["hearingDays"]).flat_map { |hearing_day|
       CommonPlatform::Api::GetHearingEvents.call(hearing_id: id, hearing_date: hearing_day["sittingDay"].to_date)

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Hearing
-  attr_reader :data
+  attr_reader :data, :skip_events
 
   delegate :blank?, to: :data
 
-  def initialize(data)
+  def initialize(data, skip_events: false)
     @data = HashWithIndifferentAccess.new(data || {})
+    @skip_events = skip_events
   end
 
   def id
@@ -116,6 +117,8 @@ private
   end
 
   def hearing_event_recordings
+    return [] if skip_events
+
     @hearing_event_recordings ||= Array(data["hearingDays"]).flat_map { |hearing_day|
       CommonPlatform::Api::GetHearingEvents.call(hearing_id: id, hearing_date: hearing_day["sittingDay"].to_date)
     }.compact

--- a/app/models/hearing_result.rb
+++ b/app/models/hearing_result.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class HearingResult
-  attr_reader :data, :skip_events
+  attr_reader :data, :load_events
 
   delegate :blank?, to: :data
 
-  def initialize(data, skip_events: false)
+  def initialize(data, load_events: true)
     @data = HashWithIndifferentAccess.new(data || {})
-    @skip_events = skip_events
+    @load_events = load_events
   end
 
   def hearing
-    Hearing.new(data[:hearing], skip_events:)
+    Hearing.new(data[:hearing], load_events:)
   end
 
   def shared_time

--- a/app/models/hearing_result.rb
+++ b/app/models/hearing_result.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 class HearingResult
-  attr_reader :data
+  attr_reader :data, :skip_events
 
   delegate :blank?, to: :data
 
-  def initialize(data)
+  def initialize(data, skip_events: false)
     @data = HashWithIndifferentAccess.new(data || {})
+    @skip_events = skip_events
   end
 
   def hearing
-    Hearing.new(data[:hearing])
+    Hearing.new(data[:hearing], skip_events:)
   end
 
   def shared_time

--- a/app/models/hmcts_common_platform/court_application_type.rb
+++ b/app/models/hmcts_common_platform/court_application_type.rb
@@ -54,10 +54,6 @@ module HmctsCommonPlatform
       data[:validFrom]
     end
 
-    def valid_to
-      data[:validTo]
-    end
-
     def offence_active_order
       data[:offenceActiveOrder]
     end
@@ -124,7 +120,8 @@ module HmctsCommonPlatform
         court_application_type.plea_applicable_flag plea_applicable_flag
         court_application_type.summons_template_type summons_template_type
         court_application_type.valid_from valid_from
-        court_application_type.valid_to valid_to
+        court_application_type.valid_to nil # We used to mistakenly believe this was a datum provided by HMCTS.
+        # It is not, but removing it would be a breaking change
         court_application_type.offence_active_order offence_active_order
         court_application_type.commr_of_oath_flag commr_of_oath_flag
         court_application_type.breach_type breach_type

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -37,8 +37,8 @@ class ProsecutionCase < LegalCase
     body["prosecutionCaseReference"]
   end
 
-  def load_hearing_results(defendant_id, skip_events: false)
-    hearing_results(defendant_id, skip_events:)
+  def load_hearing_results(defendant_id, load_events: true)
+    hearing_results(defendant_id, load_events:)
   end
 
 private
@@ -62,13 +62,13 @@ private
       .group_by { |defendant| defendant["id"] }
   end
 
-  def hearing_results(defendant_id = nil, skip_events: false)
+  def hearing_results(defendant_id = nil, load_events: true)
     @hearing_results ||= hearing_summaries_for(defendant_id).flat_map { |hearing_summary|
       HearingResult.new(
         CommonPlatform::Api::GetHearingResults.call(
           hearing_id: hearing_summary.id,
         ),
-        skip_events:,
+        load_events:,
       )
     }.reject(&:blank?)
   end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -37,8 +37,8 @@ class ProsecutionCase < LegalCase
     body["prosecutionCaseReference"]
   end
 
-  def load_hearing_results(defendant_id)
-    hearing_results(defendant_id)
+  def load_hearing_results(defendant_id, skip_events: false)
+    hearing_results(defendant_id, skip_events:)
   end
 
 private
@@ -62,16 +62,14 @@ private
       .group_by { |defendant| defendant["id"] }
   end
 
-  def hearing_results(defendant_id = nil)
+  def hearing_results(defendant_id = nil, skip_events: false)
     @hearing_results ||= hearing_summaries_for(defendant_id).flat_map { |hearing_summary|
-      hearing_summary.hearing_days.map do |hearing_day|
-        HearingResult.new(
-          CommonPlatform::Api::GetHearingResults.call(
-            hearing_id: hearing_summary.id,
-            sitting_day: hearing_day.sitting_day,
-          ),
-        )
-      end
+      HearingResult.new(
+        CommonPlatform::Api::GetHearingResults.call(
+          hearing_id: hearing_summary.id,
+        ),
+        skip_events:,
+      )
     }.reject(&:blank?)
   end
 

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -36,7 +36,7 @@ module CommonPlatform
         # fetch details needed to include plea and mode of trial reason, at least
         prosecution_case = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)&.first
 
-        prosecution_case&.load_hearing_results(defendant_id)
+        prosecution_case&.load_hearing_results(defendant_id, skip_events: true)
 
         prosecution_case
       end

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -36,7 +36,7 @@ module CommonPlatform
         # fetch details needed to include plea and mode of trial reason, at least
         prosecution_case = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)&.first
 
-        prosecution_case&.load_hearing_results(defendant_id, skip_events: true)
+        prosecution_case&.load_hearing_results(defendant_id, load_events: false)
 
         prosecution_case
       end

--- a/app/services/common_platform/api/get_hearing_results.rb
+++ b/app/services/common_platform/api/get_hearing_results.rb
@@ -3,10 +3,10 @@
 module CommonPlatform
   module Api
     class GetHearingResults < ApplicationService
-      def initialize(hearing_id:, sitting_day: nil, publish_to_queue: false)
+      def initialize(hearing_id:, publish_to_queue: false)
         @hearing_id = hearing_id
         @publish_to_queue = publish_to_queue
-        @response = HearingFetcher.call(hearing_id:, sitting_day:)
+        @response = HearingFetcher.call(hearing_id:)
       end
 
       def call

--- a/app/services/common_platform/api/hearing_fetcher.rb
+++ b/app/services/common_platform/api/hearing_fetcher.rb
@@ -5,8 +5,8 @@ module CommonPlatform
     class HearingFetcher < ApplicationService
       URL = "hearing/results"
 
-      def initialize(hearing_id:, sitting_day:, connection: CommonPlatform::Connection.instance.call)
-        @params = { hearingId: hearing_id, sittingDay: sitting_day }.reject { |_k, v| v.blank? }
+      def initialize(hearing_id:, connection: CommonPlatform::Connection.instance.call)
+        @params = { hearingId: hearing_id }.reject { |_k, v| v.blank? }
         @connection = connection
       end
 

--- a/app/services/court_application_maat_link_creator.rb
+++ b/app/services/court_application_maat_link_creator.rb
@@ -67,15 +67,13 @@ private
 
   def fetch_past_hearings
     court_application_summary.hearing_summary.each do |hearing_summary|
-      hearing_summary.hearing_days.each do |hearing_day|
-        HearingResultFetcherWorker.perform_at(
-          30.seconds.from_now,
-          Current.request_id,
-          hearing_summary.id,
-          hearing_day.sitting_day,
-          laa_reference.defendant_id,
-        )
-      end
+      HearingResultFetcherWorker.perform_at(
+        30.seconds.from_now,
+        Current.request_id,
+        hearing_summary.id,
+        nil,
+        laa_reference.defendant_id,
+      )
     end
   end
 

--- a/app/services/hearing_result_fetcher.rb
+++ b/app/services/hearing_result_fetcher.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
 class HearingResultFetcher < ApplicationService
-  attr_reader :hearing_id, :sitting_day, :defendant_id
+  attr_reader :hearing_id, :defendant_id
 
-  def initialize(hearing_id, sitting_day, defendant_id)
+  def initialize(hearing_id, defendant_id)
     @hearing_id = hearing_id
-    @sitting_day = sitting_day
     @defendant_id = defendant_id
   end
 
   def call
     response = CommonPlatform::Api::HearingFetcher.call(
       hearing_id:,
-      sitting_day:,
     )
 
     if response.success?

--- a/app/services/maat_link_creator.rb
+++ b/app/services/maat_link_creator.rb
@@ -70,15 +70,13 @@ private
 
   def fetch_past_hearings
     hearing_summaries.each do |hearing_summary|
-      hearing_summary.hearing_days.each do |hearing_day|
-        HearingResultFetcherWorker.perform_at(
-          30.seconds.from_now,
-          Current.request_id,
-          hearing_summary.id,
-          hearing_day.sitting_day,
-          defendant_id,
-        )
-      end
+      HearingResultFetcherWorker.perform_at(
+        30.seconds.from_now,
+        Current.request_id,
+        hearing_summary.id,
+        nil,
+        defendant_id,
+      )
     end
   end
 

--- a/app/workers/hearing_result_fetcher_worker.rb
+++ b/app/workers/hearing_result_fetcher_worker.rb
@@ -4,9 +4,9 @@ class HearingResultFetcherWorker
   include Sidekiq::Worker
   sidekiq_options retry: 7 # with exponential backoff, this retries over ~40 minutes
 
-  def perform(request_id, hearing_id, sitting_day, defendant_id)
+  def perform(request_id, hearing_id, _sitting_day, defendant_id)
     Current.set(request_id:) do
-      HearingResultFetcher.call(hearing_id, sitting_day, defendant_id)
+      HearingResultFetcher.call(hearing_id, defendant_id)
     end
   end
 end

--- a/docs/schemas_common_platform_court_applications/global_2/apiCourtApplication.json
+++ b/docs/schemas_common_platform_court_applications/global_2/apiCourtApplication.json
@@ -69,7 +69,7 @@
     },
     "subject": {
       "description": "The party that is the subject of teh application.  The subject is also a respondent or an applicant and is the subject of any orders and directions that are made during court proceedings",
-      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtApplicationParty.json"
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtApplicationSubject.json"
     },
     "applicationParticulars": {
       "description": "The particulars of the application when not covered by the associated document",

--- a/docs/schemas_common_platform_court_applications/global_2/apiCourtApplicationSubject.json
+++ b/docs/schemas_common_platform_court_applications/global_2/apiCourtApplicationSubject.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://justice.gov.uk/core/courts/external/apiCourtApplicationSubject.json",
+  "description": "The subject of an application",
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+    },
+    "masterDefendant": {
+      "description": "The primary defendant",
+      "$ref": "http://justice.gov.uk/core/courts/external/apiMasterDefendant.json"
+    },
+    "organisationPersons": {
+      "description": "Provided when the party is an organisation",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "http://justice.gov.uk/core/courts/external/apiAssociatedPerson.json"
+      }
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas_common_platform_court_applications/global_2/apiCourtApplicationType.json
+++ b/docs/schemas_common_platform_court_applications/global_2/apiCourtApplicationType.json
@@ -48,10 +48,6 @@
       "type": "string",
       "format": "date"
     },
-    "validTo": {
-      "type": "string",
-      "format": "date"
-    },
     "applicantAppellantFlag": {
       "type": "boolean"
     },
@@ -102,12 +98,6 @@
       "type": "boolean"
     },
     "hearingCode": {
-      "type": "string"
-    },
-    "resentencingActivationCode": {
-      "type": "string"
-    },
-    "prefix": {
       "type": "string"
     }
   },

--- a/lib/schemas/global/apiCourtApplicationType.json
+++ b/lib/schemas/global/apiCourtApplicationType.json
@@ -48,10 +48,6 @@
       "type": "string",
       "format": "date"
     },
-    "validTo": {
-      "type": "string",
-      "format": "date"
-    },
     "applicantAppellantFlag": {
       "type": "boolean"
     },
@@ -102,12 +98,6 @@
       "type": "boolean"
     },
     "hearingCode": {
-      "type": "string"
-    },
-    "resentencingActivationCode": {
-      "type": "string"
-    },
-    "prefix": {
       "type": "string"
     }
   },

--- a/spec/fixtures/files/court_application_type/all_fields.json
+++ b/spec/fixtures/files/court_application_type/all_fields.json
@@ -20,6 +20,5 @@
   "spiOutApplicableFlag": true,
   "summonsTemplateType": "NOT_APPLICABLE",
   "type": "Application for transfer of legal aid",
-  "validFrom": "2022-01-01",
-  "validTo": "2022-01-02"
+  "validFrom": "2022-01-01"
 }

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
       let(:hearing_result_data) do
         VCR.use_cassette("hearing_result_fetcher/success") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id:, sitting_day: nil)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id:)
         end
       end
       let(:hearing) { described_class.new(hearing_result_data["hearing"]) }
@@ -64,7 +64,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "29b73d8f-7683-4e27-9069-f7a031672c35" }
       let(:hearing_result_data) do
         VCR.use_cassette("hearing_result_fetcher/success_hearing_attendees") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id:, sitting_day: nil)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id:)
         end
       end
       let(:hearing) { described_class.new(hearing_result_data["hearing"]) }
@@ -99,7 +99,7 @@ RSpec.describe Hearing, type: :model do
       let(:hearing_id) { "da124701-048f-408c-85b4-81138316ddce" }
       let(:hearing_result_data) do
         VCR.use_cassette("hearing_result_fetcher/success_hearing_cracked_trial") do
-          CommonPlatform::Api::GetHearingResults.call(hearing_id:, sitting_day: nil)
+          CommonPlatform::Api::GetHearingResults.call(hearing_id:)
         end
       end
       let(:hearing) { described_class.new(hearing_result_data["hearing"]) }

--- a/spec/models/hmcts_common_platform/court_application_type_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_type_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationType, type: :model do
       expect(court_application_type.to_json["plea_applicable_flag"]).to be false
       expect(court_application_type.to_json["summons_template_type"]).to eql("NOT_APPLICABLE")
       expect(court_application_type.to_json["valid_from"]).to eql("2022-01-01")
-      expect(court_application_type.to_json["valid_to"]).to eql("2022-01-02")
+      expect(court_application_type.to_json["valid_to"]).to be_nil
       expect(court_application_type.to_json["offence_active_order"]).to eql("NOT_APPLICABLE")
       expect(court_application_type.to_json["commr_of_oath_flag"]).to be false
       expect(court_application_type.to_json["breach_type"]).to eql("NOT_APPLICABLE")
@@ -47,7 +47,6 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationType, type: :model do
     it { expect(court_application_type.plea_applicable_flag).to be false }
     it { expect(court_application_type.summons_template_type).to eql("NOT_APPLICABLE") }
     it { expect(court_application_type.valid_from).to eql("2022-01-01") }
-    it { expect(court_application_type.valid_to).to eql("2022-01-02") }
     it { expect(court_application_type.offence_active_order).to eql("NOT_APPLICABLE") }
     it { expect(court_application_type.commr_of_oath_flag).to be false }
     it { expect(court_application_type.breach_type).to eql("NOT_APPLICABLE") }

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ProsecutionCase, type: :model do
     context "when GetHearingResults returns a hearing" do
       before do
         allow(CommonPlatform::Api::GetHearingResults).to receive(:call)
-          .with(hearing_id: "0c401e0d-9d88-4cb8-8543-2090782edd32", sitting_day: "2025-02-18T09:01:01.001Z")
+          .with(hearing_id: "0c401e0d-9d88-4cb8-8543-2090782edd32")
           .and_return(hearing_result_body)
       end
 
@@ -134,21 +134,15 @@ RSpec.describe ProsecutionCase, type: :model do
             ]
           end
 
-          it "looks up hearing results for every day of every hearing" do
+          it "looks up hearing results for every hearing" do
             expect(CommonPlatform::Api::GetHearingResults).to receive(:call).once.ordered.with(
               hearing_id: "HEARING_1_ID",
-              sitting_day: "2025-01-01",
             ).and_return({ tag: "result_1" })
             expect(CommonPlatform::Api::GetHearingResults).to receive(:call).once.ordered.with(
-              hearing_id: "HEARING_1_ID",
-              sitting_day: "2025-01-02",
-            ).and_return({ tag: "result_2" })
-            expect(CommonPlatform::Api::GetHearingResults).to receive(:call).once.ordered.with(
               hearing_id: "HEARING_2_ID",
-              sitting_day: "2025-02-01",
-            ).and_return({ tag: "result_3" })
+            ).and_return({ tag: "result_2" })
             call
-            expect(output.length).to eq 3
+            expect(output.length).to eq 2
           end
         end
 
@@ -175,7 +169,6 @@ RSpec.describe ProsecutionCase, type: :model do
           it "looks up hearing results for only the relevant hearings" do
             expect(CommonPlatform::Api::GetHearingResults).to receive(:call).once.with(
               hearing_id: "HEARING_2_ID",
-              sitting_day: "2025-02-01",
             ).and_return({ tag: "result_3" })
             call
             expect(output.length).to eq 1

--- a/spec/requests/api/internal/v1/hearings_request_spec.rb
+++ b/spec/requests/api/internal/v1/hearings_request_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "api/internal/v1/hearings", swagger_doc: "v1/swagger.yaml", type:
                   description: "The sitting day of the hearing"
 
         around do |example|
-          VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
+          VCR.use_cassette("hearing_result_fetcher/success") do
             VCR.use_cassette("hearing_logs_fetcher/success") do
               example.run
             end

--- a/spec/requests/api/internal/v2/hearing_results_request_spec.rb
+++ b/spec/requests/api/internal/v2/hearing_results_request_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "api/internal/v2/hearing_results", swagger_doc: "v2/swagger.yaml"
                   description: "The sitting day of the hearing"
 
         before do
-          stub_request(:get, "#{ENV['COMMON_PLATFORM_URL']}/hearing/results?hearingId=#{hearing_id}&sittingDay=#{sitting_day}")
+          stub_request(:get, "#{ENV['COMMON_PLATFORM_URL']}/hearing/results?hearingId=#{hearing_id}")
             .to_return(
               status: 200,
               headers: { content_type: "application/json" },

--- a/spec/services/common_platform/api/get_hearing_results_spec.rb
+++ b/spec/services/common_platform/api/get_hearing_results_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CommonPlatform::Api::GetHearingResults do
 
     allow(CommonPlatform::Api::HearingFetcher)
       .to receive(:call)
-      .with(hearing_id:, sitting_day: nil)
+      .with(hearing_id:)
       .and_return(response)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe CommonPlatform::Api::GetHearingResults do
     it "calls HearingFetcher with hearing ID" do
       expect(CommonPlatform::Api::HearingFetcher)
         .to receive(:call)
-        .with(hearing_id:, sitting_day: nil)
+        .with(hearing_id:)
 
       get_hearing_results
     end
@@ -37,20 +37,19 @@ RSpec.describe CommonPlatform::Api::GetHearingResults do
     end
   end
 
-  context "when getting results by hearing id and hearing date" do
-    subject(:get_hearing_results) { described_class.call(hearing_id:, sitting_day:) }
+  context "when getting results by hearing id" do
+    subject(:get_hearing_results) { described_class.call(hearing_id:) }
 
     let(:hearing_id) { "ceb158e3-7171-40ce-915b-441e2c4e3f75" }
-    let(:sitting_day) { "2021-05-20" }
 
     before do
-      allow(CommonPlatform::Api::HearingFetcher).to receive(:call).with(hearing_id:, sitting_day:).and_return(response)
+      allow(CommonPlatform::Api::HearingFetcher).to receive(:call).with(hearing_id:).and_return(response)
     end
 
-    it "calls HearingFetcher with hearing ID and sitting day" do
+    it "calls HearingFetcher with hearing ID" do
       expect(CommonPlatform::Api::HearingFetcher)
         .to receive(:call)
-        .with(hearing_id:, sitting_day:)
+        .with(hearing_id:)
 
       get_hearing_results
     end

--- a/spec/services/common_platform/api/hearing_fetcher_spec.rb
+++ b/spec/services/common_platform/api/hearing_fetcher_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe CommonPlatform::Api::HearingFetcher do
   context "when fetching result by hearing id only" do
-    subject(:fetch_hearing) { described_class.call(hearing_id:, sitting_day: nil) }
+    subject(:fetch_hearing) { described_class.call(hearing_id:) }
 
     let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
 
@@ -13,7 +13,7 @@ RSpec.describe CommonPlatform::Api::HearingFetcher do
     end
 
     context "with a incorrect key" do
-      subject(:fetch_hearing) { described_class.call(hearing_id:, sitting_day: nil, connection:) }
+      subject(:fetch_hearing) { described_class.call(hearing_id:, connection:) }
 
       let(:connection) { CommonPlatform::Connection.instance.call }
 
@@ -29,7 +29,7 @@ RSpec.describe CommonPlatform::Api::HearingFetcher do
     end
 
     context "with connection" do
-      subject(:fetch_hearing) { described_class.call(hearing_id:, sitting_day: nil, connection:) }
+      subject(:fetch_hearing) { described_class.call(hearing_id:, connection:) }
 
       let(:connection) { double("CommonPlatformConnection") }
       let(:url) { "hearing/results" }
@@ -43,33 +43,32 @@ RSpec.describe CommonPlatform::Api::HearingFetcher do
   end
 
   context "when fetching result with hearing_id and hearing_day query params" do
-    subject(:fetch_hearing) { described_class.call(hearing_id:, sitting_day:) }
+    subject(:fetch_hearing) { described_class.call(hearing_id:) }
 
     let(:hearing_id) { "4d01840d-5959-4539-a450-d39f57171036" }
-    let(:sitting_day) { "2020-08-17" }
 
     let(:connection) { double("CommonPlatform::Connection") }
     let(:url) { "hearing/results" }
     let(:params) { { hearingId: hearing_id } }
 
     it "returns the requested hearing info" do
-      VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
+      VCR.use_cassette("hearing_result_fetcher/success") do
         expect(fetch_hearing.body["hearing"]["id"]).to eq(hearing_id)
       end
     end
 
     it "returns the requested hearing date" do
-      VCR.use_cassette("hearing_result_fetcher/success_specified_sitting_day") do
+      VCR.use_cassette("hearing_result_fetcher/success") do
         expect(fetch_hearing.body["hearing"]["hearingDays"][0]["sittingDay"]).to eq("2020-08-17T09:01:01.001Z")
       end
     end
 
     context "with connection" do
-      subject(:fetch_hearing) { described_class.call(hearing_id:, sitting_day:, connection:) }
+      subject(:fetch_hearing) { described_class.call(hearing_id:, connection:) }
 
       let(:connection) { double("CommonPlatformConnection") }
       let(:url) { "hearing/results" }
-      let(:params) { { hearingId: hearing_id, sittingDay: sitting_day } }
+      let(:params) { { hearingId: hearing_id } }
 
       it "makes a get request" do
         expect(connection).to receive(:get).with(url, params)

--- a/spec/services/hearing_result_fetcher_spec.rb
+++ b/spec/services/hearing_result_fetcher_spec.rb
@@ -4,14 +4,12 @@ RSpec.describe HearingResultFetcher do
   subject(:fetch_hearing_result) do
     described_class.call(
       hearing_id,
-      sitting_day,
       defendant_id,
     )
   end
 
   let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing_resulted.json").read) }
   let(:hearing_id) { hearing_resulted_data["hearing"]["id"] }
-  let(:sitting_day) { "2022-12-05" }
   let(:defendant_id) { hearing_resulted_data["hearing"]["prosecutionCases"].first["defendants"].first["id"] }
 
   let(:response) do

--- a/spec/services/maat_link_creator_spec.rb
+++ b/spec/services/maat_link_creator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MaatLinkCreator do
     allow(CommonPlatform::Api::RecordLaaReference).to receive(:call)
   end
 
-  it "enqueues a HearingResultFetcherWorker per hearing day" do
+  it "enqueues a HearingResultFetcherWorker per hearing" do
     allow(CommonPlatform::Api::RecordLaaReference)
       .to receive(:call)
       .and_return(response)
@@ -41,7 +41,7 @@ RSpec.describe MaatLinkCreator do
         Current.set(request_id: "XYZ") do
           expect(HearingResultFetcherWorker)
             .to receive(:perform_at)
-            .exactly(3).times
+            .exactly(4).times
 
           create_maat_link
         end

--- a/spec/workers/hearing_result_fetcher_worker_spec.rb
+++ b/spec/workers/hearing_result_fetcher_worker_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe HearingResultFetcherWorker, type: :worker do
         .once
         .with(
           "99c753e2-9c89-4c1a-b191-4f73084721b4",
-          "2022-11-05",
           nil,
         )
 

--- a/swagger/v2/court_application_type.json
+++ b/swagger/v2/court_application_type.json
@@ -55,8 +55,7 @@
       "format": "date"
     },
     "valid_to": {
-      "type": "string",
-      "format": "date"
+      "type": "null"
     },
     "applicant_appellant_flag": {
       "type": "boolean"


### PR DESCRIPTION
## What
- Stop expecting court application type to include validTo, resentencingActivationCode and prefix
- Since the hearing results endpoint ignores the sittingDay param, stop sending it and also stop calling it multiple times with different sittingDays
- Also stop loading hearing events when constructing the v1 defendant payload as that slows down the endpoint.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-669)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
