### PR TITLE
Add missing config for liveness and readiness checks

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/templates/deployment-api.yaml
+++ b/helm_deploy/laa-court-data-adaptor/templates/deployment-api.yaml
@@ -41,10 +41,16 @@ spec:
             httpGet:
               path: /status
               port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /status
               port: http
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+            periodSeconds: 10
           {{ include "laa-court-data-adaptor.env-vars" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This PR adds missing config for the liveness and readiness checks for CDA pods. Specifically, it adds an initial delay period for the liveness and readiness probes to `30` and `15s` respectively, the same as VCD. A timeout period is set for both checks to `10s`, moving away from the `1s` default which it is believed has been a recent contributing factor to an incident affecting CDA when the cluster restarted all CDA pods simultaneously. Finally the period is set to `10s`, again the same as VCD, meaning that it would take `30s` and three consecutive failed requests for the cluster to mark a pod as unhealthy.