### PR TITLE
ACD-1375: add GET endpoint for XHIBIT migrated cases

### DIFF
--- a/app/controllers/api/internal/v2/migrated_cases_controller.rb
+++ b/app/controllers/api/internal/v2/migrated_cases_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module V2
+      class MigratedCasesController < ApplicationController
+        DEFAULT_PER_PAGE = 10
+        MAX_PER_PAGE = 100
+
+        # GET /api/internal/v2/link_migrated_cases
+        def index
+          migrated_cases = filtered_cases
+
+          results = paginate(migrated_cases.order(:created_at))
+
+          render json: {
+            total_results: migrated_cases.count,
+            page: current_page,
+            per_page: current_per_page,
+            results: results.as_json,
+          }
+        end
+
+      private
+
+        def filtered_cases
+          return XhibitMigratedCase.all if status_filter.blank?
+          return XhibitMigratedCase.none unless XhibitMigratedCase.statuses.key?(status_filter)
+
+          XhibitMigratedCase.where(status: status_filter)
+        end
+
+        def status_filter
+          params[:status].to_s
+        end
+
+        def paginate(scope)
+          scope.offset((current_page - 1) * current_per_page)
+               .limit(current_per_page)
+        end
+
+        def current_page
+          page_int = params[:page].to_i
+          page_int.positive? ? page_int : 1
+        end
+
+        def current_per_page
+          parsed_value = params[:per_page].to_i
+          if (1..MAX_PER_PAGE).cover?(parsed_value)
+            parsed_value
+          else
+            DEFAULT_PER_PAGE
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/v2/migrated_cases_controller.rb
+++ b/app/controllers/api/internal/v2/migrated_cases_controller.rb
@@ -6,12 +6,24 @@ module Api
       class MigratedCasesController < ApplicationController
         DEFAULT_PER_PAGE = 10
         MAX_PER_PAGE = 100
+        SORTABLE_FIELDS = {
+          "case_urn" => %w[case_urn],
+          "xhibit_case_number" => %w[xhibit_case_number],
+          "case_type" => %w[case_type],
+          "court_name" => %w[court_name],
+          "defendant_name" => %w[defendant_first_name defendant_last_name],
+          "created_at" => %w[created_at],
+          "maat_id" => %w[maat_id],
+          "linked_by" => %w[linked_by],
+          "status" => %w[status],
+        }.freeze
 
         # GET /api/internal/v2/link_migrated_cases
         def index
           migrated_cases = filtered_cases
+          ordered_cases = sorted_cases(migrated_cases)
 
-          results = paginate(migrated_cases.order(:created_at))
+          results = paginate(ordered_cases)
 
           render json: {
             total_results: migrated_cases.count,
@@ -32,6 +44,23 @@ module Api
 
         def status_filter
           params[:status].to_s
+        end
+
+        def sorted_cases(scope)
+          sort_by = params[:sort_by].presence || "created_at"
+          sort_direction = params[:sort_direction].to_s.downcase.presence || "asc"
+
+          unless SORTABLE_FIELDS.key?(sort_by) && %w[asc desc].include?(sort_direction)
+            sort_by = "created_at"
+            sort_direction = "asc"
+          end
+
+          order_columns = SORTABLE_FIELDS.fetch(sort_by) + %w[id]
+          order_direction = sort_direction.to_sym
+
+          order_columns.reduce(scope) do |relation, column|
+            relation.order(column => order_direction)
+          end
         end
 
         def paginate(scope)

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -1,5 +1,11 @@
 class XhibitMigratedCase < ApplicationRecord
   attribute :status, :string, default: "pending"
+  enum :status, {
+    pending: "pending",
+    auto_linked: "auto_linked",
+    manually_linked: "manually_linked",
+    action_required: "action_required",
+  }
 
   validates :case_urn, presence: true
   validates :xhibit_case_number, presence: true

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -7,7 +7,12 @@ class XhibitMigratedCase < ApplicationRecord
     action_required: "action_required",
   }
 
-  validates :case_urn, presence: true
+  validates :case_urn, presence: true, uniqueness: {
+    scope: %i[defendant_first_name defendant_last_name],
+    message: lambda { |object, _data|
+      "#{object.case_urn}, defendant: #{object.defendant_first_name} #{object.defendant_last_name} is already present"
+    },
+  }
   validates :xhibit_case_number, presence: true
   validates :court_name, presence: true
   validates :ou_code, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
       namespace :v2 do
         resources :court_applications, only: [:show]
