### PR TITLE
set ips.restrict to false in UAT

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
+++ b/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
@@ -126,7 +126,7 @@ affinity: {}
 
 ips:
   restrict: true
-  hmcts: "85.210.83.182,51.145.115.21"
+  hmcts: "85.210.83.182,51.145.115.21,51.140.138.86"
 
 featureFlags:
   breachCourtApplications: true


### PR DESCRIPTION
Disables IPS IP restriction in the UAT environment by setting `ips.restrict: false` in the UAT Helm values.

This allows UAT traffic to bypass the IP allowlist, enabling broader access for testing purposes.