### PR TITLE
ACD-1351: Create errors CSV output for the import Xhibit

### DIFF
--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -7,8 +7,9 @@ class XhibitMigratedCase < ApplicationRecord
     action_required: "action_required",
   }
 
-  validates :case_urn, presence: true, uniqueness: {
+  validates :case_urn, uniqueness: {
     scope: %i[defendant_first_name defendant_last_name],
+    allow_nil: true,
     message: lambda { |object, _data|
       "#{object.case_urn}, defendant: #{object.defendant_first_name} #{object.defendant_last_name} is already present"
     },

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -11,15 +11,13 @@ class XhibitMigratedCase < ApplicationRecord
     scope: %i[defendant_first_name defendant_last_name],
     allow_nil: true,
     message: lambda { |object, _data|
-      "#{object.case_urn}, defendant: #{object.defendant_first_name} #{object.defendant_last_name} is already present"
+      "is invalid: URN #{object.case_urn} and Defendant #{object.defendant_first_name} #{object.defendant_last_name} is already present"
     },
   }
   validates :xhibit_case_number, presence: true
   validates :court_name, presence: true
   validates :ou_code, presence: true
   validates :case_type, presence: true
-  validates :case_sub_type, presence: true
-  validates :mode_of_trial, presence: true
   validates :defendant_id, presence: true
   validates :defendant_first_name, presence: true
   validates :defendant_last_name, presence: true

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -22,17 +22,24 @@ class XhibitMigratedCase < ApplicationRecord
   validates :defendant_id, presence: true
   validates :defendant_first_name, presence: true
   validates :defendant_last_name, presence: true
-  validates :defendant_arrest_summons_number, presence: true
 
-  validate :defendant_date_of_birth_format
+  validate :defendant_date_of_birth_format, if: -> { defendant_date_of_birth_before_type_cast.present? }
 
 private
 
+  # Date example: 2002-11-03
+  DATE_FORMAT_REGEX = /\A\d{4}-\d{2}-\d{2}\z/
+
   def defendant_date_of_birth_format
-    if defendant_date_of_birth_before_type_cast.blank?
-      errors.add(:defendant_date_of_birth, :blank)
-    elsif defendant_date_of_birth.nil?
+    raw = defendant_date_of_birth_before_type_cast
+    return if raw.is_a?(Date)
+
+    if raw.match?(DATE_FORMAT_REGEX)
+      Date.strptime(raw, "%Y-%m-%d")
+    else
       errors.add(:defendant_date_of_birth, "is invalid.")
     end
+  rescue Date::Error
+    errors.add(:defendant_date_of_birth, "is invalid.")
   end
 end

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -26,6 +26,7 @@ class XhibitMigratedCase < ApplicationRecord
   validate :defendant_date_of_birth_format, if: -> { defendant_date_of_birth_before_type_cast.present? }
   validate :committal_date_format, if: -> { committal_date_before_type_cast.present? }
   validate :sent_date_format, if: -> { sent_date_before_type_cast.present? }
+  validate :committal_or_sent_date_present
 
 private
 
@@ -42,6 +43,12 @@ private
 
   def defendant_date_of_birth_format
     validate_date_format(:defendant_date_of_birth, defendant_date_of_birth_before_type_cast)
+  end
+
+  def committal_or_sent_date_present
+    return if committal_date_before_type_cast.present? || sent_date_before_type_cast.present?
+
+    errors.add(:base, "Committal date or sent date must be present")
   end
 
   def validate_date_format(field, raw)

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -24,22 +24,35 @@ class XhibitMigratedCase < ApplicationRecord
   validates :defendant_last_name, presence: true
 
   validate :defendant_date_of_birth_format, if: -> { defendant_date_of_birth_before_type_cast.present? }
+  validate :committal_date_format, if: -> { committal_date_before_type_cast.present? }
+  validate :sent_date_format, if: -> { sent_date_before_type_cast.present? }
 
 private
 
   # Date example: 2002-11-03
   DATE_FORMAT_REGEX = /\A\d{4}-\d{2}-\d{2}\z/
 
+  def committal_date_format
+    validate_date_format(:committal_date, committal_date_before_type_cast)
+  end
+
+  def sent_date_format
+    validate_date_format(:sent_date, sent_date_before_type_cast)
+  end
+
   def defendant_date_of_birth_format
-    raw = defendant_date_of_birth_before_type_cast
+    validate_date_format(:defendant_date_of_birth, defendant_date_of_birth_before_type_cast)
+  end
+
+  def validate_date_format(field, raw)
     return if raw.is_a?(Date)
 
     if raw.match?(DATE_FORMAT_REGEX)
       Date.strptime(raw, "%Y-%m-%d")
     else
-      errors.add(:defendant_date_of_birth, "is invalid.")
+      errors.add(field, "is invalid. Expected format: YYYY-MM-DD")
     end
   rescue Date::Error
-    errors.add(:defendant_date_of_birth, "is invalid.")
+    errors.add(field, "is invalid. Expected format: YYYY-MM-DD")
   end
 end

--- a/app/services/import_xhibit_cases.rb
+++ b/app/services/import_xhibit_cases.rb
@@ -6,13 +6,13 @@ class ImportXhibitCases < ApplicationService
   end
 
   def call
-    results = { inserted: [], errors: [] }
-    CSV.foreach(file_path, headers: true).with_index(2) do |row, line|
+    results = { success_count: 0, errors: [] }
+    CSV.foreach(file_path, headers: true).with_index(2) do |row, line_number|
       xhibit_case = XhibitMigratedCase.create(row.to_h.transform_values(&:presence))
       if xhibit_case.persisted?
-        results[:inserted] << { line:, case_urn: xhibit_case.case_urn }
+        results[:success_count] += 1
       else
-        results[:errors] << { line:, case_urn: row["case_urn"], messages: xhibit_case.errors.full_messages }
+        results[:errors] << { line_number:, case_urn: row["case_urn"], row: row.to_h, messages: xhibit_case.errors.full_messages }
       end
     end
     results

--- a/lib/tasks/xhibit_cases.rake
+++ b/lib/tasks/xhibit_cases.rake
@@ -1,3 +1,5 @@
+require "csv"
+
 namespace :xhibit_cases do
   desc "Import XHIBIT cases from a CSV file. Example: rake xhibit_cases:import FILE_PATH=spec/fixtures/files/xhibit_cases_import.csv"
 
@@ -12,11 +14,23 @@ namespace :xhibit_cases do
     results = ImportXhibitCases.call(file_path:)
 
     results[:errors].each do |row|
-      puts "[ERROR - #{Time.zone.now}] Line #{row[:line]}: #{row[:messages].join(', ')}"
+      puts "[ERROR - #{Time.zone.now}] Line #{row[:line_number]}: #{row[:messages].join(', ')}"
+    end
+
+    errors_file = "/tmp/import-errors.csv"
+    input_headers = CSV.open(file_path, headers: true) { |csv| csv.first&.headers } || []
+
+    CSV.open(errors_file, "w") do |csv|
+      csv << input_headers + %w[errors]
+
+      results[:errors].each do |error|
+        csv << error[:row].values_at(*input_headers) + [error[:messages].join(" | ")]
+      end
     end
 
     puts "- - -"
 
-    puts "[INFO  - #{Time.zone.now}] Import completed — #{results[:inserted].count} inserted, #{results[:errors].count} error(s)."
+    puts "[INFO  - #{Time.zone.now}] Import completed — #{results[:success_count]} inserted, #{results[:errors].count} error(s)."
+    puts "[INFO  - #{Time.zone.now}] Error details written to #{errors_file}"
   end
 end

--- a/lib/tasks/xhibit_cases.rake
+++ b/lib/tasks/xhibit_cases.rake
@@ -17,7 +17,8 @@ namespace :xhibit_cases do
       puts "[ERROR - #{Time.zone.now}] Line #{row[:line_number]}: #{row[:messages].join(', ')}"
     end
 
-    errors_file = "/tmp/import-errors.csv"
+    timestamp = Time.zone.now.to_i
+    errors_file = "/tmp/import-errors-#{timestamp}.csv"
     input_headers = CSV.open(file_path, headers: true) { |csv| csv.first&.headers } || []
 
     CSV.open(errors_file, "w") do |csv|

--- a/spec/fixtures/files/xhibit_cases_import_with_errors.csv
+++ b/spec/fixtures/files/xhibit_cases_import_with_errors.csv
@@ -13,3 +13,5 @@ case_urn,xhibit_case_number,court_name,ou_code,case_type,case_sub_type,mode_of_t
 30GD0001008,T20260008,Derby Justice Centre,B30PI00,T,Either way offence,Either way,,Amy,,Winehouse,1990-01-08,ASN008,,2020-01-08
 30GD0001009,T20260009,,B30PI00,T,Either way offence,Either way,aaa00009-0000-0000-0000-000000000009,Elvis,,Presley,1990-01-09,ASN009,,2020-01-09
 30GD0001010,T20260010,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00010-0000-0000-0000-000000000010,Prince,,Rogers,1990-01-10,ASN010,,
+30GD0001011,T20260011,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00011-0000-0000-0000-000000000011,Diana,,Ross,1990-01-11,ASN011,25/01/2020,2020-01-25
+30GD0001012,T20260012,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00012-0000-0000-0000-000000000012,Stevie,,Wonder,1990-01-12,ASN012,2020-01-26,26/01/2020

--- a/spec/fixtures/files/xhibit_cases_import_with_errors.csv
+++ b/spec/fixtures/files/xhibit_cases_import_with_errors.csv
@@ -1,5 +1,5 @@
 case_urn,xhibit_case_number,court_name,ou_code,case_type,case_sub_type,mode_of_trial,defendant_id,defendant_first_name,defendant_middle_name,defendant_last_name,defendant_date_of_birth,defendant_arrest_summons_number,committal_date,sent_date
 ,T20254007,Derby Justice Centre,B30PI00,T,Either way offence,Either way,2b6fafcd-f204-4d97-8571-cd1c09f4c789,John,,Yundt,1987-05-21,XVITYX8RAIHZ,,2019-10-25
-29GD7216523,T20251234,Warrington Crown Court,B31BK00,S,Breach of community order,Summary,3a5e8721-b123-4c56-9012-ef3456789abc,Jammy,,,1990-01-01,TFL1,2021-03-15,
+29GD7216523,,Warrington Crown Court,B31BK00,S,Breach of community order,Summary,3a5e8721-b123-4c56-9012-ef3456789abc,Jammy,,,1990-01-01,TFL1,2021-03-15,
 20GD0217101,A20255678,Chelmsford Crown Court,B10JQ00,A,Crown Court appeal,Either way,7d9c2145-e678-4f12-8901-bc2345678def,Wallace,James,McClure,2002-10-10,B0000W4DP6,,2021-05-11
 20GD0217102,T20259999,Leeds Crown Court,B16HG00,T,Either way offence,Either way,4c8d3256-f789-4a23-9012-de4567890abc,Jane,,Smith,AA/BB/CCCC,ABC123,,2020-06-01

--- a/spec/fixtures/files/xhibit_cases_import_with_errors.csv
+++ b/spec/fixtures/files/xhibit_cases_import_with_errors.csv
@@ -3,3 +3,12 @@ case_urn,xhibit_case_number,court_name,ou_code,case_type,case_sub_type,mode_of_t
 29GD7216523,,Warrington Crown Court,B31BK00,S,Breach of community order,Summary,3a5e8721-b123-4c56-9012-ef3456789abc,Jammy,,,1990-01-01,TFL1,2021-03-15,
 20GD0217101,A20255678,Chelmsford Crown Court,B10JQ00,A,Crown Court appeal,Either way,7d9c2145-e678-4f12-8901-bc2345678def,Wallace,James,McClure,2002-10-10,B0000W4DP6,,2021-05-11
 20GD0217102,T20259999,Leeds Crown Court,B16HG00,T,Either way offence,Either way,4c8d3256-f789-4a23-9012-de4567890abc,Jane,,Smith,AA/BB/CCCC,ABC123,,2020-06-01
+30GD0001001,T20260001,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00001-0000-0000-0000-000000000001,,,Smith,1990-01-01,ASN001,,2020-01-01
+30GD0001002,T20260002,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00002-0000-0000-0000-000000000002,Jane,,,1990-01-02,ASN002,,2020-01-02
+30GD0001003,T20260003,Derby Justice Centre,,T,Either way offence,Either way,aaa00003-0000-0000-0000-000000000003,Jim,,Jones,1990-01-03,ASN003,,2020-01-03
+30GD0001004,T20260004,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00004-0000-0000-0000-000000000004,Bob,,Builder,1990-01-04,ASN004,,2020-01-04
+30GD0001005,T20260005,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00005-0000-0000-0000-000000000005,Mary,,Lamb,1990-01-05,ASN005,2020-01-05,
+30GD0001006,T20260006,Derby Justice Centre,B30PI00,T,,Either way,aaa00006-0000-0000-0000-000000000006,Tom,,Cat,1990-01-06,ASN006,,2020-01-06
+30GD0001007,T20260007,Derby Justice Centre,B30PI00,T,Either way offence,,aaa00007-0000-0000-0000-000000000007,Jerry,,Mouse,1990-01-07,ASN007,,2020-01-07
+30GD0001008,T20260008,Derby Justice Centre,B30PI00,T,Either way offence,Either way,,Amy,,Winehouse,1990-01-08,ASN008,,2020-01-08
+30GD0001009,T20260009,,B30PI00,T,Either way offence,Either way,aaa00009-0000-0000-0000-000000000009,Elvis,,Presley,1990-01-09,ASN009,,2020-01-09

--- a/spec/fixtures/files/xhibit_cases_import_with_errors.csv
+++ b/spec/fixtures/files/xhibit_cases_import_with_errors.csv
@@ -12,3 +12,4 @@ case_urn,xhibit_case_number,court_name,ou_code,case_type,case_sub_type,mode_of_t
 30GD0001007,T20260007,Derby Justice Centre,B30PI00,T,Either way offence,,aaa00007-0000-0000-0000-000000000007,Jerry,,Mouse,1990-01-07,ASN007,,2020-01-07
 30GD0001008,T20260008,Derby Justice Centre,B30PI00,T,Either way offence,Either way,,Amy,,Winehouse,1990-01-08,ASN008,,2020-01-08
 30GD0001009,T20260009,,B30PI00,T,Either way offence,Either way,aaa00009-0000-0000-0000-000000000009,Elvis,,Presley,1990-01-09,ASN009,,2020-01-09
+30GD0001010,T20260010,Derby Justice Centre,B30PI00,T,Either way offence,Either way,aaa00010-0000-0000-0000-000000000010,Prince,,Rogers,1990-01-10,ASN010,,

--- a/spec/models/xhibit_migrated_case_spec.rb
+++ b/spec/models/xhibit_migrated_case_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe XhibitMigratedCase, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:xhibit_case_number) }
     it { is_expected.to validate_presence_of(:case_type) }
