### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete regular expression for hostnames

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.before(:each, type: ->(spec_type) { %i[model request].include? spec_type }) do
-    stub_request(:any, /justice.gov.uk/).to_rack(CommonPlatformSchemas)
+    stub_request(:any, /justice\.gov\.uk/).to_rack(CommonPlatformSchemas)
   end
 
   config.before(:all) do


### PR DESCRIPTION
Potential fix for [https://github.com/ministryofjustice/laa-court-data-adaptor/security/code-scanning/4](https://github.com/ministryofjustice/laa-court-data-adaptor/security/code-scanning/4)

To fix the issue, the `.` in the regular expression `/justice.gov.uk/` should be escaped to `\.`. This ensures that the `.` is treated as a literal dot rather than a wildcard character. The updated regular expression will only match domains that explicitly contain `justice.gov.uk` and not unintended variations.

The change should be made on line 119 of the file `spec/spec_helper.rb`. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
