### PR TITLE
Stop filtering. Again.

### DIFF
--- a/app/controllers/concerns/prosecution_concludable.rb
+++ b/app/controllers/concerns/prosecution_concludable.rb
@@ -37,46 +37,6 @@ private
   end
 
   def prosecution_conclusion_params
-    params.require(:prosecution_conclusion).permit(
-      prosecutionConcluded: [
-        :prosecutionCaseId,
-        :defendantId,
-        :isConcluded,
-        :hearingIdWhereChangeOccurred,
-        {
-          applicationConcluded: %i[
-            applicationId
-            applicationResultCode
-            subjectId
-          ],
-          offenceSummary: [
-            :offenceId,
-            :offenceCode,
-            :proceedingsConcluded,
-            :proceedingsConcludedChangedDate,
-            {
-              plea: %i[
-                originatingHearingId
-                value
-                pleaDate
-              ],
-              verdict: [
-                :verdictDate,
-                :originatingHearingId,
-                {
-                  verdictType: %i[
-                    description
-                    category
-                    categoryType
-                    sequence
-                    verdictTypeId
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    )
+    params.require(:prosecution_conclusion).permit!
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,28 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "a13fae50ad49fb39ce3fdde70d4bbb6c6f2f7c104da8d413ff143c796c2d5b28",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/concerns/prosecution_concludable.rb",
+      "line": 40,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:prosecution_conclusion).permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProsecutionConcludable",
+        "method": "prosecution_conclusion_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "We trust Common Platform and treat this endpoint as a pass-thru to pass on messages from them to MAAT"
+    }
+  ],
+  "brakeman_version": "7.0.2"
+}


### PR DESCRIPTION
## What
Turns out MAAT really does want data from the prosecution concluded payload that we currently filter out. So I'm re-removing the filtering.