-    it { is_expected.to validate_presence_of(:case_sub_type) }
-    it { is_expected.to validate_presence_of(:mode_of_trial) }
     it { is_expected.to validate_presence_of(:court_name) }
     it { is_expected.to validate_presence_of(:ou_code) }
     it { is_expected.to validate_presence_of(:defendant_id) }
@@ -37,7 +35,7 @@ RSpec.describe XhibitMigratedCase, type: :model do
     it {
       expect(migrated_case).to validate_uniqueness_of(:case_urn)
         .scoped_to(:defendant_first_name, :defendant_last_name)
-        .with_message("20GD021701, defendant: John Doe is already present")
+        .with_message("is invalid: URN 20GD021701 and Defendant John Doe is already present")
     }
 
     context "when the same case_urn, defendant_first_name and defendant_last_name already exists" do
@@ -45,7 +43,7 @@ RSpec.describe XhibitMigratedCase, type: :model do
 
       it "is invalid" do
         expect(migrated_case).not_to be_valid
-        expect(migrated_case.errors[:case_urn]).to include("20GD021701, defendant: John Doe is already present")
+        expect(migrated_case.errors[:case_urn]).to include("is invalid: URN 20GD021701 and Defendant John Doe is already present")
       end
     end
 

--- a/spec/models/xhibit_migrated_case_spec.rb
+++ b/spec/models/xhibit_migrated_case_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe XhibitMigratedCase, type: :model do
   end
 
   describe "validations" do
