### PR TITLE
Change Common Platform endpoint to dev1

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
+++ b/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
@@ -16,7 +16,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-common_platform_url: https://apigw.dev.cjscp.org.uk/LAA/V04
+common_platform_url: https://apigw.dev.cjscp.org.uk/LAA/V1
 sqs_region: eu-west-2
 sqs_messaging_enabled: true
 maat_api:


### PR DESCRIPTION
This PR changes the Common Platform endpoint for CDA UAT to the HMCTS Dev1 endpoint for standalone application testing.