### PR TITLE
Be permissive about counsel attribute names

### DIFF
--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -65,13 +65,13 @@ module HmctsCommonPlatform
     end
 
     def prosecution_counsels
-      Array(data[:prosecutionCounsels]).map do |prosecution_counsel_data|
+      Array(data[:respondentCounsels].presence || data[:prosecutionCounsels]).map do |prosecution_counsel_data|
         HmctsCommonPlatform::ProsecutionCounsel.new(prosecution_counsel_data)
       end
     end
 
     def defence_counsels
-      Array(data[:defenceCounsels]).map do |defence_counsel_data|
+      Array(data[:applicantCounsels].presence || data[:defenceCounsels]).map do |defence_counsel_data|
         HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
       end
     end


### PR DESCRIPTION
## What
Turns out for court application hearings, counsels are included under `applicantCounsels` and `respondentCounsels` attribute names, so check for the presence of those.