+    it { is_expected.to validate_presence_of(:xhibit_case_number) }
+    it { is_expected.to validate_presence_of(:case_type) }
+    it { is_expected.to validate_presence_of(:case_sub_type) }
+    it { is_expected.to validate_presence_of(:mode_of_trial) }
+    it { is_expected.to validate_presence_of(:court_name) }
+    it { is_expected.to validate_presence_of(:ou_code) }
+    it { is_expected.to validate_presence_of(:defendant_id) }
+    it { is_expected.to validate_presence_of(:defendant_first_name) }
+    it { is_expected.to validate_presence_of(:defendant_last_name) }
+
     it {
       expect(migrated_case).to validate_uniqueness_of(:case_urn)
         .scoped_to(:defendant_first_name, :defendant_last_name)
@@ -60,6 +70,14 @@ RSpec.describe XhibitMigratedCase, type: :model do
 
       it "is valid" do
         expect(described_class.new(valid_attributes.merge(defendant_last_name: "Smith"))).to be_valid
+      end
+    end
+
+    context "when case_urn is nil" do
+      before { described_class.create!(valid_attributes.merge(case_urn: nil, xhibit_case_number: "T202540002")) }
+
+      it "skips uniqueness check and is valid" do
+        expect(described_class.new(valid_attributes.merge(case_urn: nil))).to be_valid
       end
     end
   end

--- a/spec/models/xhibit_migrated_case_spec.rb
+++ b/spec/models/xhibit_migrated_case_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe XhibitMigratedCase, type: :model do
       defendant_last_name: "Doe",
       defendant_date_of_birth: Date.new(1987, 5, 21),
       defendant_arrest_summons_number: "ASN001",
+      sent_date: Date.new(2019, 10, 25),
     }
   end
 

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe ImportXhibitCases do
       expect(error).to include(line_number: 17, case_urn: "30GD0001012")
       expect(error[:messages]).to include("Sent date is invalid. Expected format: YYYY-MM-DD")
     end
