### PR TITLE
ACD-1304: handle civil case proceedings with unknown application type codes

### DIFF
--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -15,4 +15,8 @@ class CourtApplication < ApplicationRecord
 
     category == "appeal"
   end
+
+  def supported_category?
+    SupportedCourtApplicationTypes.get_category_by_code(body["applicationType"]).present?
+  end
 end

--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -16,6 +16,8 @@ class CourtApplication < ApplicationRecord
     category == "appeal"
   end
 
+  # Civil case proceedings (e.g. ASB injunctions, stalking protection orders) produce a nil
+  # category for now, as they are not yet mapped in supported_court_application_types.yaml.
   def supported_category?
     SupportedCourtApplicationTypes.get_category_by_code(body["applicationType"]).present?
   end

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -61,6 +61,8 @@ module HmctsCommonPlatform
       elsif application_category.in?(%w[breach poca])
         latest_hearing_judicial_results
       end
+      # TODO: Should judicial results be retrieved from hearings for civil case proceedings
+      # (nil category)? If so, the elsif above should include nil category or be removed entirely.
     end
 
     def subject_summary
@@ -75,10 +77,6 @@ module HmctsCommonPlatform
       # Warning: this `to_json` method doesn't return JSON, it returns a hash.
       # This is to be consistent with other models in this repo
       to_builder.attributes!
-    end
-
-    def category_supported?
-      true
     end
 
     def application_category

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -78,11 +78,7 @@ module HmctsCommonPlatform
     end
 
     def category_supported?
-      if ENV["BREACH_COURT_APPLICATIONS"] == "true"
-        application_category.present?
-      else
-        application_category == "appeal"
-      end
+      application_category.present?
     end
 
     def application_category

--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -78,7 +78,7 @@ module HmctsCommonPlatform
     end
 
     def category_supported?
-      application_category.present?
+      true
     end
 
     def application_category

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -46,7 +46,6 @@ class ProsecutionCase < ApplicationRecord
 
   def court_applications
     (body["applicationSummary"] || []).map { retrieve_full_court_application(it) }
-                                      .select(&:category_supported?)
   end
 
 private

--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -44,6 +44,8 @@ module CommonPlatform
       end
 
       def record_court_application_representation_order(court_application)