+        resources :link_migrated_cases, only: [:index], controller: :migrated_cases
         resources :prosecution_cases, only: [:index], param: :reference do
           resources :defendants, only: %i[show] do
             member { get :offence_history }

--- a/db/migrate/20260424132600_add_unique_index_to_xhibit_migrated_cases.rb
+++ b/db/migrate/20260424132600_add_unique_index_to_xhibit_migrated_cases.rb
@@ -1,0 +1,22 @@
+class AddUniqueIndexToXhibitMigratedCases < ActiveRecord::Migration[8.0]
+  def up
+    execute(<<~SQL)
+      DELETE FROM xhibit_migrated_cases
+      WHERE id NOT IN (
+        SELECT DISTINCT ON (case_urn, defendant_first_name, defendant_last_name) id
+        FROM xhibit_migrated_cases
+        ORDER BY case_urn, defendant_first_name, defendant_last_name, created_at ASC
+      )
+    SQL
+
+    add_index :xhibit_migrated_cases,
+              %i[case_urn defendant_first_name defendant_last_name],
+              unique: true,
+              name: "idx_xhibit_migrated_cases_unique_case_defendant"
+  end
+
+  def down
+    remove_index :xhibit_migrated_cases,
+                 name: "idx_xhibit_migrated_cases_unique_case_defendant"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -453,6 +453,13 @@ CREATE INDEX idx_on_hearing_repull_batch_id_61b4f3e760 ON public.prosecution_cas
 
 
 --
+-- Name: idx_xhibit_migrated_cases_unique_case_defendant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_xhibit_migrated_cases_unique_case_defendant ON public.xhibit_migrated_cases USING btree (case_urn, defendant_first_name, defendant_last_name);
+
+
+--
 -- Name: index_case_defendant_offences_on_prosecution_case; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -611,6 +618,7 @@ ALTER TABLE ONLY public.oauth_access_grants
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424132600'),
 ('20260409121749'),
 ('20260401124945'),
 ('20251127093515'),

--- a/lib/tasks/xhibit_cases.rake
+++ b/lib/tasks/xhibit_cases.rake
@@ -12,7 +12,7 @@ namespace :xhibit_cases do
     results = ImportXhibitCases.call(file_path:)
 
     results[:errors].each do |row|
-      puts "[ERROR - #{Time.zone.now}] Line #{row[:line]} (case_urn: #{row[:case_urn]}): #{row[:messages].join(', ')}"
+      puts "[ERROR - #{Time.zone.now}] Line #{row[:line]}: #{row[:messages].join(', ')}"
     end
 
     puts "- - -"

