### PR TITLE
ACD-969: Cope with a null applicationSummary

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -45,8 +45,8 @@ class ProsecutionCase < ApplicationRecord
   end
 
   def court_applications
-    body["applicationSummary"].select { ::CourtApplication::SUPPORTED_COURT_APPLICATION_TITLES.include?(it["applicationTitle"]) }
-                              .map { retrieve_full_court_application(it) }
+    (body["applicationSummary"] || []).select { ::CourtApplication::SUPPORTED_COURT_APPLICATION_TITLES.include?(it["applicationTitle"]) }
+                                      .map { retrieve_full_court_application(it) }
   end
 
 private


### PR DESCRIPTION
Sometimes applicationSummary is missing from the payload.