### PR TITLE
Send appropriate messages to MAAT

### DIFF
--- a/app/models/hmcts_common_platform/court_application.rb
+++ b/app/models/hmcts_common_platform/court_application.rb
@@ -14,6 +14,10 @@ module HmctsCommonPlatform
       data[:id]
     end
 
+    def subject_id
+      data.dig(:subject, :id)
+    end
+
     def application_particulars
       data[:applicationParticulars]
     end


### PR DESCRIPTION
## What
When a court application hearing is resulted, Common Platform was already sending us messages, and we were already sending messages about court applications associated with the hearing to MAAT. So we thought no action was needed. BUT it turns out we were only sending messages about MAAT-linked defendants of the case associated with the appeal, not the subject of the appeal. This PR fixes that.