### PR TITLE
Add new HMCTS IP addresses to UAT allowlist

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
+++ b/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
@@ -126,7 +126,7 @@ affinity: {}
 
 ips:
   restrict: true
-  hmcts: "85.210.83.182,51.145.115.21"
+  hmcts: "85.210.83.182,51.145.115.21,51.140.138.86,85.210.17.233"
 
 featureFlags:
   breachCourtApplications: true


### PR DESCRIPTION
## Summary

Adds two new HMCTS IP addresses (`51.140.138.86` and `85.210.17.233`) to the IP allowlist in the UAT environment, ensuring traffic from these endpoints is permitted through the IP restriction layer.