### PR TITLE
Handle unrecognised court centre IDs gracefully

### DIFF
--- a/app/models/hmcts_common_platform/court_centre.rb
+++ b/app/models/hmcts_common_platform/court_centre.rb
@@ -45,7 +45,7 @@ module HmctsCommonPlatform
     end
 
     def code
-      data[:code] || HmctsCommonPlatform::Reference::CourtCentre.find(id).oucode
+      data[:code] || HmctsCommonPlatform::Reference::CourtCentre.find(id)&.oucode
     end
 
     def address

--- a/spec/models/hmcts_common_platform/court_centre_spec.rb
+++ b/spec/models/hmcts_common_platform/court_centre_spec.rb
@@ -50,4 +50,24 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
     it { expect(court_centre.short_oucode).to eq("B30PI") }
     it { expect(court_centre.oucode_l2_code).to eq("30") }
   end
+
+  describe "when there is no code" do
+    let(:data) { { "id" => id } }
+
+    context "when ID is recognised" do
+      let(:id) { "14876ea1-5f7c-32ef-9fbd-aa0b63193550" }
+
+      it { expect(court_centre.code).to eq("B30PI00") }
+      it { expect(court_centre.short_oucode).to eq("B30PI") }
+      it { expect(court_centre.oucode_l2_code).to eq("30") }
+    end
+
+    context "when ID is not recognised" do
+      let(:id) { SecureRandom.uuid }
+
+      it { expect(court_centre.code).to be_nil }
+      it { expect(court_centre.short_oucode).to be_nil }
+      it { expect(court_centre.oucode_l2_code).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
## What
When no explicit code is returned, we try to look up the code based on the ID from a hard-coded list in a gem. But if that fails we currently throw an error even though other parts of the code make clear that we should be able to cope with not knowing what the code is.