+        return unless court_application.supported_category?
+
         if court_application.appeal?
           offences.each do |offence|
             params = offence.merge(

--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -44,7 +44,7 @@ module CommonPlatform
       end
 
       def record_court_application_representation_order(court_application)
-        # Civil case proceedings produce a nil category for now — no RO is submitted in that case.
+        # Civil Case proceedings produce a nil category for now. No Representation Order is submitted in that case.
         return unless court_application.supported_category?
 
         if court_application.appeal?

--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -44,6 +44,7 @@ module CommonPlatform
       end
 
       def record_court_application_representation_order(court_application)
+        # Civil case proceedings produce a nil category for now — no RO is submitted in that case.
         return unless court_application.supported_category?
 
         if court_application.appeal?

--- a/app/services/supported_court_application_types.rb
+++ b/app/services/supported_court_application_types.rb
@@ -5,7 +5,9 @@ class SupportedCourtApplicationTypes
 
   class << self
     def get_by_code(code)
-      supported_types.find { |type| type["codes"].include?(code) }
+      result = supported_types.find { |type| type["codes"].include?(code) }
+      Rails.logger.warn("SupportedCourtApplicationTypes: unknown court application type code: #{code}") if result.nil? && code.present?
+      result
     end
 
     def get_category_by_code(code)

--- a/spec/models/court_application_spec.rb
+++ b/spec/models/court_application_spec.rb
@@ -14,4 +14,18 @@ RSpec.describe CourtApplication, type: :model do
 
     it { expect(court_application.appeal?).to be(false) }
   end
+
+  describe "#supported_category?" do
+    context "when the code maps to a known category" do
+      let(:application_type) { "MC80801" }
+
+      it { expect(court_application.supported_category?).to be(true) }
+    end
+
+    context "when the code produces a nil category" do
+      let(:application_type) { "AS14501" }
+
+      it { expect(court_application.supported_category?).to be(false) }
+    end
+  end
 end

--- a/spec/models/hmcts_common_platform/court_application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_summary_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
   it { expect(court_application_summary.application_title).to eql("Appeal against conviction by a Magistrates' Court to the Crown Court") }
   it { expect(court_application_summary.application_type).to eql("MC80802") }
   it { expect(court_application_summary.application_category).to eq("appeal") }
-  it { expect(court_application_summary.category_supported?).to be true }
   it { expect(court_application_summary.application_result).to eql("AACD") }
   it { expect(court_application_summary.received_date).to eql("2023-06-27") }
   it { expect(court_application_summary.short_id).to eql("A25ABCDE1234") }
@@ -47,22 +46,6 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
       expect(court_application_summary.to_json["hearing_summary"]).to be_a(Array)
       expect(court_application_summary.to_json["subject_summary"]).to be_a(Hash)
       expect(court_application_summary.to_json["judicial_results"]).to be_a(Array)
-    end
-  end
-
-  describe "#category_supported?" do
-    subject(:supported) { court_application_summary.category_supported? }
-
-    context "when type is breach" do
-      let(:data) { { "applicationType" => "SE20521" } }
-
-      it { is_expected.to be true }
-    end
-
-    context "when type is unknown" do
-      let(:data) { { "applicationType" => "UNKNOWN" } }
-
-      it { is_expected.to be true }
     end
   end
 

--- a/spec/models/hmcts_common_platform/court_application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_summary_spec.rb
@@ -56,19 +56,13 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
     context "when type is breach" do
       let(:data) { { "applicationType" => "SE20521" } }
 
-      context "when flag is switched off" do
-        it { is_expected.to be false }
-      end
+      it { is_expected.to be true }
+    end
 
-      context "when flag is switched on" do
-        around do |example|
-          ENV["BREACH_COURT_APPLICATIONS"] = "true"
-          example.run
-          ENV.delete("BREACH_COURT_APPLICATIONS")
-        end
+    context "when type is unknown" do
+      let(:data) { { "applicationType" => "UNKNOWN" } }
 
-        it { is_expected.to be true }
-      end
+      it { is_expected.to be false }
     end
   end
 

--- a/spec/models/hmcts_common_platform/court_application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_summary_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
     context "when type is unknown" do
       let(:data) { { "applicationType" => "UNKNOWN" } }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
   end
 

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
 
     context "when this is for a breach or poca application" do
-      let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
+      let(:application_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
 
       it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach service once" do
         expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach)
@@ -94,6 +94,17 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
           .once
           .with(hash_including(application_reference: maat_reference,
                                defence_organisation: transformed_defence_organisation))
+
+        create_rep_order
+      end
+    end
+
+    context "when the application category is nil" do
+      let(:application_type) { "AS14501" }
+
+      it "does not call any representation order endpoint" do
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal).not_to receive(:call)
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach).not_to receive(:call)
 
         create_rep_order
       end
@@ -115,7 +126,7 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       }
     end
 
-    let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
+    let(:application_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
 
     it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal service without offence ID" do
       expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach)


### PR DESCRIPTION
## Summary

Civil case proceedings use application type codes **not currently** mapped in CDA's `supported_court_application_types.yaml`. 

Previously, unknown codes were silently misprocessed. The most dangerous case being incorrect representation orders submitted to HMCTS.

This PR makes CDA behave safely and visibly when encountering unknown codes:

- Removes the `BREACH_COURT_APPLICATIONS` feature flag. Breach applications are always enabled
- Removes `category_supported?` filtering so all court applications are returned regardless of category, including those with nil category (civil proceedings). This makes the application visible on VCD  search.
- Guards representation order creation with `supported_category?` — no Represenation Order is submitted to HMCTS for unknown categories, **preventing silent misrouting to the breach endpoint**
- Adds a `TODO` comment on judicial results for civil proceedings pending business confirmation
- Adds a `Rails.logger.warn` in `SupportedCourtApplicationTypes` when an unknown code is encountered, making these cases immediately visible in logs