+
+    it "reports missing committal and sent dates as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001010" }
+      expect(error).to include(line_number: 15, case_urn: "30GD0001010")
+      expect(error[:messages]).to include("Committal date or sent date must be present")
+    end
   end
 
   describe "mapped attributes" do

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ImportXhibitCases do
       )
       expect(date_error[:messages]).to include("Defendant date of birth is invalid. Expected format: YYYY-MM-DD")
     end
-
   end
 
   context "with missing required fields" do
@@ -51,19 +50,6 @@ RSpec.describe ImportXhibitCases do
       expect(error[:messages]).to include("Ou code can't be blank")
     end
 
-    it "reports a missing case sub-type as an error" do
-      result = import
-      error = result[:errors].find { |e| e[:case_urn] == "30GD0001006" }
-      expect(error).to include(line_number: 11, case_urn: "30GD0001006")
-      expect(error[:messages]).to include("Case sub type can't be blank")
-    end
-
-    it "reports a missing mode of trial as an error" do
-      result = import
-      error = result[:errors].find { |e| e[:case_urn] == "30GD0001007" }
-      expect(error).to include(line_number: 12, case_urn: "30GD0001007")
-      expect(error[:messages]).to include("Mode of trial can't be blank")
-    end
 
     it "reports a missing defendant ID as an error" do
       result = import

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe ImportXhibitCases do
       )
       expect(date_error[:messages]).to include("Defendant date of birth is invalid.")
     end
