### PR TITLE
ACD-701: Add start date to offences payload

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -64,6 +64,10 @@ class Offence
     HmctsCommonPlatform::Verdict.new(body["verdict"])
   end
 
+  def start_date
+    body["startDate"]
+  end
+
 private
 
   def laa_reference

--- a/app/serializers/api/internal/v1/offence_serializer.rb
+++ b/app/serializers/api/internal/v1/offence_serializer.rb
@@ -13,7 +13,8 @@ module Api
                    :legislation,
                    :mode_of_trial,
                    :mode_of_trial_reasons,
-                   :pleas
+                   :pleas,
+                   :start_date
 
         attribute :verdict do |offence|
           {

--- a/spec/serializers/api/internal/v1/offence_serializer_spec.rb
+++ b/spec/serializers/api/internal/v1/offence_serializer_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Api::Internal::V1::OffenceSerializer do
         expect(attributes[:pleas]).to eq([{ pleaded_at: "2020-04-12", code: "NOT_GUILTY", originating_hearing_id: "dda833bb-4956-4c9a-a553-59c6af5c15a6" }])
       end
 
+      it "start_date" do
+        expect(attributes[:start_date]).to eq("2021-03-06")
+      end
+
       it "verdict" do
         expected = {
           verdict_date: "2020-04-12",

--- a/swagger/v1/offence.json
+++ b/swagger/v1/offence.json
@@ -233,6 +233,10 @@
           "$ref": "judicial_result.json#/definitions/included_type"
         }
       }
+    },
+    "start_date": {
+      "example": "2023-01-27",
+      "type": "string"
     }
   },
   "resource_collection": {
@@ -291,6 +295,9 @@
     },
     "verdict": {
       "$ref": "#/definitions/verdict"
+    },
+    "start_date": {
+      "$ref": "#/definitions/start_date"
     }
   }
 }


### PR DESCRIPTION
## What
Allow us to show offence dates in VCD without having to switch to the v2 defendants endpoint

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-701)