### PR TITLE
ACD-953: Appeal counsels

### DIFF
--- a/app/models/hmcts_common_platform/applicant_counsel.rb
+++ b/app/models/hmcts_common_platform/applicant_counsel.rb
@@ -1,0 +1,62 @@
+module HmctsCommonPlatform
+  class ApplicantCounsel
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def id
+      data[:id]
+    end
+
+    def title
+      data[:title]
+    end
+
+    def first_name
+      data[:firstName]
+    end
+
+    def middle_name
+      data[:middleName]
+    end
+
+    def last_name
+      data[:lastName]
+    end
+
+    def status
+      data[:status]
+    end
+
+    def attendance_days
+      data[:attendanceDays]
+    end
+
+    def applicants
+      data[:applicants]
+    end
+
+    def to_json(*_args)
+      to_builder.attributes!
+    end
+
+  private
+
+    def to_builder
+      Jbuilder.new do |defence_counsel|
+        defence_counsel.id id
+        defence_counsel.title title
+        defence_counsel.first_name first_name
+        defence_counsel.middle_name middle_name
+        defence_counsel.last_name last_name
+        defence_counsel.status status
+        defence_counsel.attendance_days attendance_days
+        defence_counsel.applicants applicants
+      end
+    end
+  end
+end

--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -65,13 +65,13 @@ module HmctsCommonPlatform
     end
 
     def prosecution_counsels
-      Array(data[:prosecutionCounsels]).map do |prosecution_counsel_data|
+      Array(data[:respondentCounsels].presence || data[:prosecutionCounsels]).map do |prosecution_counsel_data|
         HmctsCommonPlatform::ProsecutionCounsel.new(prosecution_counsel_data)
       end
     end
 
     def defence_counsels
-      Array(data[:defenceCounsels]).map do |defence_counsel_data|
+      Array(data[:applicantCounsels].presence || data[:defenceCounsels]).map do |defence_counsel_data|
         HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
       end
     end

--- a/app/models/hmcts_common_platform/hearing.rb
+++ b/app/models/hmcts_common_platform/hearing.rb
@@ -65,14 +65,26 @@ module HmctsCommonPlatform
     end
 
     def prosecution_counsels
-      Array(data[:respondentCounsels].presence || data[:prosecutionCounsels]).map do |prosecution_counsel_data|
+      Array(data[:prosecutionCounsels]).map do |prosecution_counsel_data|
         HmctsCommonPlatform::ProsecutionCounsel.new(prosecution_counsel_data)
       end
     end
 
     def defence_counsels
-      Array(data[:applicantCounsels].presence || data[:defenceCounsels]).map do |defence_counsel_data|
+      Array(data[:defenceCounsels]).map do |defence_counsel_data|
         HmctsCommonPlatform::DefenceCounsel.new(defence_counsel_data)
+      end
+    end
+
+    def respondent_counsels
+      Array(data[:respondentCounsels] || []).map do |respondent_counsel_data|
+        HmctsCommonPlatform::RespondentCounsel.new(respondent_counsel_data)
+      end
+    end
+
+    def applicant_counsels
+      Array(data[:applicantCounsels] || []).map do |applicant_counsel_data|
+        HmctsCommonPlatform::ApplicantCounsel.new(applicant_counsel_data)
       end
     end
 
@@ -113,6 +125,8 @@ module HmctsCommonPlatform
         hearing.judiciary judicial_roles.map(&:to_json)
         hearing.prosecution_counsels prosecution_counsels.map(&:to_json)
         hearing.defence_counsels defence_counsels.map(&:to_json)
+        hearing.respondent_counsels respondent_counsels.map(&:to_json)
+        hearing.applicant_counsels applicant_counsels.map(&:to_json)
         hearing.cracked_ineffective_trial cracked_ineffective_trial.to_json
         hearing.defendant_attendance defendant_attendance.map(&:to_json)
       end