+    it "reports the row with no case URN as an error" do
+      result = import
+      urn_error = result[:errors].find { |e| e[:line_number] == 2 }
+      expect(urn_error).to include(
+        line_number: 2,
+        case_urn: nil,
+        row: hash_including("case_urn" => nil),
+      )
+      expect(urn_error[:messages]).to include("Case urn can't be blank")
+    end
   end
 
   describe "mapped attributes" do

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe ImportXhibitCases do
       expect(error).to include(line_number: 14, case_urn: "30GD0001009")
       expect(error[:messages]).to include("Court name can't be blank")
     end
+
+    it "reports when both committal and sent dates are missing" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001010" }
+      expect(error).to include(line_number: 15, case_urn: "30GD0001010")
+      expect(error[:messages]).to include("Committal date and sent date can't both be blank")
+    end
   end
 
   describe "mapped attributes" do

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ImportXhibitCases do
     expect { import }.to change(XhibitMigratedCase, :count).by(3)
   end
 
-  it "returns inserted and errors keys" do
-    expect(import).to match(inserted: Array, errors: Array)
+  it "returns success_count and errors keys" do
+    expect(import).to match(success_count: Integer, errors: Array)
   end
 
   context "with invalid defendant_date_of_birth format" do
@@ -17,7 +17,11 @@ RSpec.describe ImportXhibitCases do
     it "reports the row with invalid date as an error" do
       result = import
       date_error = result[:errors].find { |e| e[:case_urn] == "20GD0217102" }
