### PR TITLE
ACD-757: Use masterDefendantId to link appeals to defendants

### DIFF
--- a/app/models/hmcts_common_platform/defendant_summary.rb
+++ b/app/models/hmcts_common_platform/defendant_summary.rb
@@ -70,7 +70,7 @@ module HmctsCommonPlatform
 
       court_application_summaries.select do |summary|
         master_defendant_id = summary.dig("subjectSummary", "masterDefendantId").to_s.strip
-        master_defendant_id == data[:defendantId].to_s.strip
+        master_defendant_id == data[:masterDefendantId].to_s.strip
       end
     end
 

--- a/lib/schemas/global/search/apiDefendantSummary.json
+++ b/lib/schemas/global/search/apiDefendantSummary.json
@@ -8,6 +8,10 @@
       "description": "The identifier of the defendant",
       "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
     },
+    "masterDefendantId": {
+      "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid",
+      "description": "Technical identifier that uniquely identifies the defendant on CPP i.e. across prosecution cases.  Case defendants that are the same person will be matched and provided the same defendantMasterId"
+    },
     "defendantNINO": {
       "description": "The person nino when the defendant is a person",
       "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/nino"
@@ -64,7 +68,7 @@
       "items": {
         "$ref": "http://justice.gov.uk/core/courts/search/external/apiApplicationSummary.json"
       }
-    }    
+    }
   },
   "oneOf": [
     {

--- a/spec/fixtures/files/defendant_summary/all_fields.json
+++ b/spec/fixtures/files/defendant_summary/all_fields.json
@@ -1,6 +1,7 @@
 {
   "proceedingsConcluded": false,
   "defendantId": "a86c42dc-6566-4076-9655-b3a53cd58566",
+  "masterDefendantId": "a86c42dc-6566-4076-9655-b3a53cd58566",
   "defendantASN": "2100000000000267128K",
   "defendantFirstName": "Bob",
   "defendantMiddleName": "Steven",

--- a/spec/models/hmcts_common_platform/defendant_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_summary_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe HmctsCommonPlatform::DefendantSummary, type: :model do
 
     let(:defendant_summary) do
       described_class.new(
-        { defendantId: "DEF123" },
+        { masterDefendantId: "DEF123" },
         [matching_court_application, not_matching_court_application],
       )
     end

--- a/spec/models/hmcts_common_platform/defendant_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_summary_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe HmctsCommonPlatform::DefendantSummary, type: :model do
       )
     end
 
-    it "includes only summaries where masterDefendantId matches defendantId" do
+    it "includes only the summaries that match the defendant masterDefendantId" do
       summaries = defendant_summary.application_summaries
 
       expect(summaries).not_to be_empty

--- a/spec/models/hmcts_common_platform/defendant_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/defendant_summary_spec.rb
@@ -59,41 +59,43 @@ RSpec.describe HmctsCommonPlatform::DefendantSummary, type: :model do
   end
 
   describe "#match_application_summaries" do
-    let(:matching_court_application) do
-      {
-        "applicationId" => "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
-        "subjectSummary" => {
-          "masterDefendantId" => "DEF123",
-        },
-      }
-    end
+    context "when there are matching and non-matching court applications" do
+      let(:matching_court_application) do
+        {
+          "applicationId" => "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
+          "subjectSummary" => {
+            "masterDefendantId" => "DEF123",
+          },
+        }
+      end
 
-    let(:not_matching_court_application) do
-      {
-        "applicationId" => "f38d0030-0b4a-4fa5-9484-bb37b1e6ac56",
-        "subjectSummary" => {
-          "masterDefendantId" => "DEF145",
-        },
-      }
-    end
+      let(:not_matching_court_application) do
+        {
+          "applicationId" => "f38d0030-0b4a-4fa5-9484-bb37b1e6ac56",
+          "subjectSummary" => {
+            "masterDefendantId" => "DEF145",
+          },
+        }
+      end
 
-    let(:defendant_summary) do
-      described_class.new(
-        { masterDefendantId: "DEF123" },
-        [matching_court_application, not_matching_court_application],
-      )
-    end
+      let(:defendant_summary) do
+        described_class.new(
+          { masterDefendantId: "DEF123" },
+          [matching_court_application, not_matching_court_application],
+        )
+      end
 
-    it "includes only the summaries that match the defendant masterDefendantId" do
-      summaries = defendant_summary.application_summaries
+      it "includes only the summaries that match the defendant masterDefendantId" do
+        summaries = defendant_summary.application_summaries
 
-      expect(summaries).not_to be_empty
-      expect(summaries).to all(be_a(HmctsCommonPlatform::ApplicationSummary))
+        expect(summaries).not_to be_empty
+        expect(summaries).to all(be_a(HmctsCommonPlatform::ApplicationSummary))
 
-      application_ids = summaries.map { |summary| summary.data["applicationId"] }
+        application_ids = summaries.map { |summary| summary.data["applicationId"] }
 
-      expect(application_ids).to contain_exactly("f38d0030-0b4a-4fa5-9484-bb37b1e6ab39")
-      expect(application_ids).not_to include("f38d0030-0b4a-4fa5-9484-bb37b1e6ac56")
+        expect(application_ids).to contain_exactly("f38d0030-0b4a-4fa5-9484-bb37b1e6ab39")
+        expect(application_ids).not_to include("f38d0030-0b4a-4fa5-9484-bb37b1e6ac56")
+      end
     end
   end
 end


### PR DESCRIPTION
## What
- HMCTS defendant summaries actually include masterDefendantId, which is sometimes but not always the same as defendantId
- Since appeals include masterDefendantId but not defendantId, we should consistently compare masterDefendantId to masterDefendantId when working out which defendant is associated with which appeal

[Link to story](https://dsdmoj.atlassian.net/browse/-ACD-757)