--- a/app/models/hmcts_common_platform/respondent_counsel.rb
+++ b/app/models/hmcts_common_platform/respondent_counsel.rb
@@ -1,0 +1,58 @@
+module HmctsCommonPlatform
+  class RespondentCounsel
+    attr_reader :data
+
+    delegate :blank?, to: :data
+
+    def initialize(data)
+      @data = HashWithIndifferentAccess.new(data || {})
+    end
+
+    def title
+      data[:title]
+    end
+
+    def first_name
+      data[:firstName]
+    end
+
+    def middle_name
+      data[:middleName]
+    end
+
+    def last_name
+      data[:lastName]
+    end
+
+    def status
+      data[:status]
+    end
+
+    def attendance_days
+      data[:attendanceDays]
+    end
+
+    def to_json(*_args)
+      return {} if attrs.all? { |_k, v| v.blank? }
+
+      attrs
+    end
+
+  private
+
+    def attrs
+      @attrs ||= to_builder.attributes!
+    end
+
+    def to_builder
+      Jbuilder.new do |prosecution_counsel|
+        prosecution_counsel.title title
+        prosecution_counsel.first_name first_name
+        prosecution_counsel.middle_name middle_name
+        prosecution_counsel.last_name last_name
+        prosecution_counsel.status status
+        prosecution_counsel.attendance_days attendance_days
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/applicant_counsel.json
+++ b/spec/fixtures/files/applicant_counsel.json
@@ -1,0 +1,13 @@
+{
+  "applicants": [
+    "35df5b45-83e2-4419-8236-3eb15b43dc63"
+  ],
+  "attendanceDays": [
+    "2025-07-29"
+  ],
+  "firstName": "Charlie Test",
+  "id": "53cab703-de93-47ca-97b7-0dedd2456547",
+  "lastName": "Advocate",
+  "status": "QC",
+  "title": "Ms"
+}

--- a/spec/fixtures/files/respondent_counsel.json
+++ b/spec/fixtures/files/respondent_counsel.json
@@ -1,0 +1,13 @@
+{
+  "attendanceDays": [
+    "2025-07-29"
+  ],
+  "firstName": "John Test",
+  "id": "75b46cde-1c4f-4c51-a9aa-e153813e1139",
+  "lastName": "Doe",
+  "respondents": [
+    "053b7d17-9e1f-4f31-aa61-b90df78e1d7f"
+  ],
+  "status": "Leading junior",
+  "title": "Mr"
+}

--- a/spec/models/hmcts_common_platform/applicant_counsel_spec.rb
+++ b/spec/models/hmcts_common_platform/applicant_counsel_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe HmctsCommonPlatform::ApplicantCounsel, type: :model do
+  let(:applicant_counsel) { described_class.new(data) }
+
+  let(:data) { JSON.parse(file_fixture("applicant_counsel.json").read) }
+
+  it "generates a JSON representation of the data" do
+    expect(applicant_counsel.to_json["title"]).to eql("Ms")
+    expect(applicant_counsel.to_json["first_name"]).to eql("Charlie Test")
+    expect(applicant_counsel.to_json["middle_name"]).to be_nil
+    expect(applicant_counsel.to_json["last_name"]).to eql("Advocate")
+    expect(applicant_counsel.to_json["status"]).to eql("QC")
+    expect(applicant_counsel.to_json["attendance_days"]).to eql(%w[2025-07-29])
+    expect(applicant_counsel.to_json["applicants"]).to eql(%w[35df5b45-83e2-4419-8236-3eb15b43dc63])
+  end
+
+  it { expect(applicant_counsel.title).to eql("Ms") }
+  it { expect(applicant_counsel.first_name).to eql("Charlie Test") }
+  it { expect(applicant_counsel.middle_name).to be_nil }
+  it { expect(applicant_counsel.last_name).to eql("Advocate") }
+  it { expect(applicant_counsel.status).to eql("QC") }
+  it { expect(applicant_counsel.attendance_days).to eql(%w[2025-07-29]) }
+  it { expect(applicant_counsel.applicants).to eql(%w[35df5b45-83e2-4419-8236-3eb15b43dc63]) }
+end

--- a/spec/models/hmcts_common_platform/hearing_spec.rb
+++ b/spec/models/hmcts_common_platform/hearing_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe HmctsCommonPlatform::Hearing, type: :model do
     expect(hearing.to_json["court_applications"]).to be_present
     expect(hearing.to_json["prosecution_counsels"]).to be_present
     expect(hearing.to_json["defence_counsels"]).to be_present