-      expect(date_error).to include(line: 5, case_urn: "20GD0217102")
+      expect(date_error).to include(
+        line_number: 5,
+        case_urn: "20GD0217102",
+        row: hash_including("case_urn" => "20GD0217102"),
+      )
       expect(date_error[:messages]).to include("Defendant date of birth is invalid.")
     end
   end

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -36,6 +36,59 @@ RSpec.describe ImportXhibitCases do
     end
   end
 
+  context "with missing required fields" do
+    subject(:import) { described_class.call(file_path: file_fixture("xhibit_cases_import_with_errors.csv")) }
+
+    it "reports a missing defendant first name as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001001" }
+      expect(error).to include(line_number: 6, case_urn: "30GD0001001")
+      expect(error[:messages]).to include("Defendant first name can't be blank")
+    end
+
+    it "reports a missing defendant last name as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001002" }
+      expect(error).to include(line_number: 7, case_urn: "30GD0001002")
+      expect(error[:messages]).to include("Defendant last name can't be blank")
+    end
+
+    it "reports a missing OU code as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001003" }
+      expect(error).to include(line_number: 8, case_urn: "30GD0001003")
+      expect(error[:messages]).to include("Ou code can't be blank")
+    end
+
+    it "reports a missing case sub-type as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001006" }
+      expect(error).to include(line_number: 11, case_urn: "30GD0001006")
+      expect(error[:messages]).to include("Case sub type can't be blank")
+    end
+
+    it "reports a missing mode of trial as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001007" }
+      expect(error).to include(line_number: 12, case_urn: "30GD0001007")
+      expect(error[:messages]).to include("Mode of trial can't be blank")
+    end
+
+    it "reports a missing defendant ID as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001008" }
+      expect(error).to include(line_number: 13, case_urn: "30GD0001008")
+      expect(error[:messages]).to include("Defendant can't be blank")
+    end
+
+    it "reports a missing court name as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001009" }
+      expect(error).to include(line_number: 14, case_urn: "30GD0001009")
+      expect(error[:messages]).to include("Court name can't be blank")
+    end
+  end
+
   describe "mapped attributes" do
     before { import }
 

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -25,16 +25,6 @@ RSpec.describe ImportXhibitCases do
       expect(date_error[:messages]).to include("Defendant date of birth is invalid. Expected format: YYYY-MM-DD")
     end
 
-    it "reports the row with no case URN as an error" do
-      result = import
-      urn_error = result[:errors].find { |e| e[:line_number] == 2 }
-      expect(urn_error).to include(
-        line_number: 2,
-        case_urn: nil,
-        row: hash_including("case_urn" => nil),
-      )
-      expect(urn_error[:messages]).to include("Case urn can't be blank")
-    end
   end
 
   context "with missing required fields" do

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -1,21 +1,20 @@
 require "rails_helper"
 
 RSpec.describe ImportXhibitCases do
-  subject(:import) { described_class.call(file_path: file_fixture("xhibit_cases_import.csv")) }
+  subject(:result) { described_class.call(file_path: file_fixture("xhibit_cases_import.csv")) }
 
   it "imports all rows from the CSV" do
-    expect { import }.to change(XhibitMigratedCase, :count).by(3)
+    expect { result }.to change(XhibitMigratedCase, :count).by(3)
   end
 
   it "returns success_count and errors keys" do
-    expect(import).to match(success_count: Integer, errors: Array)
+    expect(result).to match(success_count: Integer, errors: Array)
   end
 
   context "with invalid defendant_date_of_birth format" do
-    subject(:import) { described_class.call(file_path: file_fixture("xhibit_cases_import_with_errors.csv")) }
+    subject(:result) { described_class.call(file_path: file_fixture("xhibit_cases_import_with_errors.csv")) }
 
     it "reports the row with invalid date as an error" do
