### PR TITLE
ACD-888: Raise clearer error when data issues prevent linking

### DIFF
--- a/spec/services/prosecution_case_maat_link_creator_spec.rb
+++ b/spec/services/prosecution_case_maat_link_creator_spec.rb
@@ -232,4 +232,23 @@ RSpec.describe ProsecutionCaseMaatLinkCreator do
       # rubocop enable Lint/SuppressedException
     end
   end
+
+  context "when the defendant ID is duplicated across cases" do
+    let(:other_prosecution_case_id) { SecureRandom.uuid }
+
+    before do
+      ProsecutionCase.create!(
+        id: other_prosecution_case_id,
+        body: JSON.parse(file_fixture("prosecution_case_search_result.json").read)["cases"][0],
+      )
+
+      ProsecutionCaseDefendantOffence.create!(prosecution_case_id: other_prosecution_case_id,
+                                              defendant_id:,
+                                              offence_id: SecureRandom.uuid)
+    end
+
+    it "raises an error" do
+      expect { create_maat_link }.to raise_error Errors::DefendantError
+    end
+  end
 end


### PR DESCRIPTION
## What
If the same defendant ID exists across multiple cases in our local DB ProsecutionCaseDefendantOffence table, when we link (by passing the defendant ID to CDA) we can come a-cropper if that defendant ID no longer features in the payload of the prosecution case payload. This can result in a not very helpful `undefined method 'arrest_summons_number' for nil` NoMethodError. This PR makes it more explicit what the problem is and makes sure that if we fail out, we do so straight away, not half way through the operation.
