### PR TITLE
ACD-936 & ACD-937: (Breaches/POCA) Link and unlink without offences

### DIFF
--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -58,7 +58,7 @@ module HmctsCommonPlatform
     end
 
     def subject_summary
-      @subject_summary ||= HmctsCommonPlatform::SubjectSummary.new(data[:subjectSummary])
+      @subject_summary ||= HmctsCommonPlatform::SubjectSummary.new(data[:subjectSummary], self)
     end
 
     def linked_maat_id

--- a/app/models/hmcts_common_platform/subject_summary.rb
+++ b/app/models/hmcts_common_platform/subject_summary.rb
@@ -1,9 +1,10 @@
 module HmctsCommonPlatform
   class SubjectSummary
-    attr_reader :data
+    attr_reader :data, :application_summary
 
-    def initialize(data)
+    def initialize(data, application_summary = nil)
       @data = HashWithIndifferentAccess.new(data || {})
+      @application_summary = application_summary
     end
 
     def date_of_next_hearing
@@ -51,7 +52,7 @@ module HmctsCommonPlatform
     end
 
     def offence_summary
-      Array(data[:offenceSummary]).map do |summary_object|
+      offence_payload.map do |summary_object|
         HmctsCommonPlatform::OffenceSummary.new(summary_object, subject_id)
       end
     end
@@ -78,6 +79,22 @@ module HmctsCommonPlatform
         summary.organisation_name organisation_name
         summary.representation_order representation_order.to_json
       end
+    end
+
+    def offence_payload
+      return Array(data[:offenceSummary]) if data[:offenceSummary].present? || application_summary.nil?
+
+      # For court applications without offences (e.g. breaches) we construct
+      # a 'dummy' offence
+      [
+        {
+          "offenceId": application_summary.application_id,
+          "offenceCode": application_summary.application_type,
+          "asnSeq": 1,
+          "offenceDate": application_summary.received_date,
+          "offenceShortTitle": application_summary.application_title,
+        },
+      ]
     end
   end
 end

--- a/app/models/hmcts_common_platform/subject_summary.rb
+++ b/app/models/hmcts_common_platform/subject_summary.rb
@@ -63,6 +63,10 @@ module HmctsCommonPlatform
       to_builder.attributes!
     end
 
+    def has_offences?
+      data[:offenceSummary].present?
+    end
+
   private
 
     def to_builder
@@ -82,7 +86,7 @@ module HmctsCommonPlatform
     end
 
     def offence_payload
-      return Array(data[:offenceSummary]) if data[:offenceSummary].present? || application_summary.nil?
+      return Array(data[:offenceSummary]) if has_offences? || application_summary.nil?
 
       # For court applications without offences (e.g. breaches) we construct
       # a 'dummy' offence

--- a/app/services/common_platform/api/record_court_application_laa_reference.rb
+++ b/app/services/common_platform/api/record_court_application_laa_reference.rb
@@ -13,10 +13,16 @@ module CommonPlatform
         @application_reference = application_reference.to_s
         @status_date = status_date
         @connection = connection
-        @url = "prosecutionCases/laaReference"\
-                "/applications/#{application_id}"\
-                "/subject/#{subject_id}"\
-                "/offences/#{offence_id}"
+
+        @url = if @offence_id
+                 "prosecutionCases/laaReference"\
+                 "/applications/#{application_id}"\
+                 "/subject/#{subject_id}"\
+                 "/offences/#{offence_id}"
+               else
+                 "prosecutionCases/laaReference"\
+                 "/applications/#{application_id}"
+               end
       end
 
       def call

--- a/app/services/common_platform/api/record_court_application_representation_order.rb
+++ b/app/services/common_platform/api/record_court_application_representation_order.rb
@@ -19,10 +19,15 @@ module CommonPlatform
         @effective_start_date = effective_start_date
         @effective_end_date = effective_end_date
         @defence_organisation = defence_organisation
-        @url = "prosecutionCases/representationOrder"\
-                "/applications/#{court_application_id}"\
-                "/subject/#{subject_id}"\
-                "/offences/#{offence_id}"
+        @url = if offence_id
+                 "prosecutionCases/representationOrder"\
+                         "/applications/#{court_application_id}"\
+                         "/subject/#{subject_id}"\
+                         "/offences/#{offence_id}"
+               else
+                 "prosecutionCases/representationOrder"\
+                       "/applications/#{court_application_id}"
+               end
         @connection = connection
       end
 

--- a/app/services/court_application_laa_reference_unlinker.rb
+++ b/app/services/court_application_laa_reference_unlinker.rb
@@ -35,14 +35,18 @@ private
   end
 
   def update_offences_on_common_platform
