### PR TITLE
Try to capture Sidekiq errors in Sentry

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -21,6 +21,7 @@ if Rails.env.production?
     config.server_middleware do |chain|
       chain.add PrometheusExporter::Instrumentation::Sidekiq
     end
+    config.error_handlers << proc { |exception, tags, _config| Sentry.capture_exception(exception, tags:) }
     config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
     config.on :startup do
       PrometheusExporter::Instrumentation::Process.start type: "sidekiq"


### PR DESCRIPTION
We're not seeing Sentry notifications when Sidekiq jobs fail, either temporarily or permanently. This isn't great. So this PR attempts to make Sentry be told every time a job fails, even transient errors (like Sentry is notified of transient errors for web requests).