-      result = import
       date_error = result[:errors].find { |e| e[:case_urn] == "20GD0217102" }
       expect(date_error).to include(
         line_number: 5,
@@ -27,60 +26,51 @@ RSpec.describe ImportXhibitCases do
   end
 
   context "with missing required fields" do
-    subject(:import) { described_class.call(file_path: file_fixture("xhibit_cases_import_with_errors.csv")) }
+    subject(:result) { described_class.call(file_path: file_fixture("xhibit_cases_import_with_errors.csv")) }
 
     it "reports a missing defendant first name as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001001" }
       expect(error).to include(line_number: 6, case_urn: "30GD0001001")
       expect(error[:messages]).to include("Defendant first name can't be blank")
     end
 
     it "reports a missing defendant last name as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001002" }
       expect(error).to include(line_number: 7, case_urn: "30GD0001002")
       expect(error[:messages]).to include("Defendant last name can't be blank")
     end
 
     it "reports a missing OU code as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001003" }
       expect(error).to include(line_number: 8, case_urn: "30GD0001003")
       expect(error[:messages]).to include("Ou code can't be blank")
     end
 
-
     it "reports a missing defendant ID as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001008" }
       expect(error).to include(line_number: 13, case_urn: "30GD0001008")
       expect(error[:messages]).to include("Defendant can't be blank")
     end
 
     it "reports a missing court name as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001009" }
       expect(error).to include(line_number: 14, case_urn: "30GD0001009")
       expect(error[:messages]).to include("Court name can't be blank")
     end
 
     it "reports an invalid committal date format as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001011" }
       expect(error).to include(line_number: 16, case_urn: "30GD0001011")
       expect(error[:messages]).to include("Committal date is invalid. Expected format: YYYY-MM-DD")
     end
 
     it "reports an invalid sent date format as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001012" }
       expect(error).to include(line_number: 17, case_urn: "30GD0001012")
       expect(error[:messages]).to include("Sent date is invalid. Expected format: YYYY-MM-DD")
     end
 
     it "reports missing committal and sent dates as an error" do
-      result = import
       error = result[:errors].find { |e| e[:case_urn] == "30GD0001010" }
       expect(error).to include(line_number: 15, case_urn: "30GD0001010")
       expect(error[:messages]).to include("Committal date or sent date must be present")
@@ -88,7 +78,9 @@ RSpec.describe ImportXhibitCases do
   end
 
   describe "mapped attributes" do
-    before { import }
+    before do
+      described_class.call(file_path: file_fixture("xhibit_cases_import.csv"))
+    end
 
     let(:first_case) { XhibitMigratedCase.find_by(case_urn: "20GD0217100") }
 

--- a/spec/services/import_xhibit_cases_spec.rb
+++ b/spec/services/import_xhibit_cases_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe ImportXhibitCases do
         case_urn: "20GD0217102",
         row: hash_including("case_urn" => "20GD0217102"),
       )
-      expect(date_error[:messages]).to include("Defendant date of birth is invalid.")
+      expect(date_error[:messages]).to include("Defendant date of birth is invalid. Expected format: YYYY-MM-DD")
     end
+
     it "reports the row with no case URN as an error" do
       result = import
       urn_error = result[:errors].find { |e| e[:line_number] == 2 }
@@ -88,11 +89,18 @@ RSpec.describe ImportXhibitCases do
       expect(error[:messages]).to include("Court name can't be blank")
     end
 
-    it "reports when both committal and sent dates are missing" do
+    it "reports an invalid committal date format as an error" do
       result = import
-      error = result[:errors].find { |e| e[:case_urn] == "30GD0001010" }
-      expect(error).to include(line_number: 15, case_urn: "30GD0001010")
-      expect(error[:messages]).to include("Committal date and sent date can't both be blank")
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001011" }
+      expect(error).to include(line_number: 16, case_urn: "30GD0001011")
+      expect(error[:messages]).to include("Committal date is invalid. Expected format: YYYY-MM-DD")
+    end
+
+    it "reports an invalid sent date format as an error" do
+      result = import
+      error = result[:errors].find { |e| e[:case_urn] == "30GD0001012" }
+      expect(error).to include(line_number: 17, case_urn: "30GD0001012")
+      expect(error[:messages]).to include("Sent date is invalid. Expected format: YYYY-MM-DD")
     end
   end
 


### PR DESCRIPTION
Improves the XHIBIT cases import task to write failed rows to a CSV errors file.

- Adds CSV errors file output (`/tmp/import-errors.csv`) with all failed rows and their validation messages
- Makes `defendant_date_of_birth` optional with strict `yyyy-mm-dd` format validation when present
- Removes mandatory `defendant_arrest_summons_number` presence validation