### PR TITLE
ACD-862: Report routing errors to Sentry in UAT/Prod

### DIFF
--- a/config/initializers/routing_errors.rb
+++ b/config/initializers/routing_errors.rb
@@ -5,6 +5,6 @@ ActionDispatch::DebugExceptions.register_interceptor do |_req, exception|
   # to the API is IP-restricted, so that we're not constantly alerted by
   # crawlers trying random paths.
   if exception.is_a?(ActionController::RoutingError) && ENV.fetch("ACCESS_IP_RESTRICTED", "false") == "true"
-    Sentry.capture_exception(exception)
+    Sentry.capture_exception(exception, hint: { ignore_exclusions: true })
   end
 end

--- a/config/initializers/routing_errors.rb
+++ b/config/initializers/routing_errors.rb
@@ -1,0 +1,10 @@
+ActionDispatch::DebugExceptions.register_interceptor do |_req, exception|
+  # Rails normally handles these errors itself so they are never exposed to
+  # Sentry. However we want to be alerted whenever a system tries to reach
+  # an endpoint that doesn't exist, BUT ONLY in environments where access
+  # to the API is IP-restricted, so that we're not constantly alerted by
+  # crawlers trying random paths.
+  if exception.is_a?(ActionController::RoutingError) && ENV.fetch("ACCESS_IP_RESTRICTED", "false") == "true"
+    Sentry.capture_exception(exception)
+  end
+end

--- a/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
+++ b/helm_deploy/laa-court-data-adaptor/templates/_environment.tpl
@@ -99,4 +99,6 @@ env:
     value: {{ .Values.rails.host_env }}
   - name: METRICS_SERVICE_HOST
     value: {{ include "laa-court-data-adaptor.fullname" . }}
+  - name: ACCESS_IP_RESTRICTED
+    value: '{{ .Values.ips.restrict }}'
 {{- end -}}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-862)

If the only things talking to CDA are our systems, and something requests an endpoint that doesn't exist,  let Sentry know so we get alerted.