--- a/spec/models/xhibit_migrated_case_spec.rb
+++ b/spec/models/xhibit_migrated_case_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe XhibitMigratedCase, type: :model do
+  subject(:migrated_case) { described_class.new(valid_attributes) }
+
+  let(:valid_attributes) do
+    {
+      case_urn: "20GD021701",
+      xhibit_case_number: "T202540001",
+      court_name: "Derby Justice Centre",
+      ou_code: "B30PI00",
+      case_type: "T",
+      case_sub_type: "Either way offence",
+      mode_of_trial: "Either way",
+      defendant_id: "defendant-1",
+      defendant_first_name: "John",
+      defendant_last_name: "Doe",
+      defendant_date_of_birth: Date.new(1987, 5, 21),
+      defendant_arrest_summons_number: "ASN001",
+    }
+  end
+
+  describe "validations" do
+    it {
+      expect(migrated_case).to validate_uniqueness_of(:case_urn)
+        .scoped_to(:defendant_first_name, :defendant_last_name)
+        .with_message("20GD021701, defendant: John Doe is already present")
+    }
+
+    context "when the same case_urn, defendant_first_name and defendant_last_name already exists" do
+      before { described_class.create!(valid_attributes) }
+
+      it "is invalid" do
+        expect(migrated_case).not_to be_valid
+        expect(migrated_case.errors[:case_urn]).to include("20GD021701, defendant: John Doe is already present")
+      end
+    end
+
+    context "when case_urn is different" do
+      before { described_class.create!(valid_attributes) }
+
+      it "is valid" do
+        expect(described_class.new(valid_attributes.merge(case_urn: "20GD021702"))).to be_valid
+      end
+    end
+
+    context "when defendant_first_name is different" do
+      before { described_class.create!(valid_attributes) }
+
+      it "is valid" do
+        expect(described_class.new(valid_attributes.merge(defendant_first_name: "Jane"))).to be_valid
+      end
+    end
+
+    context "when defendant_last_name is different" do
+      before { described_class.create!(valid_attributes) }
+
+      it "is valid" do
+        expect(described_class.new(valid_attributes.merge(defendant_last_name: "Smith"))).to be_valid
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/v2/migrated_cases_request_spec.rb
+++ b/spec/requests/api/internal/v2/migrated_cases_request_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/internal/v2/link_migrated_cases", swagger_doc: "v2/swagger.yaml", type: :request do
+  include AuthorisedRequestHelper
+
+  let(:token) { access_token }
+  let(:Authorization) { "Bearer #{token.token}" }
+
+  path "/api/internal/v2/link_migrated_cases" do
+    get("list migrated cases") do
+      description "List XHIBIT migrated cases with optional status filter and pagination"
+      tags "Internal - available to other LAA applications"
+      security [{ oAuth: [] }]
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :status, in: :query, required: false, type: :string,
+                schema: {
+                  type: :string,
+                  enum: %w[pending auto_linked manually_linked action_required],
+                },
+                description: "Filter records by status"
+
+      parameter name: :page, in: :query, required: false, type: :integer,
+                description: "Page number (default: 1)"
+
+      parameter name: :per_page, in: :query, required: false, type: :integer,
+                description: "Records per page (default: 10)"
+
+      parameter "$ref" => "#/components/parameters/transaction_id_header"
+
+      response(200, "Success with default pagination") do
+        before do
+          12.times { |index| create_migrated_case(status: "pending", suffix: index) }
+        end
+
+        run_test! do |http_response|
+          body = JSON.parse(http_response.body)
+
+          expect(body["total_results"]).to eq(12)
+          expect(body["page"]).to eq(1)
+          expect(body["per_page"]).to eq(10)
+          expect(body["results"].size).to eq(10)
+        end
+      end
+
+      response(200, "Success filtered by status") do
+        let(:status) { "pending" }
+
+        before do
+          3.times { |index| create_migrated_case(status: "pending", suffix: index) }
+          create_migrated_case(status: "auto_linked", suffix: 3)
+          create_migrated_case(status: "action_required", suffix: 4)
+        end
+
+        run_test! do |http_response|
+          body = JSON.parse(http_response.body)
+
+          expect(body["total_results"]).to eq(3)
+          expect(body["results"].size).to eq(3)
+          expect(body["results"].map { |record| record["status"] }.uniq).to eq(%w[pending])
+        end
+      end
+
+      response(200, "Success with custom page and per_page") do
+        let(:page) { 2 }
+        let(:per_page) { 7 }
+
+        before do
+          25.times { |index| create_migrated_case(status: "manually_linked", suffix: index) }
+        end
+
+        run_test! do |http_response|
+          body = JSON.parse(http_response.body)
+
+          expect(body["total_results"]).to eq(25)
+          expect(body["page"]).to eq(2)
+          expect(body["per_page"]).to eq(7)
+          expect(body["results"].size).to eq(7)
+        end
+      end
+
+      response(200, "When per_page is above 100, it defaults to 10") do
+        let(:per_page) { 101 }
+
+        before do
+          120.times { |index| create_migrated_case(status: "pending", suffix: index) }
+        end
+
+        run_test! do |http_response|
+          body = JSON.parse(http_response.body)
+
+          expect(body["total_results"]).to eq(120)
+          expect(body["per_page"]).to eq(10)
+          expect(body["results"].size).to eq(10)
+        end
+      end
+
+      response(200, "When per_page is below 1, it defaults to 10") do
+        let(:per_page) { 0 }
+
+        before do
+          12.times { |index| create_migrated_case(status: "pending", suffix: index) }
+        end
+
+        run_test! do |http_response|
+          body = JSON.parse(http_response.body)
+
+          expect(body["total_results"]).to eq(12)
+          expect(body["per_page"]).to eq(10)
+          expect(body["results"].size).to eq(10)
+        end
+      end
+
+      response(401, "Unauthorized") do
+        let(:Authorization) { nil }
+
+        run_test!
+      end
+    end
+  end
+
+  def create_migrated_case(status:, suffix:)
+    XhibitMigratedCase.create!(
+      case_urn: "20GD0217#{suffix}",
+      xhibit_case_number: "T20254#{suffix}",
+      court_name: "Derby Justice Centre",
+      ou_code: "B30PI00",
+      case_type: "T",
+      case_sub_type: "Either way offence",
+      mode_of_trial: "Either way",
+      defendant_id: "defendant-#{suffix}",
+      defendant_first_name: "John",
+      defendant_middle_name: nil,
+      defendant_last_name: "Doe#{suffix}",
+      defendant_date_of_birth: Date.new(1987, 5, 21),
+      defendant_arrest_summons_number: "ASN#{suffix}",
+      committal_date: nil,
+      sent_date: Date.new(2019, 10, 25),
+      status:,
+    )
+  end
+end