-    offences.each { |offence| update_offence_on_common_platform!(offence) }
+    if court_application_summary.subject_summary.has_offences?
+      offences.each { |offence| update_laa_reference_on_common_platform!(offence) }
+    else
+      update_laa_reference_on_common_platform!
+    end
   end
 
-  def update_offence_on_common_platform!(offence)
+  def update_laa_reference_on_common_platform!(offence = nil)
     response = CommonPlatform::Api::RecordCourtApplicationLaaReference.call(
       application_id: court_application_summary.application_id,
       subject_id:,
-      offence_id: offence.offence_id,
+      offence_id: offence&.offence_id,
       status_code: "AP",
       application_reference: dummy_maat_reference,
       status_date: Time.zone.today.strftime("%Y-%m-%d"),

--- a/spec/models/hmcts_common_platform/subject_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/subject_summary_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe HmctsCommonPlatform::SubjectSummary, type: :model do
-  let(:subject_summary) { described_class.new(data) }
+  let(:subject_summary) { described_class.new(data, application_summary) }
   let(:data) { JSON.parse(file_fixture("subject_summary.json").read) }
+  let(:application_summary) do
+    instance_double(HmctsCommonPlatform::CourtApplicationSummary,
+                    application_id: "id", application_type: "type", received_date: "date", application_title: "title")
+  end
 
   it "generates a JSON representation of the data" do
     expect(subject_summary.to_json["proceedings_concluded"]).to be(true)
@@ -31,8 +35,13 @@ RSpec.describe HmctsCommonPlatform::SubjectSummary, type: :model do
   context "when there is no offence summary data" do
     before { data.delete("offenceSummary") }
 
-    it "returns an empty array" do
-      expect(subject_summary.to_json["offence_summary"]).to eq []
+    it "returns a single dummy offence" do
+      expect(subject_summary.to_json["offence_summary"].length).to eq 1
+      expect(subject_summary.offence_summary.first).to be_a(HmctsCommonPlatform::OffenceSummary)
+      expect(subject_summary.to_json["offence_summary"].first).to include(
+        "code" => "type",
+        "id" => "id",
+      )
     end
   end
 end

--- a/spec/models/maat_api/court_application_laa_reference_spec.rb
+++ b/spec/models/maat_api/court_application_laa_reference_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe MaatApi::CourtApplicationLaaReference, type: :model do
       forename: "Naida",
       nino: "JG101010A",
       surname: "Daniel",
-      offences: [],
     }
 
-    expect(laa_reference.defendant).to eql(expected)
+    expect(laa_reference.defendant).to include(expected)
+    expect(laa_reference.defendant[:offences]).to be_present
   end
 end

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
   end
 
-  context "when this is for a court application is present" do
+  context "when this is for a court application" do
     before do
       CourtApplication.create!(subject_id: defendant_id, body: { foo: :bar })
     end
@@ -77,6 +77,28 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
         .with(hash_including(application_reference: maat_reference,
                              subject_id: defendant_id,
                              defence_organisation: transformed_defence_organisation))
+
+      create_rep_order
+    end
+  end
+
+  context "when a dummy offence is being passed in" do
+    let(:court_application) { CourtApplication.create!(subject_id: defendant_id, body: { foo: :bar }) }
+    let(:offence_one) do
+      {
+        offence_id: court_application.id,
+        status_code: "AB",
+        status_date: "2020-10-12",
+        effective_start_date: "2020-10-12",
+        effective_end_date: "2020-11-12",
+      }
+    end
+
+    it "calls the CommonPlatform::Api::RecordCourtApplicationRepresentationOrder service without offence ID" do
+      expect(CommonPlatform::Api::RecordCourtApplicationRepresentationOrder)
+        .to receive(:call)
+        .once
+        .with(hash_not_including(:offence_id))
 
       create_rep_order
     end

--- a/spec/services/court_application_laa_reference_unlinker_spec.rb
+++ b/spec/services/court_application_laa_reference_unlinker_spec.rb
@@ -166,9 +166,9 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
       call_unlinker
     end
 
-    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service with dummy ID" do
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service with no offence ID" do
       expect(CommonPlatform::Api::RecordCourtApplicationLaaReference).to receive(:call).once.with(
-        hash_including(offence_id: application_id),
+        hash_including(offence_id: nil),
       )
       call_unlinker
     end

--- a/spec/services/court_application_laa_reference_unlinker_spec.rb
+++ b/spec/services/court_application_laa_reference_unlinker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
   end
 
   let(:subject_id) { "8cd0ba7e-df89-45a3-8c61-4008a2186d64" }
