### PR TITLE
ACD-1436: add canUpdateLaaStatus to SQS link message

### DIFF
--- a/app/models/maat_api/laa_reference_message.rb
+++ b/app/models/maat_api/laa_reference_message.rb
@@ -11,6 +11,7 @@ module MaatApi
         maatId: object.maat_reference,
         caseUrn: object.case_urn,
         asn: object.defendant_asn,
+        canUpdateLaaStatus: true,
         cjsAreaCode: object.cjs_area_code,
         createdUser: object.user_name,
         cjsLocation: object.cjs_location,

--- a/spec/services/prosecution_case_maat_link_creator_spec.rb
+++ b/spec/services/prosecution_case_maat_link_creator_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe ProsecutionCaseMaatLinkCreator do
         cjsAreaCode: "1",
         cjsLocation: "B01LY",
         createdUser: "bob-smith",
+        canUpdateLaaStatus: true,
       )
 
       expect(arg[:log_info]).to include(


### PR DESCRIPTION
Adds `canUpdateLaaStatus: true` to the SQS message published when a defendant is linked to a MAAT reference