### PR TITLE
ACD-935: (Breaches/POCA) Add breach-specific details

### DIFF
--- a/app/models/hmcts_common_platform/hearing_resulted.rb
+++ b/app/models/hmcts_common_platform/hearing_resulted.rb
@@ -2,7 +2,7 @@ module HmctsCommonPlatform
   class HearingResulted
     attr_reader :data
 
-    delegate :blank?, to: :data
+    delegate :blank?, :present?, to: :data
 
     delegate :jurisdiction_type, :court_centre_id, :court_centre, :first_sitting_day_date, to: :hearing, prefix: true
 


### PR DESCRIPTION
## What
The "plea" for breaches/POCA is going to be available as a judicial result in the latest hearing payload, so we retrieve that and add it to the court application payload if this is a breach/POCA.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-935)