--- a/spec/requests/api/internal/v2/migrated_cases_request_spec.rb
+++ b/spec/requests/api/internal/v2/migrated_cases_request_spec.rb
@@ -29,6 +29,30 @@ RSpec.describe "api/internal/v2/link_migrated_cases", swagger_doc: "v2/swagger.y
       parameter name: :per_page, in: :query, required: false, type: :integer,
                 description: "Records per page (default: 10)"
 
+      parameter name: :sort_by, in: :query, required: false, type: :string,
+                schema: {
+                  type: :string,
+                  enum: %w[
+                    case_urn
+                    xhibit_case_number
+                    case_type
+                    court_name
+                    defendant_name
+                    created_at
+                    maat_id
+                    linked_by
+                    status
+                  ],
+                },
+                description: "Sort field"
+
+      parameter name: :sort_direction, in: :query, required: false, type: :string,
+                schema: {
+                  type: :string,
+                  enum: %w[asc desc],
+                },
+                description: "Sort direction"
+
       parameter "$ref" => "#/components/parameters/transaction_id_header"
 
       response(200, "Success with default pagination") do
@@ -122,24 +146,214 @@ RSpec.describe "api/internal/v2/link_migrated_cases", swagger_doc: "v2/swagger.y
     end
   end
 
-  def create_migrated_case(status:, suffix:)
+  describe "sorting behavior" do
+    let(:headers) { { "Authorization" => "Bearer #{token.token}" } }
+
+    sorting_cases = {
+      "case_urn" => { column: :case_urn, values: %w[URN-B URN-A URN-C] },
+      "xhibit_case_number" => { column: :xhibit_case_number, values: %w[T-300 T-100 T-200] },
+      "case_type" => { column: :case_type, values: %w[T A S] },
+      "court_name" => { column: :court_name, values: ["York Crown Court", "Bristol Crown Court", "Woolwich Crown Court"] },
+      "created_at" => {
+        column: :created_at,
+        values: [
+          Time.zone.parse("2024-01-03 09:00:00"),
+          Time.zone.parse("2024-01-01 09:00:00"),
+          Time.zone.parse("2024-01-02 09:00:00"),
+        ],
+      },
+      "maat_id" => { column: :maat_id, values: %w[300003 100001 200002] },
+      "linked_by" => { column: :linked_by, values: %w[user-z user-a user-m] },
+      "status" => { column: :status, values: %w[pending action_required auto_linked] },
+    }.freeze
+
+    sorting_cases.each do |sort_by, scenario|
+      it "sorts #{sort_by} ascending" do
+        records = scenario[:values].each_with_index.map do |value, index|
+          create_migrated_case(
+            status: "pending",
+            suffix: index,
+            case_urn: "CASE-#{sort_by}-#{index}",
+            xhibit_case_number: "XHIBIT-#{sort_by}-#{index}",
+            scenario[:column] => value,
+          )
+        end
+
+        request_sorted(sort_by:, sort_direction: "asc", headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(result_ids).to eq(expected_order(records, scenario[:column], "asc"))
+      end
+
+      it "sorts #{sort_by} descending" do
+        records = scenario[:values].each_with_index.map do |value, index|
+          create_migrated_case(
+            status: "pending",
+            suffix: index,
+            case_urn: "CASE-DESC-#{sort_by}-#{index}",
+            xhibit_case_number: "XHIBIT-DESC-#{sort_by}-#{index}",
+            scenario[:column] => value,
+          )
+        end
+
+        request_sorted(sort_by:, sort_direction: "desc", headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(result_ids).to eq(expected_order(records, scenario[:column], "desc"))
+      end
+    end
+
+    it "sorts defendant_name ascending by first name then last name" do
+      create_migrated_case(status: "pending", suffix: 1, defendant_first_name: "Alex", defendant_last_name: "Zulu")
+      create_migrated_case(status: "pending", suffix: 2, defendant_first_name: "Alex", defendant_last_name: "Alpha")
+      create_migrated_case(status: "pending", suffix: 3, defendant_first_name: "Ben", defendant_last_name: "Bravo")
+
+      request_sorted(sort_by: "defendant_name", sort_direction: "asc", headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(result_name_pairs).to eq(
+        [
+          %w[Alex Alpha],
+          %w[Alex Zulu],
+          %w[Ben Bravo],
+        ],
+      )
+    end
+
+    it "sorts defendant_name descending by first name then last name" do
+      create_migrated_case(status: "pending", suffix: 4, defendant_first_name: "Alex", defendant_last_name: "Zulu")
+      create_migrated_case(status: "pending", suffix: 5, defendant_first_name: "Alex", defendant_last_name: "Alpha")
+      create_migrated_case(status: "pending", suffix: 6, defendant_first_name: "Ben", defendant_last_name: "Bravo")
+
+      request_sorted(sort_by: "defendant_name", sort_direction: "desc", headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(result_name_pairs).to eq(
+        [
+          %w[Ben Bravo],
+          %w[Alex Zulu],
+          %w[Alex Alpha],
+        ],
+      )
+    end
+
+    it "falls back to created_at ascending when sort_by is invalid" do
+      early = create_migrated_case(status: "pending", suffix: 10, created_at: Time.zone.parse("2024-01-01 09:00:00"))
+      middle = create_migrated_case(status: "pending", suffix: 11, created_at: Time.zone.parse("2024-01-02 09:00:00"))
+      late = create_migrated_case(status: "pending", suffix: 12, created_at: Time.zone.parse("2024-01-03 09:00:00"))
+
+      request_sorted(sort_by: "unknown_field", sort_direction: "desc", headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(result_ids).to eq([early.id, middle.id, late.id])
+    end
+
+    it "falls back to created_at ascending when sort_direction is invalid" do
+      early = create_migrated_case(status: "pending", suffix: 13, created_at: Time.zone.parse("2024-01-01 09:00:00"))
+      middle = create_migrated_case(status: "pending", suffix: 14, created_at: Time.zone.parse("2024-01-02 09:00:00"))
+      late = create_migrated_case(status: "pending", suffix: 15, created_at: Time.zone.parse("2024-01-03 09:00:00"))
+
+      request_sorted(sort_by: "case_urn", sort_direction: "invalid", headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(result_ids).to eq([early.id, middle.id, late.id])
+    end
+
+    it "uses db default null ordering for maat_id" do
+      create_migrated_case(status: "pending", suffix: 16, maat_id: nil)
+      create_migrated_case(status: "pending", suffix: 17, maat_id: "200002")
+      create_migrated_case(status: "pending", suffix: 18, maat_id: "100001")
+
+      request_sorted(sort_by: "maat_id", sort_direction: "asc", headers:)
+      expect(result_field_values("maat_id")).to eq(["100001", "200002", nil])
+
+      request_sorted(sort_by: "maat_id", sort_direction: "desc", headers:)
+      expect(result_field_values("maat_id")).to eq([nil, "200002", "100001"])
+    end
+
+    it "uses db default null ordering for linked_by" do
+      create_migrated_case(status: "pending", suffix: 19, linked_by: nil)
+      create_migrated_case(status: "pending", suffix: 20, linked_by: "user-z")
+      create_migrated_case(status: "pending", suffix: 21, linked_by: "user-a")
+
+      request_sorted(sort_by: "linked_by", sort_direction: "asc", headers:)
+      expect(result_field_values("linked_by")).to eq(["user-a", "user-z", nil])
+
+      request_sorted(sort_by: "linked_by", sort_direction: "desc", headers:)
+      expect(result_field_values("linked_by")).to eq([nil, "user-z", "user-a"])
+    end
+
+    it "applies sorting before pagination" do
+      %w[D A C B].each_with_index do |case_urn, index|
+        create_migrated_case(status: "pending", suffix: 40 + index, case_urn:)
+      end
+      create_migrated_case(status: "auto_linked", suffix: 50, case_urn: "AA")
+
+      request_sorted(
+        sort_by: "case_urn",
+        sort_direction: "asc",
+        headers:,
+        params: {
+          status: "pending",
+          page: 2,
+          per_page: 2,
+        },
+      )
+
+      body = parsed_body
+
+      expect(response).to have_http_status(:ok)
+      expect(body["total_results"]).to eq(4)
+      expect(body["results"].map { |record| record["case_urn"] }).to eq(%w[C D])
+    end
+  end
+
+  def expected_order(records, column, direction)
+    ordered = records.sort_by { |record| [record.public_send(column), record.id] }
+    ordered = ordered.reverse if direction == "desc"
+    ordered.map(&:id)
+  end
+
+  def parsed_body
+    JSON.parse(response.body)
+  end
+
+  def result_ids
+    parsed_body.fetch("results").map { |record| record.fetch("id") }
+  end
+
+  def result_name_pairs
+    parsed_body.fetch("results").map { |record| [record["defendant_first_name"], record["defendant_last_name"]] }
+  end
+
+  def result_field_values(field)
+    parsed_body.fetch("results").map { |record| record[field] }
+  end
+
+  def request_sorted(sort_by:, sort_direction:, headers:, params: {})
+    get "/api/internal/v2/link_migrated_cases", params: params.merge(sort_by:, sort_direction:), headers:
+  end
+
+  def create_migrated_case(status:, suffix:, **overrides)
     XhibitMigratedCase.create!(
-      case_urn: "20GD0217#{suffix}",
-      xhibit_case_number: "T20254#{suffix}",
-      court_name: "Derby Justice Centre",
-      ou_code: "B30PI00",
-      case_type: "T",
-      case_sub_type: "Either way offence",
-      mode_of_trial: "Either way",
-      defendant_id: "defendant-#{suffix}",
-      defendant_first_name: "John",
-      defendant_middle_name: nil,
-      defendant_last_name: "Doe#{suffix}",
-      defendant_date_of_birth: Date.new(1987, 5, 21),
-      defendant_arrest_summons_number: "ASN#{suffix}",
-      committal_date: nil,
-      sent_date: Date.new(2019, 10, 25),
-      status:,
+      {
+        case_urn: "20GD0217#{suffix}",
+        xhibit_case_number: "T20254#{suffix}",
+        court_name: "Derby Justice Centre",
+        ou_code: "B30PI00",
+        case_type: "T",
+        case_sub_type: "Either way offence",
+        mode_of_trial: "Either way",
+        defendant_id: "defendant-#{suffix}",
+        defendant_first_name: "John",
+        defendant_middle_name: nil,
+        defendant_last_name: "Doe#{suffix}",
+        defendant_date_of_birth: Date.new(1987, 5, 21),
+        defendant_arrest_summons_number: "ASN#{suffix}",
+        committal_date: nil,
+        sent_date: Date.new(2019, 10, 25),
+        status:,
+      }.merge(overrides),
     )
   end
 end


### PR DESCRIPTION
## Summary

Exposes a new internal API endpoint that allows LAA applications to retrieve XHIBIT migrated cases, with support for status filtering and pagination. 
This enables VCD to query and display migrated cases.

- Added `GET /api/internal/v2/link_migrated_cases` endpoint with optional `status` query parameter (`pending`, `auto_linked`, `manually_linked`, `action_required`) and `page`/`per_page` pagination (default 10, max 100)
- Added `status` enum to `XhibitMigratedCase` model
- Added request spec covering default pagination, status filtering, custom pagination, boundary values, and 401 unauthorised