### PR TITLE
ACD-887: Add a minimum retry interval

### DIFF
--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -66,6 +66,7 @@ module CommonPlatform
     def retry_options
       {
         retry_statuses: [429],
+        interval: 3,
         methods: %i[delete get head options put post],
       }
     end

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe CommonPlatform::Connection do
 
       retry_options = {
         methods: %i[delete get head options put post],
+        interval: 3,
         retry_statuses: [429],
       }
 


### PR DESCRIPTION
## What
Common Platform sometimes sends 429s telling us to slow down. Looking at the Faraday source code, the built-in retry logic will respect a 'Retry-After' header in the Common Platform response, and from the logs it looks like Common Platform is providing such a header, because when a request is repeated after a 429, it typically is only repeated after an interval of between 1 and 6 seconds. So that by itself doesn't cause a logjam. However, we have multiple CDA production web pods and background pods and they can all be firing in parallel, but they don't know about each other, so if we start getting rate limited, the each pod respecting the 'Retry-After' individually can still result in exceeding the rate. So I think it would be a good idea to add a minimum retry interval of say 3 seconds so that if we start to get log-jammed (which happened again today) we pump the brakes enough to avoid compounding the issue.

