### PR TITLE
ACD-765: Precommit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: Pre Commit Checks
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Set Python hash
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+
+      - name: pre-commit
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -244,7 +244,13 @@ Further details can be found on [this](https://dsdmoj.atlassian.net/wiki/spaces/
 
 ## Pre-commit Hooks
 
-Rubocop can be set up to run pre-commits.
+We have gitleaks set up on this repo. To make it harder to accidentally leak a secret, have it run as a pre-commit hook:
+```
+pip install pre-commit
+pre-commit install
+```
+
+Rubocop can also be set up to run pre-commits.
 
 Please see this [PR](https://github.com/ministryofjustice/laa-court-data-adaptor/pull/12)
 


### PR DESCRIPTION
Check for accidentally committed secrets as a hook that runs on commit and on put to GitHub.