### PR TITLE
ACD-368: Specify maat reference when unlinking

### DIFF
--- a/app/controllers/api/internal/v2/court_application_laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/court_application_laa_references_controller.rb
@@ -45,6 +45,7 @@ module Api
             transformed_params[:user_name],
             transformed_params[:unlink_reason_code],
             transformed_params[:unlink_other_reason_text],
+            transformed_params[:maat_reference],
           )
         end
 

--- a/app/controllers/api/internal/v2/laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/laa_references_controller.rb
@@ -48,6 +48,7 @@ module Api
             transformed_params[:user_name],
             transformed_params[:unlink_reason_code],
             transformed_params[:unlink_other_reason_text],
+            transformed_params[:maat_reference],
           )
         end
 

--- a/app/services/court_application_laa_reference_unlinker.rb
+++ b/app/services/court_application_laa_reference_unlinker.rb
@@ -1,11 +1,11 @@
 class CourtApplicationLaaReferenceUnlinker < ApplicationService
-  def initialize(subject_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:)
+  def initialize(subject_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:, maat_reference: nil)
     @subject_id = subject_id
     @user_name = user_name
     @unlink_reason_code = unlink_reason_code
     @unlink_other_reason_text = unlink_other_reason_text
 
-    @laa_reference = LaaReference.find_by(defendant_id: subject_id, linked: true)
+    @laa_reference = retrieve_laa_reference(maat_reference)
   end
 
   def call
@@ -61,6 +61,13 @@ private
 
   def dummy_maat_reference
     @dummy_maat_reference ||= LaaReference.generate_unlinking_dummy_maat_reference
+  end
+
+  def retrieve_laa_reference(maat_reference)
+    collection = LaaReference.where(defendant_id: subject_id, linked: true)
+    return collection.first if maat_reference.blank?
+
+    collection.find_by(maat_reference:)
   end
 
   attr_reader :subject_id, :laa_reference, :user_name, :unlink_reason_code, :unlink_other_reason_text

--- a/app/services/laa_reference_unlinker.rb
+++ b/app/services/laa_reference_unlinker.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class LaaReferenceUnlinker < ApplicationService
-  def initialize(defendant_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:)
+  def initialize(defendant_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:, maat_reference: nil)
     @defendant_id = defendant_id
     @user_name = user_name
     @unlink_reason_code = unlink_reason_code
     @unlink_other_reason_text = unlink_other_reason_text
 
-    @laa_reference = LaaReference.find_by(defendant_id:, linked: true)
+    @laa_reference = retrieve_laa_reference(maat_reference)
   end
 
   def call
@@ -59,6 +59,13 @@ private
 
   def dummy_maat_reference
     @dummy_maat_reference ||= LaaReference.generate_unlinking_dummy_maat_reference
+  end
+
+  def retrieve_laa_reference(maat_reference)
+    collection = LaaReference.where(defendant_id:, linked: true)
+    return collection.first if maat_reference.blank?
+
+    collection.find_by(maat_reference:)
   end
 
   attr_reader :defendant_id, :laa_reference, :user_name, :unlink_reason_code, :unlink_other_reason_text

--- a/app/workers/unlink_court_application_laa_reference_worker.rb
+++ b/app/workers/unlink_court_application_laa_reference_worker.rb
@@ -1,13 +1,14 @@
 class UnlinkCourtApplicationLaaReferenceWorker
   include Sidekiq::Worker
 
-  def perform(request_id, subject_id, user_name, unlink_reason_code, unlink_other_reason_text)
+  def perform(request_id, subject_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference = nil)
     Current.set(request_id:) do
       CourtApplicationLaaReferenceUnlinker.call(
         subject_id:,
         user_name:,
         unlink_reason_code:,
         unlink_other_reason_text:,
+        maat_reference:,
       )
     end
   end

--- a/app/workers/unlink_laa_reference_worker.rb
+++ b/app/workers/unlink_laa_reference_worker.rb
@@ -3,13 +3,14 @@
 class UnlinkLaaReferenceWorker
   include Sidekiq::Worker
 
-  def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text)
+  def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference = nil)
     Current.set(request_id:) do
       LaaReferenceUnlinker.call(
         defendant_id:,
         user_name:,
         unlink_reason_code:,
         unlink_other_reason_text:,
+        maat_reference:,
       )
     end
   end

--- a/spec/requests/api/internal/v2/court_application_laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/court_application_laa_references_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "api/internal/v2/court_application_laa_references", swagger_doc: 
           let(:Authorization) { "Bearer #{token.token}" }
 
           before do
-            expect(UnlinkCourtApplicationLaaReferenceWorker).to receive(:perform_async).with("XYZ", subject_id, "JaneDoe", 1, "")
+            expect(UnlinkCourtApplicationLaaReferenceWorker).to receive(:perform_async).with("XYZ", subject_id, "JaneDoe", 1, "", 1_231_231)
           end
 
           run_test!

--- a/spec/requests/api/internal/v2/laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/laa_references_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
           let(:Authorization) { "Bearer #{token.token}" }
 
           before do
-            expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with("XYZ", defendant_id, "JaneDoe", 1, "")
+            expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with("XYZ", defendant_id, "JaneDoe", 1, "", 1_231_231)
           end
 
           run_test!

--- a/spec/workers/unlink_court_application_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_court_application_laa_reference_worker_spec.rb
@@ -2,7 +2,7 @@ require "sidekiq/testing"
 
 RSpec.describe UnlinkCourtApplicationLaaReferenceWorker, type: :worker do
   subject(:work) do
-    described_class.perform_async(request_id, subject_id, user_name, unlink_reason_code, unlink_other_reason_text)
+    described_class.perform_async(request_id, subject_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference)
   end
 
   let(:request_id) { "XYZ" }
@@ -10,6 +10,7 @@ RSpec.describe UnlinkCourtApplicationLaaReferenceWorker, type: :worker do
   let(:user_name) { "bob-smith" }
   let(:unlink_reason_code) { 4 }
   let(:unlink_other_reason_text) { "foo" }
+  let(:maat_reference) { "55555555" }
 
   it "queues the job" do
     expect {
@@ -24,6 +25,7 @@ RSpec.describe UnlinkCourtApplicationLaaReferenceWorker, type: :worker do
         user_name:,
         unlink_reason_code:,
         unlink_other_reason_text:,
+        maat_reference:,
       )
       work
     end

--- a/spec/workers/unlink_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_laa_reference_worker_spec.rb
@@ -4,7 +4,7 @@ require "sidekiq/testing"
 
 RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   subject(:work) do
-    described_class.perform_async(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text)
+    described_class.perform_async(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference)
   end
 
   let(:defendant_id) { "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3" }
@@ -13,6 +13,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   let(:unlink_other_reason_text) { "Wrong defendant" }
   let(:request_id) { "XYZ" }
   let(:prosecution_case_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
+  let(:maat_reference) { "6666666" }
   let(:set_up_linked_prosecution_case) do
     LaaReference.create!(defendant_id:, user_name: "cpUser", maat_reference: 101_010)
     ProsecutionCase.create!(
@@ -39,6 +40,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
         user_name:,
         unlink_reason_code:,
         unlink_other_reason_text:,
+        maat_reference:,
       ).and_call_original
       work
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-ACD-368)

To make sure we update the correct record in our DB, if the client provides a MAAT reference when unlinking, use that MAAT reference to identify the correct local record to update.
