### PR TITLE
ACD-1437: report non-2xx CP responses to Sentry

### DIFF
--- a/app/services/common_platform/api/errors/failed_dependency.rb
+++ b/app/services/common_platform/api/errors/failed_dependency.rb
@@ -1,4 +1,5 @@
 module CommonPlatform::Api::Errors
+  # Raises "Faraday::ConnectionFailed", which is when the TCP connection itself fails.
   class FailedDependency < StandardError
     def codes
       [:common_platform_connection_failed]

--- a/app/services/common_platform/api/errors/unsuccessful_http_response.rb
+++ b/app/services/common_platform/api/errors/unsuccessful_http_response.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CommonPlatform::Api::Errors
+  class UnsuccessfulHttpResponse < StandardError
+    # Common Platform was reached but returned a non-2xx HTTP status.
+    def initialize(service:, status:, body: nil)
+      super("#{service} failed with status #{status}: #{body}")
+    end
+  end
+end

--- a/app/services/common_platform/api/record_prosecution_case_representation_order.rb
+++ b/app/services/common_platform/api/record_prosecution_case_representation_order.rb
@@ -30,6 +30,7 @@ module CommonPlatform
 
       def call
         response = connection.post(url, request_body)
+        report_to_sentry(response) unless response.success?
         update_offence(response)
         response
       end
@@ -56,6 +57,21 @@ module CommonPlatform
           defence_organisation:,
           response_status: response.status,
           response_body: response.body,
+        )
+      end
+
+      def report_to_sentry(response)
+        Sentry.capture_exception(
+          CommonPlatform::Api::Errors::UnsuccessfulHttpResponse.new(
+            service: self.class.name,
+            status: response.status,
+            body: response.body,
+          ),
+          tags: { request_id: Current.request_id },
+          extra: {
+            defendant_id:,
+            offence_id:,
+          },
         )
       end
 

--- a/spec/services/common_platform/api/errors/unsuccessful_http_response_spec.rb
+++ b/spec/services/common_platform/api/errors/unsuccessful_http_response_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe CommonPlatform::Api::Errors::UnsuccessfulHttpResponse do
+  it "includes service, status and body in the message" do
+    error = described_class.new(
+      service: "MyService",
+      status: 401,
+      body: { "statusCode" => 401, "message" => "Access denied due to invalid subscription key. Make sure to provide a valid key for an active subscription." },
+    )
+    expect(error.message).to eq(
+      'MyService failed with status 401: {"statusCode" => 401, "message" => "Access denied due to invalid subscription key. Make sure to provide a valid key for an active subscription."}',
+    )
+  end
+end


### PR DESCRIPTION
Adds Sentry observability for failed representation order calls to Common Platform without halting execution.

When CP returns a non-2xx response, `RecordProsecutionCaseRepresentationOrder` now captures the error via `Sentry.capture_exception` using a new `CommonPlatform::Api::Errors::UnsuccessfulHttpResponse` error class, then continues to update the local DB record as before.