### PR TITLE
(WIP) ACD-865: Allow loading offence history separately

### DIFF
--- a/app/controllers/api/internal/v2/defendants_controller.rb
+++ b/app/controllers/api/internal/v2/defendants_controller.rb
@@ -5,21 +5,28 @@ module Api
     module V2
       class DefendantsController < ApplicationController
         def show
-          response_data = CommonPlatform::Api::ProsecutionCaseFetcher.call(
-            prosecution_case_reference: params[:prosecution_case_reference],
-          ).body
+          response_data = CommonPlatform::Api::ProsecutionCaseFinder.call(params[:prosecution_case_reference]).body
 
-          defendant_summary = HmctsCommonPlatform::SearchProsecutionCaseResponse.new(response_data)
-            .cases
-            .first
-            .defendant_summaries
-            .find { |ds| ds.defendant_id.eql?(params[:id]) }
+          prosecution_case_summary = HmctsCommonPlatform::ProsecutionCaseSummary.new(response_data)
+          defendant_summary = prosecution_case_summary.defendant_summaries.find { |ds| ds.defendant_id.eql?(params[:id]) }
 
           if defendant_summary.present?
             render json: defendant_summary.to_json
           else
             render json: {}, status: :not_found
           end
+        end
+
+        def offence_history
+          prosecution_case = CommonPlatform::Api::ProsecutionCaseFinder.call(params[:prosecution_case_reference])
+          prosecution_case.load_hearing_results(params[:id], load_events: false)
+          defendant = prosecution_case.defendants.find { it.id == params[:id] }
+          render json: {
+            defendant_id: params[:id],
+            offence_histories: defendant.offences.map do |offence|
+              { id: offence.id, pleas: offence.pleas, mode_of_trial_reasons: offence.mode_of_trial_reasons }
+            end
+          }
         end
       end
     end

--- a/app/models/hmcts_common_platform/defendant_summary.rb
+++ b/app/models/hmcts_common_platform/defendant_summary.rb
@@ -59,6 +59,10 @@ module HmctsCommonPlatform
       end
     end
 
+    def maat_reference
+      ::LaaReference.find_by(linked: true, defendant_id:)&.maat_reference
+    end
+
     def to_json(*_args)
       to_builder.attributes!
     end
@@ -88,6 +92,7 @@ module HmctsCommonPlatform
         defendant_summary.representation_order representation_order.to_json
         defendant_summary.offence_summaries(offence_summaries.map(&:to_json))
         defendant_summary.application_summaries(application_summaries.map(&:to_json))
+        defendant_summary.maat_reference maat_reference
       end
     end
   end

--- a/app/services/common_platform/api/defendant_finder.rb
+++ b/app/services/common_platform/api/defendant_finder.rb
@@ -35,7 +35,7 @@ module CommonPlatform
       def common_platform_prosecution_case(urn)
         return unless urn
 
-        prosecution_case = load_from_common_platform(urn)
+        prosecution_case = ProsecutionCaseFinder.call(urn)
 
         # fetch details needed to include plea and mode of trial reason, at least
         prosecution_case&.load_hearing_results(defendant_id, load_events: false)
@@ -74,16 +74,6 @@ module CommonPlatform
         user_friendly = with_spaces.map { "'#{_1}'" }.to_sentence
         raise ::Errors::DefendantError.new("Defendant ID #{defendant_id} associated with unrecognised URN(s) #{user_friendly}",
                                            :spaces_in_urn)
-      end
-
-      def load_from_common_platform(urn)
-        results = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)
-
-        # Very occasionally this case-insensitive URN search will return 2 results, so we
-        # insist on the one that matches the URN exactly, as the URN we are sending here
-        # comes from our existing copies of Common Platform data so should always be an
-        # exact match.
-        results.find { it.body["prosecutionCaseReference"] == urn }
       end
 
       attr_reader :defendant_id

--- a/app/services/common_platform/api/prosecution_case_finder.rb
+++ b/app/services/common_platform/api/prosecution_case_finder.rb
@@ -1,0 +1,23 @@
+module CommonPlatform
+  module Api
+    class ProsecutionCaseFinder < ApplicationService
+      def initialize(urn)
+        @urn = urn
+      end
+
+      def call
+        results = CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)
+
+        # Very occasionally this case-insensitive URN search will return 2 results, so we
+        # insist on the one that matches the URN exactly, as the URN we are sending here
+        # comes from our existing copies of Common Platform data so should always be an
+        # exact match.
+        results.find { it.prosecution_case_reference == urn }
+      end
+
+    private
+
+      attr_reader :urn
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
       api_version(module: "V2", path: { value: "v2" }) do
         resources :court_applications, only: [:show]
         resources :prosecution_cases, only: [:index], param: :reference do
-          resources :defendants, only: %i[show]
+          resources :defendants, only: %i[show] do
+            member { get :offence_history }
+          end
           collection { post "/", to: "index" }
         end
         resources :prosecution_case_laa_references, path: "laa_references", only: %i[create update], param: :defendant_id


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-865)

New endpoint that allows loading plea history and mode of trial reasons (which can be slow) via separate defendant endpoint.