### PR TITLE
ACD-1476: fix linking error when a hearing has no hearing days

### DIFF
--- a/app/models/hmcts_common_platform/court_application_summary.rb
+++ b/app/models/hmcts_common_platform/court_application_summary.rb
@@ -50,7 +50,7 @@ module HmctsCommonPlatform
     end
 
     def hearing_summary
-      data[:hearingSummary]&.map do |summary_object|
+      Array(data[:hearingSummary]).map do |summary_object|
         HmctsCommonPlatform::HearingSummary.new(summary_object)
       end
     end

--- a/app/models/maat_api/hearing_summary_selectable.rb
+++ b/app/models/maat_api/hearing_summary_selectable.rb
@@ -1,46 +1,28 @@
 module MaatApi
   module HearingSummarySelectable
-    extend ActiveSupport::Concern
+    # Selects which hearing's court centre is reported to MAAT
 
     def relevant_hearing_summary
-      return latest_hearing_summary if all_hearings_in_past?
-      return next_upcoming_hearing_summary if all_hearings_in_future?
+      return hearing_summaries.first if hearing_summaries_with_hearing_days.empty?
 
-      latest_of_past_hearing_summaries
+      most_recent_past_hearing_summary = past_hearing_summaries.max_by { |hs| sitting_days(hs) }
+      next_upcoming_hearing_summary = hearing_summaries_with_hearing_days.min_by { |hs| sitting_days(hs) }
+
+      most_recent_past_hearing_summary || next_upcoming_hearing_summary
     end
 
-    def latest_of_past_hearing_summaries
-      past_hearing_summaries.max_by { |hs| hs.hearing_days.map(&:sitting_day) }
-    end
-
-    def next_upcoming_hearing_summary
-      hearing_summaries_with_hearing_days.min_by { |hs| hs.hearing_days.map(&:sitting_day) }
-    end
-
-    def latest_hearing_summary
-      hearing_summaries_with_hearing_days.max_by { |hs| hs.hearing_days.map(&:sitting_day) }
-    end
+  private
 
     def past_hearing_summaries
-      hearing_summaries_with_hearing_days.select do |hs|
-        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
-      end
-    end
-
-    def all_hearings_in_past?
-      hearing_summaries_with_hearing_days.all? do |hs|
-        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.past?
-      end
-    end
-
-    def all_hearings_in_future?
-      hearing_summaries_with_hearing_days.all? do |hs|
-        hs.hearing_days.map(&:sitting_day).max&.to_datetime&.future?
-      end
+      hearing_summaries_with_hearing_days.select { |hs| sitting_days(hs).max&.to_datetime&.past? }
     end
 
     def hearing_summaries_with_hearing_days
       hearing_summaries.reject { |hs| hs.hearing_days.blank? }
+    end
+
+    def sitting_days(hearing_summary)
+      hearing_summary.hearing_days.map(&:sitting_day)
     end
   end
 end

--- a/spec/models/hmcts_common_platform/court_application_summary_spec.rb
+++ b/spec/models/hmcts_common_platform/court_application_summary_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe HmctsCommonPlatform::CourtApplicationSummary, type: :model do
   it { expect(court_application_summary.short_id).to eql("A25ABCDE1234") }
   it { expect(court_application_summary.case_summary.first).to be_a(HmctsCommonPlatform::CaseSummary) }
   it { expect(court_application_summary.hearing_summary.first).to be_a(HmctsCommonPlatform::HearingSummary) }
+
+  context "when the data has no hearingSummary" do
+    let(:data) do
+      JSON.parse(file_fixture("court_application_summary.json").read).except("hearingSummary")
+    end
+
+    it { expect(court_application_summary.hearing_summary).to eql([]) }
+  end
+
   it { expect(court_application_summary.subject_summary).to be_a(HmctsCommonPlatform::SubjectSummary) }
   it { expect(court_application_summary.judicial_results.first).to be_a(HmctsCommonPlatform::JudicialResult) }
 

--- a/spec/models/maat_api/court_application_laa_reference_spec.rb
+++ b/spec/models/maat_api/court_application_laa_reference_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe MaatApi::CourtApplicationLaaReference, type: :model do
     expect(laa_reference.defendant).to include(expected)
     expect(laa_reference.defendant[:offences]).to be_present
   end
+
+  context "when no hearing summary has hearing days" do
+    let(:data) do
+      JSON.parse(file_fixture("court_application_details/all_fields.json").read).tap do |details|
+        details["hearingSummary"] = [details["hearingSummary"].last.merge("hearingDays" => [])]
+      end
+    end
+
+    it "takes cjs_location from the only hearing summary" do
+      expect(laa_reference.cjs_location).to eql("B01LY")
+    end
+
+    it "takes cjs_area_code from the only hearing summary" do
+      expect(laa_reference.cjs_area_code).to eql("1")
+    end
+  end
 end

--- a/spec/models/maat_api/laa_reference_spec.rb
+++ b/spec/models/maat_api/laa_reference_spec.rb
@@ -121,4 +121,20 @@ RSpec.describe MaatApi::LaaReference, type: :model do
       end
     end
   end
+
+  context "when no hearing summary has hearing days" do
+    let(:prosecution_case_summary_data) do
+      JSON.parse(file_fixture("prosecution_case_summary/all_fields.json").read).tap do |data|
+        data["hearingSummary"] = [data["hearingSummary"].last.merge("hearingDays" => [])]
+      end
+    end
+
+    it "takes cjs_location from the only hearing summary" do
+      expect(laa_reference.cjs_location).to eql("C30DE")
+    end
+
+    it "takes cjs_area_code from the only hearing summary" do
+      expect(laa_reference.cjs_area_code).to eql("30")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Caseworkers linking a MAAT reference to a case whose hearing has no hearing days received a 500 error and the link failed. 
The hearing selection logic now falls back to the available hearing summary when none have hearing days, so the link succeeds and MAAT receives the correct court codes.

