### PR TITLE
ACD-815: Make explicit when classes are about prosecution cases

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,8 +32,8 @@ RSpec/VerifiedDoubles:
     - 'spec/services/common_platform/api/hearing_events_fetcher_spec.rb'
     - 'spec/services/common_platform/api/hearing_fetcher_spec.rb'
     - 'spec/services/common_platform/api/prosecution_case_searcher_spec.rb'
-    - 'spec/services/common_platform/api/record_laa_reference_spec.rb'
-    - 'spec/services/common_platform/api/record_representation_order_spec.rb'
+    - 'spec/services/common_platform/api/record_prosecution_case_laa_reference_spec.rb'
+    - 'spec/services/common_platform/api/record_prosecution_case_representation_order_spec.rb'
     - 'spec/services/common_platform/api/search_prosecution_case_spec.rb'
     - 'spec/services/maat_api/connection_spec.rb'
 

--- a/app/contracts/court_application_representation_order_contract.rb
+++ b/app/contracts/court_application_representation_order_contract.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NewCourtApplicationRepresentationOrderContract < Dry::Validation::Contract
+class CourtApplicationRepresentationOrderContract < Dry::Validation::Contract
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
   config.validate_keys = true
 

--- a/app/contracts/prosecution_case_laa_reference_contract.rb
+++ b/app/contracts/prosecution_case_laa_reference_contract.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class NewLaaReferenceContract < Dry::Validation::Contract
+class ProsecutionCaseLaaReferenceContract < Dry::Validation::Contract
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
   option :maat_reference_validator, default: -> { MaatApi::MaatReferenceValidator }
-  option :link_validator, default: -> { LinkValidator }
+  option :link_validator, default: -> { ProsecutionCaseLinkValidator }
 
   params do
     optional(:maat_reference).value(:integer, lt?: 999_999_999)

--- a/app/contracts/prosecution_case_representation_order_contract.rb
+++ b/app/contracts/prosecution_case_representation_order_contract.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NewRepresentationOrderContract < Dry::Validation::Contract
+class ProsecutionCaseRepresentationOrderContract < Dry::Validation::Contract
   option :uuid_validator, default: -> { CommonPlatform::UuidValidator }
   config.validate_keys = true
 

--- a/app/controllers/api/internal/v1/court_application_representation_orders_controller.rb
+++ b/app/controllers/api/internal/v1/court_application_representation_orders_controller.rb
@@ -20,7 +20,7 @@ module Api
         end
 
         def contract
-          NewCourtApplicationRepresentationOrderContract.new.call(**transformed_params)
+          CourtApplicationRepresentationOrderContract.new.call(**transformed_params)
         end
 
         def create_params

--- a/app/controllers/api/internal/v1/defendants_controller.rb
+++ b/app/controllers/api/internal/v1/defendants_controller.rb
@@ -27,7 +27,7 @@ module Api
       private
 
         def enqueue_unlink
-          UnlinkLaaReferenceWorker.perform_async(
+          UnlinkProsecutionCaseLaaReferenceWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:user_name],

--- a/app/controllers/api/internal/v1/prosecution_case_laa_references_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_case_laa_references_controller.rb
@@ -3,12 +3,12 @@
 module Api
   module Internal
     module V1
-      class LaaReferencesController < ApplicationController
+      class ProsecutionCaseLaaReferencesController < ApplicationController
         def create
-          contract = NewLaaReferenceContract.new.call(**transformed_params)
+          contract = ProsecutionCaseLaaReferenceContract.new.call(**transformed_params)
           enforce_contract!(contract)
 
-          MaatLinkCreatorWorker.perform_async(
+          ProsecutionCaseMaatLinkCreatorWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:user_name],

--- a/app/controllers/api/internal/v1/prosecution_case_representation_orders_controller.rb
+++ b/app/controllers/api/internal/v1/prosecution_case_representation_orders_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module Internal
     module V1
-      class RepresentationOrdersController < ApplicationController
+      class ProsecutionCaseRepresentationOrdersController < ApplicationController
         def create
           enforce_contract!
           enqueue_representation_order
@@ -20,7 +20,7 @@ module Api
         end
 
         def contract
-          NewRepresentationOrderContract.new.call(**transformed_params)
+          ProsecutionCaseRepresentationOrderContract.new.call(**transformed_params)
         end
 
         def create_params
@@ -43,7 +43,7 @@ module Api
         end
 
         def enqueue_representation_order
-          RepresentationOrderCreatorWorker.perform_async(
+          ProsecutionCaseRepresentationOrderCreatorWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:offences],

--- a/app/controllers/api/internal/v2/prosecution_case_laa_references_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_case_laa_references_controller.rb
@@ -3,13 +3,13 @@
 module Api
   module Internal
     module V2
-      class LaaReferencesController < ApplicationController
+      class ProsecutionCaseLaaReferencesController < ApplicationController
         # Create link to court data
         def create
-          contract = NewLaaReferenceContract.new.call(**transformed_params)
+          contract = ProsecutionCaseLaaReferenceContract.new.call(**transformed_params)
           enforce_contract!(contract)
 
-          MaatLinkCreatorWorker.perform_async(
+          ProsecutionCaseMaatLinkCreatorWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:user_name],
@@ -41,7 +41,7 @@ module Api
         def enqueue_unlink
           check_defendant_presence!
 
