### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -2,6 +2,9 @@ name: Brakeman
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ministryofjustice/laa-court-data-adaptor/security/code-scanning/6](https://github.com/ministryofjustice/laa-court-data-adaptor/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly limit the `GITHUB_TOKEN` permissions. Since the workflow only needs to read repository contents to run Brakeman, we will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
