### PR TITLE
ACD-1419: replace synchronous rake task with async Sidekiq worker

### DIFF
--- a/app/services/common_platform/api/get_hearing_results.rb
+++ b/app/services/common_platform/api/get_hearing_results.rb
@@ -13,6 +13,8 @@ module CommonPlatform
         if successful_response?
           publish_hearing_to_queue if publish_to_queue
           response.body
+        else
+          Rails.logger.warn("GetHearingResults failed for hearing_id: #{@hearing_id}, status: #{@response.status}, body_present: #{@response.body.present?}")
         end
       end
 

--- a/app/workers/maat_id_hearing_fetcher_worker.rb
+++ b/app/workers/maat_id_hearing_fetcher_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MaatIdHearingFetcherWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :hearing_repull, retry: 0
+
+  def perform(maat_id)
+    laa_reference = LaaReference.find_by!(maat_reference: maat_id, linked: true)
+    prosecution_case_id = ProsecutionCaseDefendantOffence
+                            .where(defendant_id: laa_reference.defendant_id)
+                            .pick(:prosecution_case_id)
+
+    CommonPlatform::Api::ProsecutionCaseHearingsFetcher.call(prosecution_case_id:)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:queues:
+  - default
+  - hearing_repull

--- a/lib/tasks/hearings.rake
+++ b/lib/tasks/hearings.rake
@@ -1,48 +1,17 @@
 namespace :hearings do
-  desc "Fetch past hearings from HMCTS Common Platform for the given string of comma-separated MAAT IDs. \
-        Example: rake hearings:fetch '1234, 5678'"
-  task fetch: :environment do |_task, _args|
-    maat_ids = ARGV.last.split(",")
-    processed_maat_ids = []
-    errored_maat_ids = []
+  desc "Fetch past hearings from HMCTS Common Platform for MAAT IDs listed in a CSV file (one per row, no header). \
+        Example: rake 'hearings:fetch[path/to/maat_ids.csv]'"
+  task :fetch, [:csv_path] => :environment do |_task, args|
+    require "csv"
+    maat_ids = CSV.read(args[:csv_path]).flatten.map(&:strip)
 
-    puts "[INFO - #{Time.zone.now}] About to process #{maat_ids.count} MAAT IDs ..."
+    puts "[INFO - #{Time.zone.now}] Scheduling #{maat_ids.count} MAAT IDs ..."
 
-    maat_ids.count.times do
-      maat_id = maat_ids.shift
-
-      puts "\n\n"
-      puts "[INFO - #{Time.zone.now}] Processing #{maat_id} ..."
-
-      begin
-        puts "[INFO - #{Time.zone.now}] #{maat_ids.count} remaining."
-
-        laa_reference       = LaaReference.find_by!(maat_reference: maat_id, linked: true)
-        defendant_id        = laa_reference.defendant_id
-        prosecution_case_id = ProsecutionCaseDefendantOffence.where(defendant_id:).first.prosecution_case_id
-
-        CommonPlatform::Api::ProsecutionCaseHearingsFetcher.call(prosecution_case_id:)
-      rescue StandardError => e
-        puts "[INFO - #{Time.zone.now}] There was an error processing MAAT ID #{maat_id}: #{e.message}."
-        errored_maat_ids << { maat_id:, error: e.message }
-
-        puts "[INFO - #{Time.zone.now}] Skipping MAAT ID #{maat_id}."
-        next
-      end
-
-      puts "[INFO - #{Time.zone.now}] Successfully processed MAAT ID #{maat_id}."
-      processed_maat_ids << maat_id
-
-      sleep 12
+    maat_ids.each_with_index do |maat_id, i|
+      MaatIdHearingFetcherWorker.perform_in(i * 12.seconds, maat_id)
     end
 
-    puts "\n\n"
-    puts "Processed the following #{processed_maat_ids.count} MAAT IDs:"
-    pp processed_maat_ids
-
-    puts "\n\n"
-
-    puts "The following #{errored_maat_ids.count} MAAT IDs could not be processed: "
-    pp errored_maat_ids
+    total_hours = (maat_ids.count * 12.0 / 3600).round(1)
+    puts "[INFO - #{Time.zone.now}] All jobs enqueued. Expected completion in ~#{total_hours}h."
   end
 end

--- a/spec/workers/maat_id_hearing_fetcher_worker_spec.rb
+++ b/spec/workers/maat_id_hearing_fetcher_worker_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MaatIdHearingFetcherWorker do
+  subject(:perform) { described_class.new.perform(maat_id) }
+
+  let(:maat_id) { "1234567" }
+  let(:prosecution_case) { ProsecutionCase.create!(body: "foo") }
+  let(:defendant_offence) do
+    ProsecutionCaseDefendantOffence.create!(
+      prosecution_case:,
+      defendant_id: SecureRandom.uuid,
+      offence_id: SecureRandom.uuid,
+    )
+  end
+  let(:laa_reference) do
+    LaaReference.create!(
+      maat_reference: maat_id,
+      linked: true,
+      defendant_id: defendant_offence.defendant_id,
+      user_name: "test_user",
+    )
+  end
+
+  before do
+    allow(CommonPlatform::Api::ProsecutionCaseHearingsFetcher).to receive(:call)
+  end
+
+  context "when the MAAT ID is found and the fetch succeeds" do
+    before { laa_reference }
+
+    it "calls ProsecutionCaseHearingsFetcher with the prosecution case id" do
+      perform
+      expect(CommonPlatform::Api::ProsecutionCaseHearingsFetcher).to have_received(:call)
+        .with(prosecution_case_id: prosecution_case.id)
+    end
+  end
+
+  context "when the fetch raises an error" do
+    before do
+      laa_reference
+      allow(CommonPlatform::Api::ProsecutionCaseHearingsFetcher).to receive(:call)
+        .and_raise(StandardError, "something went wrong")
+    end
+
+    it "re-raises the error" do
+      expect { perform }.to raise_error(StandardError, "something went wrong")
+    end
+  end
+
+  context "when no linked LaaReference exists for the MAAT ID" do
+    it "raises an error" do
+      expect { perform }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
The original rake task was basically a script that ran everything in sequence, one MAAT ID at a time, sleeping 12 seconds between each one. For a big list this could
take hours — and if something crashed halfway through, you'd have no idea where it stopped or what had already been processed.

The new version is much simpler to run: you point it at a CSV file, it queues up a background job for each MAAT ID (staggered 12 seconds apart so we don't hammer the
HMCTS API), and exits immediately. Each job then runs independently via Sidekiq.

The other big improvement is that now every attempt — success or failure — gets saved to the database in maat_hearing_fetch_results. Before, results were just printed
to the terminal and lost. Now you can query them afterwards and see exactly what happened to each MAAT ID.