-          UnlinkLaaReferenceWorker.perform_async(
+          UnlinkProsecutionCaseLaaReferenceWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:user_name],

--- a/app/controllers/api/internal/v2/prosecution_case_representation_orders_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_case_representation_orders_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module Internal
     module V2
-      class RepresentationOrdersController < ApplicationController
+      class ProsecutionCaseRepresentationOrdersController < ApplicationController
         def create
           enforce_contract!
           enqueue_representation_order
@@ -20,7 +20,7 @@ module Api
         end
 
         def contract
-          NewRepresentationOrderContract.new.call(**transformed_params)
+          ProsecutionCaseRepresentationOrderContract.new.call(**transformed_params)
         end
 
         def create_params
@@ -43,7 +43,7 @@ module Api
         end
 
         def enqueue_representation_order
-          RepresentationOrderCreatorWorker.perform_async(
+          ProsecutionCaseRepresentationOrderCreatorWorker.perform_async(
             Current.request_id,
             transformed_params[:defendant_id],
             transformed_params[:offences],

--- a/app/services/common_platform/api/court_application_representation_order_creator.rb
+++ b/app/services/common_platform/api/court_application_representation_order_creator.rb
@@ -23,7 +23,7 @@ module CommonPlatform
 
           next if court_application_defendant_offence.blank?
 
-          CommonPlatform::Api::CourtApplicationRecordRepresentationOrder.call(
+          CommonPlatform::Api::RecordCourtApplicationRepresentationOrder.call(
             court_application_defendant_offence:,
             subject_id:,
             offence_id: offence[:offence_id],

--- a/app/services/common_platform/api/prosecution_case_representation_order_creator.rb
+++ b/app/services/common_platform/api/prosecution_case_representation_order_creator.rb
@@ -2,7 +2,7 @@
 
 module CommonPlatform
   module Api
-    class RepresentationOrderCreator < ApplicationService
+    class ProsecutionCaseRepresentationOrderCreator < ApplicationService
       def initialize(defendant_id:, offences:, maat_reference:, defence_organisation:)
         @offences = offences.map(&:with_indifferent_access).reject { |offence| offence[:status_date].blank? }
         @maat_reference = maat_reference
@@ -23,7 +23,7 @@ module CommonPlatform
 
           next if case_defendant_offence.blank?
 
-          CommonPlatform::Api::RecordRepresentationOrder.call(
+          CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder.call(
             case_defendant_offence:,
             defendant_id:,
             offence_id: offence[:offence_id],

--- a/app/services/common_platform/api/record_court_application_representation_order.rb
+++ b/app/services/common_platform/api/record_court_application_representation_order.rb
@@ -2,9 +2,9 @@
 
 module CommonPlatform
   module Api
-    class RecordRepresentationOrder < ApplicationService
-      def initialize(case_defendant_offence:,
-                     defendant_id:,
+    class RecordCourtApplicationRepresentationOrder < ApplicationService
+      def initialize(court_application_defendant_offence:,
+                     subject_id:,
                      offence_id:,
                      status_code:,
                      application_reference:,
@@ -13,7 +13,7 @@ module CommonPlatform
                      defence_organisation:,
                      effective_end_date: nil,
                      connection: CommonPlatform::Connection.instance.call)
-        @case_defendant_offence = case_defendant_offence
+        @court_application_defendant_offence = court_application_defendant_offence
         @offence_id = offence_id
         @status_code = status_code
         @application_reference = application_reference.to_s
@@ -22,8 +22,8 @@ module CommonPlatform
         @effective_end_date = effective_end_date
         @defence_organisation = defence_organisation
         @url = "prosecutionCases/representationOrder"\
-                "/cases/#{case_defendant_offence.prosecution_case_id}"\
-                "/defendants/#{defendant_id}"\
+                "/applications/#{court_application_defendant_offence.court_application_id}"\
+                "/subject/#{subject_id}"\
                 "/offences/#{offence_id}"
         @connection = connection
       end
@@ -48,7 +48,7 @@ module CommonPlatform
       end
 
       def update_offence(response)
-        case_defendant_offence.update!(
+        court_application_defendant_offence.update!(
           rep_order_status: status_code,
           status_date:,
           effective_start_date:,
@@ -59,7 +59,7 @@ module CommonPlatform
         )
       end
 
-      attr_reader :url, :case_defendant_offence, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
+      attr_reader :url, :court_application_defendant_offence, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
     end
   end
 end

--- a/app/services/common_platform/api/record_prosecution_case_laa_reference.rb
+++ b/app/services/common_platform/api/record_prosecution_case_laa_reference.rb
@@ -2,7 +2,7 @@
 
 module CommonPlatform
   module Api
-    class RecordLaaReference < ApplicationService
+    class RecordProsecutionCaseLaaReference < ApplicationService
       def initialize(prosecution_case_id:,
                      defendant_id:,
                      offence_id:,

--- a/app/services/common_platform/api/record_prosecution_case_representation_order.rb
+++ b/app/services/common_platform/api/record_prosecution_case_representation_order.rb
@@ -2,9 +2,9 @@
 
 module CommonPlatform
   module Api
-    class CourtApplicationRecordRepresentationOrder < ApplicationService
-      def initialize(court_application_defendant_offence:,
-                     subject_id:,
+    class RecordProsecutionCaseRepresentationOrder < ApplicationService
+      def initialize(case_defendant_offence:,
+                     defendant_id:,
                      offence_id:,
                      status_code:,
                      application_reference:,
@@ -13,7 +13,7 @@ module CommonPlatform
                      defence_organisation:,
                      effective_end_date: nil,
                      connection: CommonPlatform::Connection.instance.call)
-        @court_application_defendant_offence = court_application_defendant_offence
+        @case_defendant_offence = case_defendant_offence
         @offence_id = offence_id
         @status_code = status_code
         @application_reference = application_reference.to_s
@@ -22,8 +22,8 @@ module CommonPlatform
         @effective_end_date = effective_end_date
         @defence_organisation = defence_organisation
         @url = "prosecutionCases/representationOrder"\
-                "/applications/#{court_application_defendant_offence.court_application_id}"\
-                "/subject/#{subject_id}"\
+                "/cases/#{case_defendant_offence.prosecution_case_id}"\
+                "/defendants/#{defendant_id}"\
                 "/offences/#{offence_id}"
         @connection = connection
       end
@@ -48,7 +48,7 @@ module CommonPlatform
       end
 
       def update_offence(response)
-        court_application_defendant_offence.update!(
+        case_defendant_offence.update!(
           rep_order_status: status_code,
           status_date:,
           effective_start_date:,
@@ -59,7 +59,7 @@ module CommonPlatform
         )
       end
 
-      attr_reader :url, :court_application_defendant_offence, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
+      attr_reader :url, :case_defendant_offence, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
     end
   end
 end

--- a/app/services/prosecution_case_laa_reference_unlinker.rb
+++ b/app/services/prosecution_case_laa_reference_unlinker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LaaReferenceUnlinker < ApplicationService
+class ProsecutionCaseLaaReferenceUnlinker < ApplicationService
   def initialize(defendant_id:, user_name:, unlink_reason_code:, unlink_other_reason_text:, maat_reference: nil)
     @defendant_id = defendant_id
     @user_name = user_name
@@ -43,7 +43,7 @@ private
   end
 
   def update_offence_on_common_platform(offence)
-    CommonPlatform::Api::RecordLaaReference.call(
+    CommonPlatform::Api::RecordProsecutionCaseLaaReference.call(
       prosecution_case_id: offence.prosecution_case_id,
       defendant_id: offence.defendant_id,
       offence_id: offence.offence_id,

--- a/app/services/prosecution_case_link_validator.rb
+++ b/app/services/prosecution_case_link_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LinkValidator < ApplicationService
+class ProsecutionCaseLinkValidator < ApplicationService
   def initialize(defendant_id:)
     @prosecution_case = ProsecutionCaseDefendantOffence.find_by(defendant_id:)&.prosecution_case
   end

--- a/app/services/prosecution_case_maat_link_creator.rb
+++ b/app/services/prosecution_case_maat_link_creator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MaatLinkCreator < ApplicationService
+class ProsecutionCaseMaatLinkCreator < ApplicationService
   attr_reader :laa_reference, :defendant_id
 
   def initialize(defendant_id, user_name, maat_reference)
@@ -56,7 +56,7 @@ private
   end
 
   def post_laa_reference_to_common_platform(offence)
-    response = CommonPlatform::Api::RecordLaaReference.call(
+    response = CommonPlatform::Api::RecordProsecutionCaseLaaReference.call(
       prosecution_case_id: offence.prosecution_case_id,
       defendant_id: offence.defendant_id,
       offence_id: offence.offence_id,

--- a/app/workers/prosecution_case_maat_link_creator_worker.rb
+++ b/app/workers/prosecution_case_maat_link_creator_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class MaatLinkCreatorWorker
+class ProsecutionCaseMaatLinkCreatorWorker
   include Sidekiq::Worker
 
   def perform(request_id, defendant_id, user_name, maat_reference)
     Current.set(request_id:) do
-      MaatLinkCreator.call(defendant_id, user_name, maat_reference)
+      ProsecutionCaseMaatLinkCreator.call(defendant_id, user_name, maat_reference)
     end
   end
 end

--- a/app/workers/prosecution_case_representation_order_creator_worker.rb
+++ b/app/workers/prosecution_case_representation_order_creator_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class RepresentationOrderCreatorWorker
+class ProsecutionCaseRepresentationOrderCreatorWorker
   include Sidekiq::Worker
 
   def perform(request_id, defendant_id, offences, maat_reference, defence_organisation)
     Current.set(request_id:) do
-      CommonPlatform::Api::RepresentationOrderCreator.call(
+      CommonPlatform::Api::ProsecutionCaseRepresentationOrderCreator.call(
         defendant_id:,
         offences:,
         maat_reference:,

--- a/app/workers/unlink_prosecution_case_laa_reference_worker.rb
+++ b/app/workers/unlink_prosecution_case_laa_reference_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class UnlinkLaaReferenceWorker
+class UnlinkProsecutionCaseLaaReferenceWorker
   include Sidekiq::Worker
 
   def perform(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference = nil)
     Current.set(request_id:) do
-      LaaReferenceUnlinker.call(
+      ProsecutionCaseLaaReferenceUnlinker.call(
         defendant_id:,
         user_name:,
         unlink_reason_code:,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,9 @@ Rails.application.routes.draw do
     namespace :internal do
       api_version(module: "V1", path: { value: "v1" }, default: true) do
         resources :prosecution_cases, only: [:index]
-        resources :laa_references, only: %i[create]
+        resources :prosecution_case_laa_references, path: "laa_references", only: %i[create]
         resources :defendants, only: %i[update show]
-        resources :representation_orders, only: [:create]
+        resources :prosecution_case_representation_orders, path: "representation_orders", only: [:create]
         resources :court_application_representation_orders, only: [:create]
         resources :hearing_results, path: "hearings", only: [:show]
       end
@@ -32,9 +32,9 @@ Rails.application.routes.draw do
         resources :prosecution_cases, only: [:index], param: :reference do
           resources :defendants, only: %i[show]
         end
-        resources :laa_references, only: %i[create update], param: :defendant_id
+        resources :prosecution_case_laa_references, path: "laa_references", only: %i[create update], param: :defendant_id
         resources :court_application_laa_references, only: %i[create update], param: :subject_id
-        resources :representation_orders, only: [:create]
+        resources :prosecution_case_representation_orders, path: "representation_orders", only: [:create]
         resources :hearing_results, only: [:show], param: :hearing_id
         get "hearings/:hearing_id/event_log/:hearing_date", to: "hearing_event_logs#show"
       end

--- a/lib/schemas/api/progression.recordLAAReference.json
+++ b/lib/schemas/api/progression.recordLAAReference.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://justice.gov.uk/progression/courts/external/progression.recordLAAReference.json",
+  "id": "http://justice.gov.uk/progression/courts/external/progression.RecordProsecutionCaseLaaReference.json",
   "description": "Records a reference to the legal aid application against the court case details",
   "type": "object",
   "properties": {

--- a/spec/contracts/court_application_representation_order_contract_spec.rb
+++ b/spec/contracts/court_application_representation_order_contract_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NewCourtApplicationRepresentationOrderContract do
+RSpec.describe CourtApplicationRepresentationOrderContract do
   subject { described_class.new.call(hash_for_validation) }
 
   let(:hash_for_validation) do

--- a/spec/contracts/prosecution_case_laa_reference_contract_spec.rb
+++ b/spec/contracts/prosecution_case_laa_reference_contract_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NewLaaReferenceContract do
+RSpec.describe ProsecutionCaseLaaReferenceContract do
   subject(:validate_contract) { described_class.new.call(hash_for_validation) }
 
   around do |example|
@@ -23,7 +23,7 @@ RSpec.describe NewLaaReferenceContract do
   let(:link_validity) { true }
 
   before do
-    allow(LinkValidator).to receive(:call).and_return(link_validity)
+    allow(ProsecutionCaseLinkValidator).to receive(:call).and_return(link_validity)
   end
 
   it { is_expected.to be_a_success }

--- a/spec/contracts/prosecution_case_representation_order_contract_spec.rb
+++ b/spec/contracts/prosecution_case_representation_order_contract_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NewRepresentationOrderContract do
+RSpec.describe ProsecutionCaseRepresentationOrderContract do
   subject { described_class.new.call(hash_for_validation) }
 
   let(:hash_for_validation) do

--- a/spec/controllers/api/internal/v1/court_application_representation_orders_controller_spec.rb
+++ b/spec/controllers/api/internal/v1/court_application_representation_orders_controller_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Api::Internal::V1::CourtApplicationRepresentationOrdersController
   end
 
   let(:request_headers) { { "Content-Type" => "application/json" } }
-  let(:mock_contract) { instance_double(NewCourtApplicationRepresentationOrderContract) }
+  let(:mock_contract) { instance_double(CourtApplicationRepresentationOrderContract) }
 
   before do
     authorise_requests!
-    allow(NewCourtApplicationRepresentationOrderContract).to receive(:new).and_return(mock_contract)
+    allow(CourtApplicationRepresentationOrderContract).to receive(:new).and_return(mock_contract)
   end
 
   context "when the contract is successful" do

--- a/spec/requests/api/internal/v1/defendants_request_spec.rb
+++ b/spec/requests/api/internal/v1/defendants_request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Api::Internal::V1::Defendants", swagger_doc: "v1/swagger.yaml", 
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with(String, id, "johnDoe", 1, "").and_call_original
+          expect(UnlinkProsecutionCaseLaaReferenceWorker).to receive(:perform_async).with(String, id, "johnDoe", 1, "").and_call_original
         end
 
         run_test!
@@ -68,7 +68,7 @@ RSpec.describe "Api::Internal::V1::Defendants", swagger_doc: "v1/swagger.yaml", 
           let(:id) { "X" }
 
           before do
-            expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+            expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -80,7 +80,7 @@ RSpec.describe "Api::Internal::V1::Defendants", swagger_doc: "v1/swagger.yaml", 
           let(:Authorization) { nil }
 
           before do
-            expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+            expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
           end
 
           run_test!

--- a/spec/requests/api/internal/v1/laa_references_spec.rb
+++ b/spec/requests/api/internal/v1/laa_references_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
 
   before do
     allow(Current).to receive(:request_id).and_return("XYZ")
-    allow(LinkValidator).to receive(:call).and_return(true)
+    allow(ProsecutionCaseLinkValidator).to receive(:call).and_return(true)
   end
 
   around do |example|
@@ -68,7 +68,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(MaatLinkCreatorWorker).to receive(:perform_async)
+          expect(ProsecutionCaseMaatLinkCreatorWorker).to receive(:perform_async)
             .with("XYZ", defendant_id, "JaneDoe", 1_231_231)
         end
 
@@ -82,7 +82,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
           before do
             laa_reference[:data][:attributes].delete(:maat_reference)
 
-            expect(MaatLinkCreatorWorker).to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).to receive(:perform_async)
               .with("XYZ", defendant_id, "JaneDoe", nil)
           end
 
@@ -96,7 +96,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
 
           before do
             laa_reference[:data][:attributes].delete(:user_name)
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -109,7 +109,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
           before { laa_reference[:data][:attributes][:maat_reference] = "ABC123123" }
 
           before do
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -121,7 +121,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
           let(:Authorization) { nil }
 
           before do
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -132,7 +132,7 @@ RSpec.describe "api/internal/v1/laa_references", swagger_doc: "v1/swagger.yaml",
         before { laa_reference[:data][:relationships][:defendant][:data][:id] = "foo" }
 
         it "renders a JSON response with an unprocessable_entity error" do
-          post api_internal_v1_laa_references_path, params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
+          post api_internal_v1_prosecution_case_laa_references_path, params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
 
           expect(response.body).to include("is not a valid uuid")
           expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/internal/v1/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v1/representation_orders_request_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "api/internal/v1/representation_orders", swagger_doc: "v1/swagger
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(RepresentationOrderCreatorWorker).to receive(:perform_async).with(
+          expect(ProsecutionCaseRepresentationOrderCreatorWorker).to receive(:perform_async).with(
             String,
             defendant_id,
             offence_array.map { |o| o.deep_transform_keys(&:to_s) },
@@ -120,7 +120,7 @@ RSpec.describe "api/internal/v1/representation_orders", swagger_doc: "v1/swagger
           before { representation_order[:data][:attributes][:maat_reference] = "ABC123123" }
 
           before do
-            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseRepresentationOrderCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -132,7 +132,7 @@ RSpec.describe "api/internal/v1/representation_orders", swagger_doc: "v1/swagger
           let(:Authorization) { nil }
 
           before do
-            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseRepresentationOrderCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -143,7 +143,7 @@ RSpec.describe "api/internal/v1/representation_orders", swagger_doc: "v1/swagger
         before { representation_order[:data][:relationships][:defendant][:data][:id] = "foo" }
 
         it "renders a JSON response with an unprocessable_entity error" do
-          post api_internal_v1_representation_orders_path, params: representation_order, headers: { "Authorization" => "Bearer #{token.token}" }
+          post api_internal_v1_prosecution_case_representation_orders_path, params: representation_order, headers: { "Authorization" => "Bearer #{token.token}" }
 
           expect(response.body).to include("is not a valid uuid")
           expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/internal/v2/court_application_laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/court_application_laa_references_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "api/internal/v2/court_application_laa_references", swagger_doc: 
             let(:subject_id) { "X" }
 
             before do
-              expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+              expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
             end
 
             run_test!
@@ -199,7 +199,7 @@ RSpec.describe "api/internal/v2/court_application_laa_references", swagger_doc: 
             let(:Authorization) { nil }
 
             before do
-              expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+              expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
             end
 
             run_test!

--- a/spec/requests/api/internal/v2/laa_references_spec.rb
+++ b/spec/requests/api/internal/v2/laa_references_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
 
   before do
     allow(Current).to receive(:request_id).and_return("XYZ")
-    allow(LinkValidator).to receive(:call).and_return(true)
+    allow(ProsecutionCaseLinkValidator).to receive(:call).and_return(true)
   end
 
   around do |example|
@@ -56,7 +56,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(MaatLinkCreatorWorker).to receive(:perform_async)
+          expect(ProsecutionCaseMaatLinkCreatorWorker).to receive(:perform_async)
             .with("XYZ", defendant_id, "JaneDoe", 1_231_231)
         end
 
@@ -70,7 +70,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
           before do
             laa_reference[:laa_reference].delete(:maat_reference)
 
-            expect(MaatLinkCreatorWorker).to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).to receive(:perform_async)
               .with("XYZ", defendant_id, "JaneDoe", nil)
           end
 
@@ -84,7 +84,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
 
           before do
             laa_reference[:laa_reference].delete(:user_name)
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -97,7 +97,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
           before { laa_reference[:laa_reference][:maat_reference] = "ABC123123" }
 
           before do
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -109,7 +109,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
           let(:Authorization) { nil }
 
           before do
-            expect(MaatLinkCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseMaatLinkCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -120,7 +120,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
         let(:defendant_id) { "X" }
 
         it "renders a JSON response with an unprocessable_entity error" do
-          post api_internal_v2_laa_references_path, params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
+          post api_internal_v2_prosecution_case_laa_references_path, params: laa_reference, headers: { "Authorization" => "Bearer #{token.token}" }
 
           expect(response.body).to include("is not a valid uuid")
           expect(response).to have_http_status(:unprocessable_entity)
@@ -162,7 +162,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
           let(:Authorization) { "Bearer #{token.token}" }
 
           before do
-            expect(UnlinkLaaReferenceWorker).to receive(:perform_async).with("XYZ", defendant_id, "JaneDoe", 1, "", 1_231_231)
+            expect(UnlinkProsecutionCaseLaaReferenceWorker).to receive(:perform_async).with("XYZ", defendant_id, "JaneDoe", 1, "", 1_231_231)
           end
 
           run_test!
@@ -174,7 +174,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
             let(:defendant_id) { "X" }
 
             before do
-              expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+              expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
             end
 
             run_test!
@@ -200,7 +200,7 @@ RSpec.describe "api/internal/v2/laa_references", swagger_doc: "v2/swagger.yaml",
             let(:Authorization) { nil }
 
             before do
-              expect(UnlinkLaaReferenceWorker).not_to receive(:perform_async)
+              expect(UnlinkProsecutionCaseLaaReferenceWorker).not_to receive(:perform_async)
             end
 
             run_test!

--- a/spec/requests/api/internal/v2/representation_orders_request_spec.rb
+++ b/spec/requests/api/internal/v2/representation_orders_request_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "api/internal/v2/representation_orders", swagger_doc: "v2/swagger
         let(:Authorization) { "Bearer #{token.token}" }
 
         before do
-          expect(RepresentationOrderCreatorWorker).to receive(:perform_async).with(
+          expect(ProsecutionCaseRepresentationOrderCreatorWorker).to receive(:perform_async).with(
             String,
             representation_order.dig(:representation_order, :defendant_id),
             representation_order.dig(:representation_order, :offences),
@@ -104,7 +104,7 @@ RSpec.describe "api/internal/v2/representation_orders", swagger_doc: "v2/swagger
 
           before do
             representation_order[:representation_order][:maat_reference] = "ABC123123"
-            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseRepresentationOrderCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!
@@ -116,7 +116,7 @@ RSpec.describe "api/internal/v2/representation_orders", swagger_doc: "v2/swagger
           let(:Authorization) { nil }
 
           before do
-            expect(RepresentationOrderCreatorWorker).not_to receive(:perform_async)
+            expect(ProsecutionCaseRepresentationOrderCreatorWorker).not_to receive(:perform_async)
           end
 
           run_test!

--- a/spec/services/common_platform/api/court_application_representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/court_application_representation_order_creator_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe CommonPlatform::Api::CourtApplicationRepresentationOrderCreator d
                                              application_type: "4567")
   end
 
-  it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-    expect(CommonPlatform::Api::CourtApplicationRecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+  it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+    expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
     create_rep_order
   end
 
@@ -75,16 +75,16 @@ RSpec.describe CommonPlatform::Api::CourtApplicationRepresentationOrderCreator d
                                                application_type: "4567")
     end
 
-    it "calls the CommonPlatform::Api::RecordRepresentationOrder service twice" do
-      expect(CommonPlatform::Api::CourtApplicationRecordRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service twice" do
+      expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
 
     context "when one offence does not have a status date" do
       before { offence_two.delete(:status_date) }
 
-      it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-        expect(CommonPlatform::Api::CourtApplicationRecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+        expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
         create_rep_order
       end
     end
@@ -101,8 +101,8 @@ RSpec.describe CommonPlatform::Api::CourtApplicationRepresentationOrderCreator d
       }
     end
 
-    it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-      expect(CommonPlatform::Api::CourtApplicationRecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+      expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe CommonPlatform::Api::CourtApplicationRepresentationOrderCreator d
     end
 
     it "sanitises the data" do
-      expect(CommonPlatform::Api::CourtApplicationRecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
   end

--- a/spec/services/common_platform/api/prosecution_case_representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/prosecution_case_representation_order_creator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
+RSpec.describe CommonPlatform::Api::ProsecutionCaseRepresentationOrderCreator do
   subject(:create_rep_order) do
     described_class.call(
       maat_reference:,
@@ -50,8 +50,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
                                             offence_id: "cacbd4d4-9102-4687-98b4-d529be3d5710")
   end
 
-  it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-    expect(CommonPlatform::Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+  it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+    expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
     create_rep_order
   end
 
@@ -73,16 +73,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
                                               offence_id: "f916e952-1c35-44d6-ba15-a149f92cc38a")
     end
 
-    it "calls the CommonPlatform::Api::RecordRepresentationOrder service twice" do
-      expect(CommonPlatform::Api::RecordRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service twice" do
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
 
     context "when one offence does not have a status date" do
       before { offence_two.delete(:status_date) }
 
-      it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-        expect(CommonPlatform::Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+        expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
         create_rep_order
       end
     end
@@ -99,8 +99,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       }
     end
 
-    it "calls the CommonPlatform::Api::RecordRepresentationOrder service once" do
-      expect(CommonPlatform::Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
 
     it "sanitises the data" do
-      expect(CommonPlatform::Api::RecordRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
       create_rep_order
     end
   end

--- a/spec/services/common_platform/api/record_court_application_representation_order_spec.rb
+++ b/spec/services/common_platform/api/record_court_application_representation_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::CourtApplicationRecordRepresentationOrder do
+RSpec.describe CommonPlatform::Api::RecordCourtApplicationRepresentationOrder do
   subject(:record_representation_order) do
     described_class.call(
       court_application_defendant_offence:,

--- a/spec/services/common_platform/api/record_prosecution_case_laa_reference_spec.rb
+++ b/spec/services/common_platform/api/record_prosecution_case_laa_reference_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::RecordLaaReference do
+RSpec.describe CommonPlatform::Api::RecordProsecutionCaseLaaReference do
   subject(:record_reference) do
     described_class.call(
       prosecution_case_id: prosecution_case.id,

--- a/spec/services/common_platform/api/record_prosecution_case_representation_order_spec.rb
+++ b/spec/services/common_platform/api/record_prosecution_case_representation_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::RecordRepresentationOrder do
+RSpec.describe CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder do
   subject(:record_representation_order) do
     described_class.call(
       case_defendant_offence:,

--- a/spec/services/court_application_laa_reference_unlinker_spec.rb
+++ b/spec/services/court_application_laa_reference_unlinker_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
       call_unlinker
     end
 
-    it "calls the CommonPlatform::Api::RecordLaaReference service multiple times" do
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service multiple times" do
       expect(CommonPlatform::Api::RecordCourtApplicationLaaReference).to receive(:call).twice.with(hash_including(application_reference: "Z10000000"))
       call_unlinker
     end
@@ -140,7 +140,7 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
       call_unlinker
     end
 
-    it "calls the CommonPlatform::Api::RecordLaaReference service" do
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service" do
       expect(CommonPlatform::Api::RecordCourtApplicationLaaReference).to receive(:call).once.with(hash_including(application_reference: "Z10000000"))
       call_unlinker
     end

--- a/spec/services/prosecution_case_laa_reference_unlinker_spec.rb
+++ b/spec/services/prosecution_case_laa_reference_unlinker_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe LaaReferenceUnlinker do
+RSpec.describe ProsecutionCaseLaaReferenceUnlinker do
   subject(:call_unlinker) do
     described_class.call(defendant_id:,
                          user_name:,
@@ -32,12 +32,12 @@ RSpec.describe LaaReferenceUnlinker do
                                             offence_id: "cacbd4d4-9102-4687-98b4-d529be3d5710")
     ActiveRecord::Base.connection.execute("ALTER SEQUENCE dummy_maat_reference_seq RESTART;")
 
-    allow(CommonPlatform::Api::RecordLaaReference).to receive(:call)
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call)
     allow(Rails.logger).to receive(:warn)
   end
 
   it "creates a dummy maat_reference starting with Z" do
-    expect(CommonPlatform::Api::RecordLaaReference).to receive(:call).with(hash_including(application_reference: "Z10000000"))
+    expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call).with(hash_including(application_reference: "Z10000000"))
     call_unlinker
   end
 
@@ -126,8 +126,8 @@ RSpec.describe LaaReferenceUnlinker do
       call_unlinker
     end
 
-    it "calls the CommonPlatform::Api::RecordLaaReference service multiple times" do
-      expect(CommonPlatform::Api::RecordLaaReference).to receive(:call).twice.with(hash_including(application_reference: "Z10000000"))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service multiple times" do
+      expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call).twice.with(hash_including(application_reference: "Z10000000"))
       call_unlinker
     end
   end
@@ -140,8 +140,8 @@ RSpec.describe LaaReferenceUnlinker do
       call_unlinker
     end
 
-    it "calls the CommonPlatform::Api::RecordLaaReference service" do
-      expect(CommonPlatform::Api::RecordLaaReference).to receive(:call).once.with(hash_including(application_reference: "Z10000000"))
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service" do
+      expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call).once.with(hash_including(application_reference: "Z10000000"))
       call_unlinker
     end
   end

--- a/spec/services/prosecution_case_link_validator_spec.rb
+++ b/spec/services/prosecution_case_link_validator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe LinkValidator do
+RSpec.describe ProsecutionCaseLinkValidator do
   subject(:link_validator_response) { described_class.call(defendant_id:) }
 
   let(:defendant_id) { "8cd0ba7e-df89-45a3-8c61-4008a2186d64" }

--- a/spec/services/prosecution_case_maat_link_creator_spec.rb
+++ b/spec/services/prosecution_case_maat_link_creator_spec.rb
@@ -2,7 +2,7 @@
 
 require "sidekiq/testing"
 
-RSpec.describe MaatLinkCreator do
+RSpec.describe ProsecutionCaseMaatLinkCreator do
   subject(:create_maat_link) { described_class.call(defendant_id, user_name, maat_reference) }
 
   include ActiveSupport::Testing::TimeHelpers
@@ -28,11 +28,11 @@ RSpec.describe MaatLinkCreator do
     )
 
     allow(Sqs::MessagePublisher).to receive(:call)
-    allow(CommonPlatform::Api::RecordLaaReference).to receive(:call)
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call)
   end
 
   it "enqueues a HearingResultFetcherWorker per hearing" do
-    allow(CommonPlatform::Api::RecordLaaReference)
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
       .to receive(:call)
       .and_return(response)
 
@@ -49,13 +49,13 @@ RSpec.describe MaatLinkCreator do
     end
   end
 
-  it "calls the CommonPlatform::Api::RecordLaaReference service once" do
-    allow(CommonPlatform::Api::RecordLaaReference)
+  it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service once" do
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
       .to receive(:call)
       .once.with(hash_including(application_reference: "12345678"))
       .and_return(response)
 
-    expect(CommonPlatform::Api::RecordLaaReference)
+    expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
       .to receive(:call)
       .once
       .with(hash_including(application_reference: "12345678"))
@@ -64,7 +64,7 @@ RSpec.describe MaatLinkCreator do
   end
 
   it "calls the Sqs::MessagePublisher service once" do
-    allow(CommonPlatform::Api::RecordLaaReference)
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
       .to receive(:call)
       .once.with(hash_including(application_reference: "12345678"))
       .and_return(response)
@@ -94,7 +94,7 @@ RSpec.describe MaatLinkCreator do
     end
 
     it "calls the Sqs::MessagePublisher service once" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
@@ -103,12 +103,12 @@ RSpec.describe MaatLinkCreator do
       create_maat_link
     end
 
-    it "calls the CommonPlatform::Api::RecordLaaReference service multiple times" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service multiple times" do
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
-      expect(CommonPlatform::Api::RecordLaaReference)
+      expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .twice
         .with(hash_including(application_reference: "12345678"))
@@ -124,7 +124,7 @@ RSpec.describe MaatLinkCreator do
       before do
         existing_laa_reference.update!(linked: false)
 
-        allow(CommonPlatform::Api::RecordLaaReference)
+        allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
           .to receive(:call)
           .and_return(response)
       end
@@ -141,7 +141,7 @@ RSpec.describe MaatLinkCreator do
     let(:maat_reference) { "A10000000" }
 
     it "does not call the Sqs::MessagePublisher service" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
@@ -151,11 +151,11 @@ RSpec.describe MaatLinkCreator do
     end
 
     it "creates a dummy maat_reference" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
-      expect(CommonPlatform::Api::RecordLaaReference)
+      expect(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .with(hash_including(application_reference: "A10000000"))
 
@@ -167,7 +167,7 @@ RSpec.describe MaatLinkCreator do
     let(:maat_reference) { nil }
 
     it "creates a dummy_maat_reference" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
@@ -179,7 +179,7 @@ RSpec.describe MaatLinkCreator do
 
   describe "linking twice" do
     it "marks previous record as unlinked and creates a new one marked as linked" do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
 
@@ -196,7 +196,7 @@ RSpec.describe MaatLinkCreator do
     let(:response) { OpenStruct.new("status" => 500, "success?" => false) }
 
     before do
-      allow(CommonPlatform::Api::RecordLaaReference)
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
         .to receive(:call)
         .and_return(response)
     end

--- a/spec/workers/prosecution_case_maat_link_creator_worker_spec.rb
+++ b/spec/workers/prosecution_case_maat_link_creator_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require "sidekiq/testing"
 
-RSpec.describe MaatLinkCreatorWorker, type: :worker do
+RSpec.describe ProsecutionCaseMaatLinkCreatorWorker, type: :worker do
   subject(:work) do
     described_class.perform_async(request_id, defendant_id, user_name, maat_reference)
   end
@@ -22,7 +22,7 @@ RSpec.describe MaatLinkCreatorWorker, type: :worker do
 
   it "calls MaatLinkCreator" do
     Sidekiq::Testing.inline! do
-      expect(MaatLinkCreator).to receive(:call).once.with(defendant_id, user_name, maat_reference)
+      expect(ProsecutionCaseMaatLinkCreator).to receive(:call).once.with(defendant_id, user_name, maat_reference)
       work
     end
   end

--- a/spec/workers/prosecution_case_representation_order_creator_worker_spec.rb
+++ b/spec/workers/prosecution_case_representation_order_creator_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require "sidekiq/testing"
 
-RSpec.describe RepresentationOrderCreatorWorker, type: :worker do
+RSpec.describe ProsecutionCaseRepresentationOrderCreatorWorker, type: :worker do
   subject(:work) do
     described_class.perform_async(request_id, defendant_id, offences, maat_reference, defence_organisation)
   end
@@ -21,7 +21,7 @@ RSpec.describe RepresentationOrderCreatorWorker, type: :worker do
 
   it "creates a CommonPlatform::Api::RepresentationOrderCreator and calls it" do
     Sidekiq::Testing.inline! do
-      expect(CommonPlatform::Api::RepresentationOrderCreator).to receive(:call).once.with(
+      expect(CommonPlatform::Api::ProsecutionCaseRepresentationOrderCreator).to receive(:call).once.with(
         defendant_id:,
         offences:,
         maat_reference:,

--- a/spec/workers/unlink_prosecution_case_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_prosecution_case_laa_reference_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require "sidekiq/testing"
 
-RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
+RSpec.describe UnlinkProsecutionCaseLaaReferenceWorker, type: :worker do
   subject(:work) do
     described_class.perform_async(request_id, defendant_id, user_name, unlink_reason_code, unlink_other_reason_text, maat_reference)
   end
@@ -23,7 +23,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
     ProsecutionCaseDefendantOffence.create!(prosecution_case_id:,
                                             defendant_id:,
                                             offence_id: "cacbd4d4-9102-4687-98b4-d529be3d5710")
-    allow(CommonPlatform::Api::RecordLaaReference).to receive(:call)
+    allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference).to receive(:call)
   end
 
   it "queues the job" do
@@ -35,7 +35,7 @@ RSpec.describe UnlinkLaaReferenceWorker, type: :worker do
   it "creates a LaaReferenceUnlinker and calls it" do
     set_up_linked_prosecution_case
     Sidekiq::Testing.inline! do
-      expect(LaaReferenceUnlinker).to receive(:call).with(
+      expect(ProsecutionCaseLaaReferenceUnlinker).to receive(:call).with(
         defendant_id:,
         user_name:,
         unlink_reason_code:,


### PR DESCRIPTION
## What
Standardise the naming of things, so that entities are either `CourtApplication` or `ProsecutionCase`.

Note that this should be deployed to production out-of-hours because we are renaming some async jobs and we don't want to risk enqueueing a job that refers to a class that stops existing when the job is run.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-815)

