### PR TITLE
ACD-940: Filter non-appeal court applications

### DIFF
--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -1,6 +1,15 @@
 class CourtApplication < ApplicationRecord
   validates :body, presence: true
 
+  # These are the titles of the types of court applications that we primarily support
+  # and will return inside a prosecution case payload. Other court application types
+  # will still be returned when attached to specific hearings.
+  SUPPORTED_COURT_APPLICATION_TITLES = [
+    "Appeal against conviction and sentence by a Magistrates' Court to the Crown Court",
+    "Appeal against conviction by a Magistrates' Court to the Crown Court",
+    "Appeal against sentence by a Magistrates' Court to the Crown Court",
+  ].freeze
+
   def hearing_summaries
     body["hearingSummary"]
   end

--- a/app/models/hmcts_common_platform/prosecution_case_summary.rb
+++ b/app/models/hmcts_common_platform/prosecution_case_summary.rb
@@ -20,7 +20,7 @@ module HmctsCommonPlatform
 
     def defendant_summaries
       Array(data[:defendantSummary]).map do |defendant_summary_data|
-        HmctsCommonPlatform::DefendantSummary.new(defendant_summary_data, data[:applicationSummary])
+        HmctsCommonPlatform::DefendantSummary.new(defendant_summary_data, court_application_summaries)
       end
     end
 
@@ -42,6 +42,14 @@ module HmctsCommonPlatform
         case_summary.case_status case_status
         case_summary.defendant_summaries defendant_summaries.map(&:to_json)
         case_summary.hearing_summaries hearing_summaries.map(&:to_json)
+      end
+    end
+
+    def court_application_summaries
+      return [] unless data[:applicationSummary].is_a?(Array)
+
+      @court_application_summaries ||= data[:applicationSummary].select do |summary|
+        ::CourtApplication::SUPPORTED_COURT_APPLICATION_TITLES.include?(summary[:applicationTitle])
       end
     end
   end

--- a/spec/fixtures/files/prosecution_case_summary/all_fields.json
+++ b/spec/fixtures/files/prosecution_case_summary/all_fields.json
@@ -6,6 +6,7 @@
     {
       "proceedingsConcluded": false,
       "defendantId": "b760daba-0d38-4bae-ad57-fbfd8419aefe",
+      "masterDefendantId": "b760daba-0d38-4bae-ad57-fbfd8419aefe",
       "defendantASN": "2100000000000267128K",
       "defendantFirstName": "Bob",
       "defendantMiddleName": "Steven",

--- a/spec/models/hmcts_common_platform/prosecution_case_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/prosecution_case_summary_spec.rb
@@ -12,6 +12,26 @@ RSpec.describe HmctsCommonPlatform::ProsecutionCaseSummary, type: :model do
     it { expect(prosecution_case_summary.case_status).to eq("ACTIVE") }
     it { expect(prosecution_case_summary.defendant_summaries).to all be_an(HmctsCommonPlatform::DefendantSummary) }
     it { expect(prosecution_case_summary.hearing_summaries).to all be_an(HmctsCommonPlatform::HearingSummary) }
+
+    context "when data includes a supported-type court application" do
+      before do
+        data["applicationSummary"].first["applicationTitle"] = "Appeal against conviction by a Magistrates' Court to the Crown Court"
+      end
+
+      it "passes the application along to the appropriate defendant" do
+        expect(prosecution_case_summary.defendant_summaries.first.application_summaries.count).to eq 1
+      end
+    end
+
+    context "when data includes an unsupported-type court application" do
+      before do
+        data["applicationSummary"].first["applicationTitle"] = "Application to amend a community order on change of residence"
+      end
+
+      it "passes the application along to the appropriate defendant" do
+        expect(prosecution_case_summary.defendant_summaries.first.application_summaries.count).to eq 0
+      end
+    end
   end
 
   context "with required fields only" do


### PR DESCRIPTION
## What
Filter out non-appeal court applications from prosecution case payloads returned by HMCTS. Annoyingly in this context there is no application type code, only a title, so we have to do a string comparison on that field.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-940)