-  let(:application_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
+  let(:application_id) { "00004c9f-af9f-401a-b88b-78a4f0e08163" }
   let(:user_name) { "johnDoe" }
   let(:unlink_reason_code) { 1 }
   let(:unlink_other_reason_text) { "Wrong defendant" }
@@ -136,6 +136,40 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
 
     it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service multiple times" do
       expect(CommonPlatform::Api::RecordCourtApplicationLaaReference).to receive(:call).twice.with(hash_including(application_reference: "Z10000000"))
+      call_unlinker
+    end
+  end
+
+  context "with no offences" do
+    before do
+      court_application.body["subjectSummary"].delete("offenceSummary")
+      court_application.save!
+    end
+
+    it "calls the Sqs::MessagePublisher service once" do
+      message = {
+        defendantId: "8cd0ba7e-df89-45a3-8c61-4008a2186d64",
+        maatId: "101010",
+        userId: user_name,
+        reasonId: unlink_reason_code,
+        otherReasonText: unlink_other_reason_text,
+      }
+
+      expect(Sqs::MessagePublisher).to receive(:call)
+        .once
+        .with(
+          message:,
+          queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+          log_info: { maat_reference: message[:maatId] },
+        )
+
+      call_unlinker
+    end
+
+    it "calls the CommonPlatform::Api::RecordProsecutionCaseLaaReference service with dummy ID" do
+      expect(CommonPlatform::Api::RecordCourtApplicationLaaReference).to receive(:call).once.with(
+        hash_including(offence_id: application_id),
+      )
       call_unlinker
     end
   end

--- a/spec/services/court_application_maat_link_creator_spec.rb
+++ b/spec/services/court_application_maat_link_creator_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CourtApplicationMaatLinkCreator do
       call_link_creator
     end
 
-    it "calls the CommonPlatform::Api::RecordCourtApplicationLaaReference service with dummy offence ID" do
+    it "calls the CommonPlatform::Api::RecordCourtApplicationLaaReference service with no offence ID" do
       allow(CommonPlatform::Api::RecordCourtApplicationLaaReference)
         .to receive(:call)
         .and_return(response)
@@ -136,7 +136,7 @@ RSpec.describe CourtApplicationMaatLinkCreator do
       expect(CommonPlatform::Api::RecordCourtApplicationLaaReference)
         .to receive(:call)
         .once
-        .with(hash_including(offence_id: court_application_id))
+        .with(hash_including(offence_id: nil))
 
       call_link_creator
     end

--- a/spec/services/court_application_maat_link_creator_spec.rb
+++ b/spec/services/court_application_maat_link_creator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CourtApplicationMaatLinkCreator do
   let(:maat_reference) { 12_345_678 }
   let(:subject_id) { "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3" }
   let(:user_name) { "bob-smith" }
-  let(:court_application_id) { "7a0c947e-97b4-4c5a-ae6a-26320afc914d" }
+  let(:court_application_id) { "00004c9f-af9f-401a-b88b-78a4f0e08163" }
   let(:offence_id) { "f369a0f5-6faf-43f1-8725-fb79847107cc" }
   let(:laa_reference) { LaaReference.create!(defendant_id:, user_name: "caseWorker", maat_reference:) }
   let(:response) { OpenStruct.new("status" => 200, "success?" => true) }
@@ -107,6 +107,36 @@ RSpec.describe CourtApplicationMaatLinkCreator do
         .to receive(:call)
         .twice
         .with(hash_including(application_reference: "12345678"))
+
+      call_link_creator
+    end
+  end
+
+  context "with no offences" do
+    before do
+      court_application.body["subjectSummary"].delete("offenceSummary")
+      court_application.save!
+    end
+
+    it "calls the Sqs::MessagePublisher service once" do
+      allow(CommonPlatform::Api::RecordCourtApplicationLaaReference)
+        .to receive(:call)
+        .and_return(response)
+
+      expect(Sqs::MessagePublisher).to receive(:call).once
+
+      call_link_creator
+    end
+
+    it "calls the CommonPlatform::Api::RecordCourtApplicationLaaReference service with dummy offence ID" do
+      allow(CommonPlatform::Api::RecordCourtApplicationLaaReference)
+        .to receive(:call)
+        .and_return(response)
+
+      expect(CommonPlatform::Api::RecordCourtApplicationLaaReference)
+        .to receive(:call)
+        .once
+        .with(hash_including(offence_id: court_application_id))
 
       call_link_creator
     end


### PR DESCRIPTION
## What
When there are no offences, generate a dummy offence.
If linking and unlinking, use the dummy offence to construct calls to HMCTS

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-936)
[Link to story](https://dsdmoj.atlassian.net/browse/ACD-937)
