### PR TITLE
ACD-755: Handle no offences in subject summary

### DIFF
--- a/app/models/hmcts_common_platform/subject_summary.rb
+++ b/app/models/hmcts_common_platform/subject_summary.rb
@@ -51,7 +51,7 @@ module HmctsCommonPlatform
     end
 
     def offence_summary
-      data[:offenceSummary]&.map do |summary_object|
+      Array(data[:offenceSummary]).map do |summary_object|
         HmctsCommonPlatform::OffenceSummary.new(summary_object)
       end
     end

--- a/spec/models/hmcts_common_platform/subject_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/subject_summary_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe HmctsCommonPlatform::SubjectSummary, type: :model do
   it { expect(subject_summary.organisation_name).to eql("Franecki, Welch and Beier-newwwwwwwwwqqqq111222233344") }
   it { expect(subject_summary.representation_order).to be_a(HmctsCommonPlatform::RepresentationOrder) }
   it { expect(subject_summary.offence_summary.first).to be_a(HmctsCommonPlatform::OffenceSummary) }
+
+  context "when there is no offence summary data" do
+    before { data.delete("offenceSummary") }
+
+    it "returns an empty array" do
+      expect(subject_summary.to_json["offence_summary"]).to eq []
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-755)

Sometimes common platform court application payloads don't have an offenceSummary attribute. At present this causes a crash. This PR changes the model to handle this gracefully and return an empty array of offences.