### PR TITLE
ACD-863: Stop silently failing

### DIFF
--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -39,13 +39,8 @@ class LaaReference < ApplicationRecord
 
   def self.retrieve_by_defendant_id_and_optional_maat_reference(defendant_id, maat_reference = nil)
     laa_refs = where(defendant_id:, linked: true)
+    ref = maat_reference.blank? ? laa_refs.first : laa_refs.find_by(maat_reference:)
 
-    if laa_refs.blank?
-      raise ActiveRecord::RecordNotFound, "Defendant not found or already unlinked!"
-    end
-
-    return laa_refs.first if maat_reference.blank?
-
-    laa_refs.find_by(maat_reference:)
+    ref || (raise ActiveRecord::RecordNotFound, "Defendant not found or already unlinked!")
   end
 end

--- a/app/services/court_application_laa_reference_unlinker.rb
+++ b/app/services/court_application_laa_reference_unlinker.rb
@@ -9,8 +9,6 @@ class CourtApplicationLaaReferenceUnlinker < ApplicationService
   end
 
   def call
-    return unless laa_reference
-
     push_to_queue unless laa_reference.dummy_maat_reference?
     update_offences_on_common_platform
     unlink_maat_reference!

--- a/app/services/prosecution_case_laa_reference_unlinker.rb
+++ b/app/services/prosecution_case_laa_reference_unlinker.rb
@@ -6,7 +6,6 @@ class ProsecutionCaseLaaReferenceUnlinker < ApplicationService
     @user_name = user_name
     @unlink_reason_code = unlink_reason_code
     @unlink_other_reason_text = unlink_other_reason_text
-
     @laa_reference = LaaReference.retrieve_by_defendant_id_and_optional_maat_reference(defendant_id, maat_reference)
   end
 

--- a/app/services/prosecution_case_laa_reference_unlinker.rb
+++ b/app/services/prosecution_case_laa_reference_unlinker.rb
@@ -10,8 +10,6 @@ class ProsecutionCaseLaaReferenceUnlinker < ApplicationService
   end
 
   def call
-    return unless laa_reference
-
     push_to_queue unless laa_reference.dummy_maat_reference?
     update_offences_on_common_platform
     unlink_maat_reference!

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -109,4 +109,42 @@ RSpec.describe LaaReference, type: :model do
       expect(described_class.new(maat_reference: nil)).not_to be_dummy_maat_reference
     end
   end
+
+  describe ".retrieve_by_defendant_id_and_optional_maat_reference" do
+    before { laa_reference.save! }
+
+    context "when only defendant id provided" do
+      subject(:retrieve) { described_class.retrieve_by_defendant_id_and_optional_maat_reference(defendant_id) }
+
+      context "when defendant ID matches" do
+        let(:defendant_id) { laa_reference.defendant_id }
+
+        it { expect(retrieve).to eq laa_reference }
+      end
+
+      context "when defendant ID does not match" do
+        let(:defendant_id) { SecureRandom.uuid }
+
+        it { expect { retrieve }.to raise_error ActiveRecord::RecordNotFound }
+      end
+    end
+
+    context "when both args provided" do
+      subject(:retrieve) { described_class.retrieve_by_defendant_id_and_optional_maat_reference(defendant_id, maat_reference) }
+
+      context "when args match" do
+        let(:defendant_id) { laa_reference.defendant_id }
+        let(:maat_reference) { laa_reference.maat_reference }
+
+        it { expect(retrieve).to eq laa_reference }
+      end
+
+      context "when args not match" do
+        let(:defendant_id) { SecureRandom.uuid }
+        let(:maat_reference) { "1234567" }
+
+        it { expect { retrieve }.to raise_error ActiveRecord::RecordNotFound }
+      end
+    end
+  end
 end

--- a/spec/workers/unlink_prosecution_case_laa_reference_worker_spec.rb
+++ b/spec/workers/unlink_prosecution_case_laa_reference_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UnlinkProsecutionCaseLaaReferenceWorker, type: :worker do
   let(:prosecution_case_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
   let(:maat_reference) { "6666666" }
   let(:set_up_linked_prosecution_case) do
-    LaaReference.create!(defendant_id:, user_name: "cpUser", maat_reference: 101_010)
+    LaaReference.create!(defendant_id:, user_name: "cpUser", maat_reference:)
     ProsecutionCase.create!(
       id: prosecution_case_id,
       body: JSON.parse(file_fixture("prosecution_case_search_result.json").read)["cases"][0],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-863)

If VCD passes an invalid MAAT ID to the unlink endpoint, we currently silently fail. Instead we should return an error, otherwise VCD tells the user that unlinking has succeeded. This PR makes `LaaReference. retrieve_by_defendant_id_and_optional_maat_reference` raise errors if an invalid MAAT ID is passed, and removes the early returns from the unlinker services