### PR TITLE
ACD-806: Return error codes when something goes wrong

### DIFF
--- a/app/controllers/api/external/v1/hearing_results_controller.rb
+++ b/app/controllers/api/external/v1/hearing_results_controller.rb
@@ -15,8 +15,7 @@ module Api
 
         def enforce_contract!
           unless contract.success?
-            message = "Hearing contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Hearing contract")
           end
         end
 

--- a/app/controllers/api/external/v2/hearing_results_controller.rb
+++ b/app/controllers/api/external/v2/hearing_results_controller.rb
@@ -15,8 +15,7 @@ module Api
 
         def enforce_contract!
           unless contract.success?
-            message = "Hearing contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Hearing contract")
           end
         end
 

--- a/app/controllers/api/internal/v1/court_application_representation_orders_controller.rb
+++ b/app/controllers/api/internal/v1/court_application_representation_orders_controller.rb
@@ -15,8 +15,7 @@ module Api
 
         def enforce_contract!
           unless contract.success?
-            message = "Representation Order contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Representation Order contract")
           end
         end
 

--- a/app/controllers/api/internal/v1/laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/laa_references_controller.rb
@@ -22,8 +22,7 @@ module Api
 
         def enforce_contract!(contract)
           unless contract.success?
-            message = "Contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Contract")
           end
         end
 

--- a/app/controllers/api/internal/v1/representation_orders_controller.rb
+++ b/app/controllers/api/internal/v1/representation_orders_controller.rb
@@ -15,8 +15,7 @@ module Api
 
         def enforce_contract!
           unless contract.success?
-            message = "Representation Order contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Representation Order contract")
           end
         end
 

--- a/app/controllers/api/internal/v2/court_application_laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/court_application_laa_references_controller.rb
@@ -22,8 +22,7 @@ module Api
 
         def enforce_contract!(contract)
           unless contract.success?
-            message = "Contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Contract")
           end
         end
 

--- a/app/controllers/api/internal/v2/laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/laa_references_controller.rb
@@ -34,8 +34,7 @@ module Api
 
         def enforce_contract!(contract)
           unless contract.success?
-            message = "Contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Contract")
           end
         end
 

--- a/app/controllers/api/internal/v2/representation_orders_controller.rb
+++ b/app/controllers/api/internal/v2/representation_orders_controller.rb
@@ -15,8 +15,7 @@ module Api
 
         def enforce_contract!
           unless contract.success?
-            message = "Representation Order contract failed with: #{contract.errors.to_hash}"
-            raise Errors::ContractError, message
+            raise Errors::ContractError.new(contract, "Representation Order contract")
           end
         end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,13 +8,14 @@ class ApplicationController < ActionController::API
     ActionController::ParameterMissing => :bad_request,
     Errors::ContractError => :unprocessable_entity,
     Errors::DefendantError => :unprocessable_entity,
+    Errors::CommonPlatformConnectionFailureError => :service_unavailable,
     ActiveRecord::RecordNotFound => :not_found,
     CommonPlatform::Api::Errors::FailedDependency => :failed_dependency,
   }.freeze
 
   ERROR_MAPPINGS.each do |klass, status|
     rescue_from klass do |error|
-      render(json: { error: }, status:)
+      render(json: { error:, error_codes: error.try(:codes) }, status:)
 
       Sentry.capture_exception(
         error,

--- a/app/controllers/concerns/prosecution_concludable.rb
+++ b/app/controllers/concerns/prosecution_concludable.rb
@@ -23,8 +23,7 @@ private
 
   def enforce_contract!
     unless contract.success?
-      message = "Prosecution conclusion contract failed with: #{contract.errors.to_hash}"
-      raise Errors::ContractError, message
+      raise Errors::ContractError.new(contract, "Prosecution conclusion contract")
     end
   end
 

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -100,7 +100,7 @@ private
   def _maat_reference
     refs = offences.map(&:maat_reference).uniq.compact
 
-    raise(Errors::DefendantError, "Too many maat references: #{refs}") if refs.size > 1
+    raise(Errors::DefendantError.new("Too many maat references: #{refs}", :multiple_maats)) if refs.size > 1
 
     refs&.first
   end

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,5 +1,32 @@
 module Errors
-  class ContractError < StandardError; end
+  class ContractError < StandardError
+    def initialize(contract, contract_name)
+      # This abomination of a format is how CDA has historically contract validation
+      # errors back to clients. We are preserving it here for backwards compatibility,
+      # but now also send back an error code which clients can translate into
+      # a user-facing string as appropriate
+      legacy_message = "#{contract_name} failed with: #{contract.errors.to_hash}"
+      super legacy_message
+      @contract = contract
+    end
 
-  class DefendantError < StandardError; end
+    def codes
+      @contract.errors.map { |error| "#{error.path.join}_contract_failure" }
+    end
+  end
+
+  class DefendantError < StandardError
+    def initialize(message, code_or_codes)
+      super message
+      @codes = Array(code_or_codes)
+    end
+
+    attr_reader :codes
+  end
+
+  class CommonPlatformConnectionFailureError < StandardError
+    def codes
+      [:commmon_platform_connection_failed]
+    end
+  end
 end

--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -19,6 +19,7 @@ module CommonPlatform
           logger.filter(/(defendantDOB=)([^&]+)/, '\1[FILTERED]')
           logger.filter(/(defendantNINO=)([^&]+)/, '\1[FILTERED]')
         end
+        connection.use FailureMiddleware
         connection.response :json, content_type: "application/json"
         connection.response :json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json"
         connection.response :json, content_type: "text/plain"
@@ -36,6 +37,14 @@ module CommonPlatform
     end
 
   private
+
+    class FailureMiddleware < Faraday::Middleware
+      def call(env)
+        @app.call(env)
+      rescue Faraday::ConnectionFailed => e
+        raise Errors::CommonPlatformConnectionFailureError, e
+      end
+    end
 
     def headers
       { "Ocp-Apim-Subscription-Key" => ENV["SHARED_SECRET_KEY"] }

--- a/spec/controllers/api/internal/v1/court_application_representation_orders_controller_spec.rb
+++ b/spec/controllers/api/internal/v1/court_application_representation_orders_controller_spec.rb
@@ -55,9 +55,12 @@ RSpec.describe Api::Internal::V1::CourtApplicationRepresentationOrdersController
   end
 
   context "when the contract fails" do
+    let(:errors) { Dry::Validation::MessageSet.new([message]) }
+    let(:message) { Dry::Schema::Message.new(text: "is invalid", path: [:maat_reference], predicate: :int?, input: "123") }
+
     before do
       allow(mock_contract).to receive(:call).and_return(
-        instance_double(Dry::Validation::Result, success?: false, errors: { maat_reference: ["is invalid"] }),
+        instance_double(Dry::Validation::Result, success?: false, errors:),
       )
     end
 

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe CommonPlatform::Connection do
 
       expect(connection).to receive(:request).with(:retry, retry_options)
       expect(connection).to receive(:request).with(:json)
+      expect(connection).to receive(:use).with(CommonPlatform::Connection::FailureMiddleware)
       expect(connection).to receive(:response).with(:logger, Rails.logger, { headers: false })
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
       expect(connection).to receive(:response).with(:json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json")


### PR DESCRIPTION
## What
1. When Common Platform is offline, return a payload that includes `"error_codes": ["common_platform_connection_failed"]`
2. When a defendant has multiple MAAT IDs, return a payload that includes `"error_codes": ["multiple_maats"]`
3. When validation fails, return a payload with error codes associated with each field that failed validation.


[Link to story](https://dsdmoj.atlassian.net/browse/ACD-806)
