### PR TITLE
ACD-804: Start adding request ID to faraday logs

### DIFF
--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -14,7 +14,7 @@ module CommonPlatform
       @connection = Faraday.new HOST, options do |connection|
         connection.request :retry, retry_options
         connection.request :json
-        connection.response :logger, Rails.logger, { headers: false } do |logger|
+        connection.response :logger, TaggedLogger, { headers: false } do |logger|
           logger.filter(/(defendantName=)([^&]+)/, '\1[FILTERED]')
           logger.filter(/(defendantDOB=)([^&]+)/, '\1[FILTERED]')
           logger.filter(/(defendantNINO=)([^&]+)/, '\1[FILTERED]')

--- a/app/services/maat_api/connection.rb
+++ b/app/services/maat_api/connection.rb
@@ -13,6 +13,7 @@ module MaatApi
         connection.request :authorization, "Bearer", access_token.token
         connection.request :json
         connection.response :json, content_type: "application/json"
+        connection.response :logger, TaggedLogger, { headers: false }
         connection.adapter Faraday.default_adapter
       end
     end

--- a/app/services/tagged_logger.rb
+++ b/app/services/tagged_logger.rb
@@ -1,0 +1,28 @@
+class TaggedLogger
+  class << self
+  private
+
+    LOGGER_METHODS = %i[debug info warn error fatal].freeze
+
+    def method_missing(method, *args, &block)
+      if is_log_request?(method)
+        output = if args[0]
+                   args[0]
+                 elsif block_given?
+                   yield
+                 end
+        Rails.logger.public_send(method, "(Request ID: #{Current.request_id}) #{output}") if output
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method, *args)
+      is_log_request?(method) || super
+    end
+
+    def is_log_request?(method)
+      LOGGER_METHODS.include?(method)
+    end
+  end
+end

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CommonPlatform::Connection do
       expect(connection).to receive(:request).with(:retry, retry_options)
       expect(connection).to receive(:request).with(:json)
       expect(connection).to receive(:use).with(CommonPlatform::Connection::FailureMiddleware)
-      expect(connection).to receive(:response).with(:logger, Rails.logger, { headers: false })
+      expect(connection).to receive(:response).with(:logger, TaggedLogger, { headers: false })
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
       expect(connection).to receive(:response).with(:json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json")
       expect(connection).to receive(:response).with(:json, content_type: "text/plain")

--- a/spec/services/maat_api/connection_spec.rb
+++ b/spec/services/maat_api/connection_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe MaatApi::Connection do
       expect(connection).to receive(:request).with(:authorization, "Bearer", "TOKEN")
       expect(connection).to receive(:request).with(:json)
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
+      expect(connection).to receive(:response).with(:logger, TaggedLogger, { headers: false })
       expect(connection).to receive(:adapter).with(:net_http)
       connect
     end

--- a/spec/services/tagged_logger_spec.rb
+++ b/spec/services/tagged_logger_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe TaggedLogger do
+  before do
+    allow(Current).to receive(:request_id).and_return "<request id>"
+  end
+
+  context "when making arg-based log requests" do
+    before do
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "passes on arg-based log requests to request logger" do
+      described_class.info "FOO"
+      expect(Rails.logger).to have_received(:info).with "(Request ID: <request id>) FOO"
+    end
+  end
+
+  context "when making block-based log requests" do
+    before do
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "passes on arg-based log requests to request logger" do
+      described_class.info { "FOO" }
+      expect(Rails.logger).to have_received(:info).with "(Request ID: <request id>) FOO"
+    end
+  end
+end


### PR DESCRIPTION
## What
So that logs in OpenSearch can show together the overall log and details of all outward calls that were made.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-814)