+    expect(hearing.to_json["respondent_counsels"]).to eq []
+    expect(hearing.to_json["applicant_counsels"]).to eq []
     expect(hearing.to_json["judiciary"]).to be_present
     expect(hearing.to_json["defendant_judicial_results"]).to be_present
     expect(hearing.to_json["defendant_attendance"]).to be_present

--- a/spec/models/hmcts_common_platform/respondent_counsel_spec.rb
+++ b/spec/models/hmcts_common_platform/respondent_counsel_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe HmctsCommonPlatform::RespondentCounsel, type: :model do
+  let(:respondent_counsel) { described_class.new(data) }
+
+  let(:data) { JSON.parse(file_fixture("respondent_counsel.json").read) }
+
+  it "generates a JSON representation of the data" do
+    expect(respondent_counsel.to_json["title"]).to eql("Mr")
+    expect(respondent_counsel.to_json["first_name"]).to eql("John Test")
+    expect(respondent_counsel.to_json["middle_name"]).to be_nil
+    expect(respondent_counsel.to_json["last_name"]).to eql("Doe")
+    expect(respondent_counsel.to_json["status"]).to eql("Leading junior")
+    expect(respondent_counsel.to_json["attendance_days"]).to eql(%w[2025-07-29])
+  end
+
+  it { expect(respondent_counsel.title).to eql("Mr") }
+  it { expect(respondent_counsel.first_name).to eql("John Test") }
+  it { expect(respondent_counsel.middle_name).to be_nil }
+  it { expect(respondent_counsel.last_name).to eql("Doe") }
+  it { expect(respondent_counsel.status).to eql("Leading junior") }
+  it { expect(respondent_counsel.attendance_days).to eql(%w[2025-07-29]) }
+end

--- a/swagger/v2/applicant_counsel.json
+++ b/swagger/v2/applicant_counsel.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "applicant_counsel",
+  "type": "object",
+  "properties": {
+    "title": {
+      "description": "The attendee title",
+      "type": "string"
+    },
+    "first_name": {
+      "description": "The attendee fore name",
+      "type": "string"
+    },
+    "middle_name": {
+      "description": "The attendee middle name",
+      "type": "string"
+    },
+    "last_name": {
+      "description": "The attendee last name",
+      "type": "string"
+    },
+    "status": {
+      "description": "The attendee status for the hearing e.g. junior counsel",
+      "type": "string"
+    },
+    "applicants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+      "$ref": "definitions.json#/definitions/uuid"
+      }
+    },
+    "attendance_days": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+      "$ref": "definitions.json#/definitions/datePattern"
+      }
+    }
+  }
+}

--- a/swagger/v2/hearing.json
+++ b/swagger/v2/hearing.json
@@ -91,6 +91,20 @@
       "items": {
         "$ref": "defendant_attendance.json#"
       }
+    },
+    "applicant_counsels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "applicant_counsel.json#"
+      }
+    },
+    "respondent_counsels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "respondent_counsel.json#"
+      }
     }
   }
 }

--- a/swagger/v2/respondent_counsel.json
+++ b/swagger/v2/respondent_counsel.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "respondent_counsel",
+  "type": "object",
+  "properties": {
+    "title": {
+      "description": "The attendee title",
+      "type": "string"
+    },
+    "first_name": {
+      "description": "The attendee fore name",
+      "type": "string"
+    },
+    "middle_name": {
+      "description": "The attendee middle name",
+      "type": "string"
+    },
+    "last_name": {
+      "description": "The attendee last name",
+      "type": "string"
+    },
+    "status": {
+      "description": "The attendee status for the hearing e.g. junior counsel",
+      "type": "string"
+    },
+    "attendance_days": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+      "$ref": "definitions.json#/definitions/datePattern"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
For appeal hearings, `applicantCounsels` is populated instead of `defenceCounsels`, and `respondentCounsels` instead of `prosecutionCounsels` by HMCTS. This PR passes on those properties to VCD if they are available.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-953)

Describe what you did and why.
