### PR TITLE
ACD-872: Allow defendant page to load even if URN has a space.

### DIFF
--- a/app/controllers/api/internal/v2/defendants_controller.rb
+++ b/app/controllers/api/internal/v2/defendants_controller.rb
@@ -5,13 +5,14 @@ module Api
     module V2
       class DefendantsController < ApplicationController
         def show
-          response_data = CommonPlatform::Api::ProsecutionCaseFetcher.call(
-            prosecution_case_reference: params[:prosecution_case_reference],
+          response_data = CommonPlatform::Api::ProsecutionCaseFinder.call(
+            params[:prosecution_case_reference],
+            params[:id],
           ).body
 
-          defendant_summary = HmctsCommonPlatform::SearchProsecutionCaseResponse.new(response_data)
-            .cases
-            .first
+          return head :not_found unless response_data
+
+          defendant_summary = HmctsCommonPlatform::ProsecutionCaseSummary.new(response_data)
             .defendant_summaries
             .find { |ds| ds.defendant_id.eql?(params[:id]) }
 

--- a/app/controllers/api/internal/v2/prosecution_cases_controller.rb
+++ b/app/controllers/api/internal/v2/prosecution_cases_controller.rb
@@ -6,7 +6,13 @@ module Api
       class ProsecutionCasesController < ApplicationController
         # Get/Post /api/internal/v2/prosecution_cases
         def index
-          case_summaries = CommonPlatform::Api::SearchProsecutionCase.call(transformed_params)
+          case_summaries = if transformed_params[:prosecution_case_reference].present?
+                             CommonPlatform::Api::ProsecutionCaseFinder.call(
+                               transformed_params[:prosecution_case_reference],
+                             )
+                           else
+                             CommonPlatform::Api::SearchProsecutionCase.call(transformed_params)
+                           end
 
           case_summaries_json = Array(case_summaries).map do |case_summary|
             HmctsCommonPlatform::ProsecutionCaseSummary.new(case_summary.body).to_json

--- a/app/services/common_platform/api/prosecution_case_finder.rb
+++ b/app/services/common_platform/api/prosecution_case_finder.rb
@@ -1,0 +1,53 @@
+module CommonPlatform
+  module Api
+    # This class exists to work around two issues with search-by-URN.
+    # First, case URNs are NOT case-insensitive, but Common Platform URN
+    # search IS case insensitive.
+    # Second, case URNs can contain spaces, but Common Platform URN
+    # search strips spaces from search queries
+    class ProsecutionCaseFinder < ApplicationService
+      def initialize(urn, defendant_id = nil)
+        @urn = urn
+        @defendant_id = defendant_id
+      end
+
+      attr_reader :urn, :defendant_id
+
+      def call
+        filter_by_urn(retrieve_by_urn.presence || retrieve_by_defendant_details)
+      end
+
+      def retrieve_by_urn
+        CommonPlatform::Api::SearchProsecutionCase.call(prosecution_case_reference: urn)
+      end
+
+      def retrieve_by_defendant_details
+        return unless defendant_id
+
+        # Common Platform has a known bug where sometimes URNs have spaces, but if we
+        # look up by URN they strip spaces from the URN we send, which means we cannot
+        # successfully look up by URN if there is a space in the URN
+        local_record = ProsecutionCaseDefendantOffence.find_by(defendant_id:)&.prosecution_case
+        return unless local_record&.prosecution_case_reference == urn
+
+        local_defendant = local_record.defendants.find { it.id == defendant_id }
+        return unless local_defendant
+
+        CommonPlatform::Api::SearchProsecutionCase.call(
+          name: local_defendant.name,
+          date_of_birth: local_defendant.date_of_birth,
+        )
+      end
+
+      def filter_by_urn(results)
+        return unless results
+
+        # Very occasionally this case-insensitive URN search will return 2 results, so we
+        # insist on the one that matches the URN exactly, as the URN we are sending here
+        # comes from our existing copies of Common Platform data so should always be an
+        # exact match.
+        results.find { it.prosecution_case_reference == urn }
+      end
+    end
+  end
+end

--- a/spec/services/common_platform/api/defendant_finder_spec.rb
+++ b/spec/services/common_platform/api/defendant_finder_spec.rb
@@ -58,30 +58,6 @@ RSpec.describe CommonPlatform::Api::DefendantFinder do
       end
     end
 
-    context "when common platform does not match local records" do
-      let(:local_prosecution_cases_json) { file_fixture("prosecution_case_search_result.json").read }
-      let(:prosecution_cases_hash) { JSON.parse(local_prosecution_cases_json) }
-      let(:prosecution_cases_json) { '{ "cases":[] }' }
-
-      it { is_expected.to be_nil }
-
-      context "when it is because URN has a space in it" do
-        let(:prosecution_case_reference) { "ABCDE " }
-        let(:prosecution_case_local_body) do
-          prosecution_cases_hash["cases"][0].tap do |record|
-            record["prosecutionCaseReference"] = prosecution_case_reference
-          end
-        end
-
-        it "raises an error" do
-          expect { defendant }.to raise_error(
-            Errors::DefendantError,
-            "Defendant ID #{defendant_id} associated with unrecognised URN(s) 'ABCDE '",
-          )
-        end
-      end
-    end
-
     context "when defendant does not exist" do
       let(:defendant_id) { "2ecc9feb-9407-482f-b081-123456789012" }
 

--- a/spec/services/common_platform/api/prosecution_case_finder_spec.rb
+++ b/spec/services/common_platform/api/prosecution_case_finder_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
+  subject(:result) { described_class.call(urn, defendant_id) }
+
+  let(:urn) { "abcde" }
+  let(:matching_record) { ProsecutionCase.new(body: { prosecutionCaseReference: urn }) }
+  let(:non_matching_record) { ProsecutionCase.new(body: { prosecutionCaseReference: "ABCDE" }) }
+
+  before do
+    allow(CommonPlatform::Api::SearchProsecutionCase).to receive(:call).with(
+      prosecution_case_reference: urn,
+    ).and_return(urn_search_results)
+  end
+
+  context "when no defendant_id is provided" do
+    let(:defendant_id) { nil }
+
+    context "when search by URN returns a matching result" do
+      let(:urn_search_results) {  [matching_record] }
+
+      it "returns that result" do
+        expect(result).to eq matching_record
+      end
+    end
+
+    context "when search by URN returns a non-matching result" do
+      let(:urn_search_results) { [non_matching_record] }
+
+      it "returns nothing" do
+        expect(result).to be_nil
+      end
+    end
+
+    context "when search by URN returns two results" do
+      let(:urn_search_results) { [matching_record, non_matching_record] }
+
+      it "returns the matching result" do
+        expect(result).to eq matching_record
+      end
+    end
+
+    context "when search by URN returns no results" do
+      let(:urn_search_results) { [] }
+
+      it "returns nothing" do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  context "when defendant_id is provided" do
+    let(:defendant_id) { SecureRandom.uuid }
+
+    context "when search by URN returns a result" do
+      let(:urn_search_results) { [matching_record] }
+
+      it "returns that result" do
+        expect(result).to eq matching_record
+      end
+    end
+
+    context "when search by URN returns no results" do
+      let(:urn_search_results) { [] }
+
+      context "when there is no local record" do
+        it "returns nothing" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "when there is a local record" do
+        before do
+          matching_record.save!
+          ProsecutionCaseDefendantOffence.create!(
+            prosecution_case: matching_record,
+            defendant_id:,
+            offence_id: SecureRandom.uuid,
+          )
+        end
+
+        context "when the local record matches defendant_id" do
+          let(:matching_record) do
+            ProsecutionCase.new(body: {
+              prosecutionCaseReference: urn,
+              defendantSummary: [{ defendantId: defendant_id, defendantFirstName: "Jane", defendantLastName: "Doe", defendantDOB: "1984-01-01" }],
+            })
+          end
+
+          before do
+            allow(CommonPlatform::Api::SearchProsecutionCase).to receive(:call).with(
+              name: "Jane Doe",
+              date_of_birth: "1984-01-01",
+            ).and_return(defendant_search_results)
+          end
+
+          context "when search by defendant returns a matching result" do
+            let(:defendant_search_results) { [matching_record] }
+
+            it "returns that result" do
+              expect(result).to eq matching_record
+            end
+          end
+
+          context "when search by defendant returns a non-matching result" do
+            let(:defendant_search_results) { [non_matching_record] }
+
+            it "returns nothing" do
+              expect(result).to be_nil
+            end
+          end
+
+          context "when search by defendant returns two results" do
+            let(:defendant_search_results) { [matching_record, non_matching_record] }
+
+            it "returns the matching result" do
+              expect(result).to eq matching_record
+            end
+          end
+
+          context "when search by defendant returns no results" do
+            let(:defendant_search_results) { [] }
+
+            it "returns nothing" do
+              expect(result).to be_nil
+            end
+          end
+        end
+
+        context "when the local record does not match defendant id" do
+          let(:matching_record) do
+            ProsecutionCase.new(body: {
+              prosecutionCaseReference: urn,
+              defendantSummary: [{ defendantId: SecureRandom.uuid }],
+            })
+          end
+
+          it "returns nothing" do
+            expect(result).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/common_platform/api/prosecution_case_finder_spec.rb
+++ b/spec/services/common_platform/api/prosecution_case_finder_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
     context "when search by URN returns a non-matching result" do
       let(:urn_search_results) { [non_matching_record] }
 
-      it "returns nothing" do
-        expect(result).to be_nil
-      end
+      it { is_expected.to be_nil }
     end
 
     context "when search by URN returns two results" do
@@ -43,9 +41,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
     context "when search by URN returns no results" do
       let(:urn_search_results) { [] }
 
-      it "returns nothing" do
-        expect(result).to be_nil
-      end
+      it { is_expected.to be_nil }
     end
   end
 
@@ -64,9 +60,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
       let(:urn_search_results) { [] }
 
       context "when there is no local record" do
-        it "returns nothing" do
-          expect(result).to be_nil
-        end
+        it { is_expected.to be_nil }
       end
 
       context "when there is a local record" do
@@ -105,9 +99,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
           context "when search by defendant returns a non-matching result" do
             let(:defendant_search_results) { [non_matching_record] }
 
-            it "returns nothing" do
-              expect(result).to be_nil
-            end
+            it { is_expected.to be_nil }
           end
 
           context "when search by defendant returns two results" do
@@ -121,9 +113,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
           context "when search by defendant returns no results" do
             let(:defendant_search_results) { [] }
 
-            it "returns nothing" do
-              expect(result).to be_nil
-            end
+            it { is_expected.to be_nil }
           end
         end
 
@@ -135,9 +125,7 @@ RSpec.describe CommonPlatform::Api::ProsecutionCaseFinder do
             })
           end
 
-          it "returns nothing" do
-            expect(result).to be_nil
-          end
+          it { is_expected.to be_nil }
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-872)

Previously, if a caseworker searched by defendant details and Common Platform returned a record with a space in the URN, when the caseworker clicked through to the defendant details page we would try to look up the record by URN and this fails because Common Platform strips the spaces from search terms so doesn't match URNs that do have spaces.

This PR adds a fallback so that if we can't load the record by URN we will fall back to look up by defendant details, using the defendant details in our local DB. At every stage it checks to make sure that what is returned actually matches what was searched for.
