### PR TITLE
ACD-1472: Improve Common Platform logging

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -90,7 +90,13 @@ private
       application_id: application_summary["applicationId"],
     )
 
-    raise CommonPlatform::Api::Errors::FailedDependency, "Error retrieving court application" unless response.success?
+    unless response.success?
+      raise CommonPlatform::Api::Errors::FailedDependency.from_response(
+        service: self.class.name,
+        response:,
+        context: "retrieving court application #{application_summary['applicationId']}",
+      )
+    end
 
     HmctsCommonPlatform::CourtApplicationSummary.new(response.body)
   end

--- a/app/services/common_platform/api/errors/failed_dependency.rb
+++ b/app/services/common_platform/api/errors/failed_dependency.rb
@@ -1,6 +1,19 @@
 module CommonPlatform::Api::Errors
-  # Raises "Faraday::ConnectionFailed", which is when the TCP connection itself fails.
+  # Raised when the call to Common Platform fails:
+  # - the TCP connection itself fails ("Faraday::ConnectionFailed")
+  # - Common Platform returns an unsuccessful HTTP response.
   class FailedDependency < StandardError
+    MAX_BODY_LENGTH = 500
+
+    def self.from_response(service:, response:, context: nil)
+      # In case of error, Common Platform API returns an HTML page.
+      body = ActionView::Base.full_sanitizer.sanitize(response.body.to_s).strip.truncate(MAX_BODY_LENGTH)
+      message = "#{service} - Unsuccessful response from Common Platform: status: #{response.status}, body: #{body}"
+      message += " (#{context})" if context
+
+      new(message)
+    end
+
     def codes
       [:common_platform_connection_failed]
     end

--- a/app/services/common_platform/api/search_prosecution_case.rb
+++ b/app/services/common_platform/api/search_prosecution_case.rb
@@ -3,8 +3,6 @@
 module CommonPlatform
   module Api
     class SearchProsecutionCase < ApplicationService
-      include ActionView::Helpers::SanitizeHelper
-
       def initialize(params)
         @response = ProsecutionCaseFetcher.call(**params)
         @blank_defendants = []
@@ -76,16 +74,11 @@ module CommonPlatform
 
       def check_response_status
         if response.status != 200
-          message = "Common Platform API status: #{response.status}, body: #{sanitized_response}"
-
-          raise CommonPlatform::Api::Errors::FailedDependency, message
+          raise CommonPlatform::Api::Errors::FailedDependency.from_response(
+            service: self.class.name,
+            response:,
+          )
         end
-      end
-
-      # In case of error, Common Platform API returns an HTML.
-      # This sanitizes the error message to log, to reduce HTML tag noise
-      def sanitized_response
-        strip_tags(response.body.to_s).strip
       end
 
       attr_reader :response

--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -14,12 +14,13 @@ module CommonPlatform
       @connection = Faraday.new HOST, options do |connection|
         connection.request :retry, retry_options
         connection.request :json
-        connection.response :logger, TaggedLogger, { headers: false } do |logger|
+        connection.response :logger, TaggedLogger, { headers: false, formatter: LogFormatter } do |logger|
           logger.filter(/(defendantName=)([^&]+)/, '\1[FILTERED]')
           logger.filter(/(defendantDOB=)([^&]+)/, '\1[FILTERED]')
           logger.filter(/(defendantNINO=)([^&]+)/, '\1[FILTERED]')
         end
         connection.use FailureMiddleware
+        connection.use ErrorLoggingMiddleware
         connection.response :json, content_type: "application/json"
         connection.response :json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json"
         connection.response :json, content_type: "text/plain"
@@ -38,11 +39,44 @@ module CommonPlatform
 
   private
 
+    # Prefixes the request/response log lines with "Common Platform"
+    class LogFormatter < Faraday::Logging::Formatter
+      def request(env)
+        public_send(log_level) do
+          "Common Platform request: #{env.method.to_s.upcase} #{apply_filters(env.url.to_s)}"
+        end
+      end
+
+      def response(env)
+        public_send(log_level) { "Common Platform response: Status #{env.status}" }
+      end
+    end
+
     class FailureMiddleware < Faraday::Middleware
       def call(env)
         @app.call(env)
       rescue Faraday::ConnectionFailed => e
         raise CommonPlatform::Api::Errors::FailedDependency, e
+      end
+    end
+
+    # Logs every unsuccessful Common Platform response, including the ones
+    # whose status is never checked by the calling service.
+    class ErrorLoggingMiddleware < Faraday::Middleware
+      MAX_BODY_LENGTH = 500
+      PII_QUERY_PARAMS_FILTER = /(defendantName|defendantDOB|defendantNINO)=[^&]+/
+
+      def on_complete(env)
+        return if env.status < 400
+
+        TaggedLogger.error(
+          "Common Platform request failed: #{env.method.to_s.upcase} #{filtered_url(env)} " \
+          "status: #{env.status}, body: #{env.body.to_s.truncate(MAX_BODY_LENGTH)}",
+        )
+      end
+
+      def filtered_url(env)
+        env.url.to_s.gsub(PII_QUERY_PARAMS_FILTER, '\1=[FILTERED]')
       end
     end
 

--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -20,7 +20,6 @@ module CommonPlatform
           logger.filter(/(defendantNINO=)([^&]+)/, '\1[FILTERED]')
         end
         connection.use FailureMiddleware
-        connection.use ErrorLoggingMiddleware
         connection.response :json, content_type: "application/json"
         connection.response :json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json"
         connection.response :json, content_type: "text/plain"
@@ -39,16 +38,28 @@ module CommonPlatform
 
   private
 
-    # Prefixes the request/response log lines with "Common Platform"
+    # All Common Platform logging lives here.
+    # A request and a response line (with duration) for every call.
     class LogFormatter < Faraday::Logging::Formatter
+      MAX_BODY_LENGTH = 500
+
       def request(env)
-        public_send(log_level) do
-          "Common Platform request: #{env.method.to_s.upcase} #{apply_filters(env.url.to_s)}"
-        end
+        env[:started_at] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        info { "Common Platform request: #{env.method.to_s.upcase} #{apply_filters(env.url.to_s)}" }
       end
 
       def response(env)
-        public_send(log_level) { "Common Platform response: Status #{env.status}" }
+        duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - env[:started_at]).round(3)
+
+        if env.status >= 400
+          error do
+            "Common Platform request failed: #{env.method.to_s.upcase} #{apply_filters(env.url.to_s)} " \
+            "status: #{env.status}, body: #{env.body.to_s.truncate(MAX_BODY_LENGTH)} (duration: #{duration}s)"
+          end
+        end
+
+        info { "Common Platform response: Status #{env.status} (duration: #{duration}s)" }
       end
     end
 
@@ -57,26 +68,6 @@ module CommonPlatform
         @app.call(env)
       rescue Faraday::ConnectionFailed => e
         raise CommonPlatform::Api::Errors::FailedDependency, e
-      end
-    end
-
-    # Logs every unsuccessful Common Platform response, including the ones
-    # whose status is never checked by the calling service.
-    class ErrorLoggingMiddleware < Faraday::Middleware
-      MAX_BODY_LENGTH = 500
-      PII_QUERY_PARAMS_FILTER = /(defendantName|defendantDOB|defendantNINO)=[^&]+/
-
-      def on_complete(env)
-        return if env.status < 400
-
-        TaggedLogger.error(
-          "Common Platform request failed: #{env.method.to_s.upcase} #{filtered_url(env)} " \
-          "status: #{env.status}, body: #{env.body.to_s.truncate(MAX_BODY_LENGTH)}",
-        )
-      end
-
-      def filtered_url(env)
-        env.url.to_s.gsub(PII_QUERY_PARAMS_FILTER, '\1=[FILTERED]')
       end
     end
 

--- a/app/services/court_application_laa_reference_unlinker.rb
+++ b/app/services/court_application_laa_reference_unlinker.rb
@@ -52,7 +52,13 @@ private
       status_date: Time.zone.today.strftime("%Y-%m-%d"),
     )
 
-    raise CommonPlatform::Api::Errors::FailedDependency, "Error posting LAA Reference to Common Platform" unless response.success?
+    unless response.success?
+      raise CommonPlatform::Api::Errors::FailedDependency.from_response(
+        service: self.class.name,
+        response:,
+        context: "unlinking LAA Reference for application #{court_application_summary.application_id}",
+      )
+    end
   end
 
   def offences

--- a/app/services/court_application_maat_link_creator.rb
+++ b/app/services/court_application_maat_link_creator.rb
@@ -55,7 +55,13 @@ private
       status_date: Time.zone.today.strftime("%Y-%m-%d"),
     )
 
-    raise CommonPlatform::Api::Errors::FailedDependency, "Error posting LAA Reference to Common Platform" unless response.success?
+    unless response.success?
+      raise CommonPlatform::Api::Errors::FailedDependency.from_response(
+        service: self.class.name,
+        response:,
+        context: "posting LAA Reference for application #{court_application_summary.application_id}",
+      )
+    end
   rescue StandardError => e
     record_and_reraise(e, offence)
   end

--- a/app/services/prosecution_case_maat_link_creator.rb
+++ b/app/services/prosecution_case_maat_link_creator.rb
@@ -66,7 +66,13 @@ private
       status_date: Time.zone.today.strftime("%Y-%m-%d"),
     )
 
-    raise CommonPlatform::Api::Errors::FailedDependency, "Error posting LAA Reference to Common Platform" unless response.success?
+    unless response.success?
+      raise CommonPlatform::Api::Errors::FailedDependency.from_response(
+        service: self.class.name,
+        response:,
+        context: "posting LAA Reference for offence #{offence.offence_id}",
+      )
+    end
   end
 
   def fetch_past_hearings

--- a/app/services/tagged_logger.rb
+++ b/app/services/tagged_logger.rb
@@ -1,28 +1,16 @@
 class TaggedLogger
   class << self
+    def debug(message = nil, &block) = log(:debug, message, &block)
+    def info(message = nil, &block)  = log(:info, message, &block)
+    def warn(message = nil, &block)  = log(:warn, message, &block)
+    def error(message = nil, &block) = log(:error, message, &block)
+    def fatal(message = nil, &block) = log(:fatal, message, &block)
+
   private
 
-    LOGGER_METHODS = %i[debug info warn error fatal].freeze
-
-    def method_missing(method, *args, &block)
-      if is_log_request?(method)
-        output = if args[0]
-                   args[0]
-                 elsif block_given?
-                   yield
-                 end
-        Rails.logger.public_send(method, "(Request ID: #{Current.request_id}) #{output}") if output
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method, *args)
-      is_log_request?(method) || super
-    end
-
-    def is_log_request?(method)
-      LOGGER_METHODS.include?(method)
+    def log(level, message)
+      output = message || (yield if block_given?)
+      Rails.logger.public_send(level, "(Request ID: #{Current.request_id}) #{output}") if output
     end
   end
 end

--- a/spec/services/common_platform/api/errors/failed_dependency_spec.rb
+++ b/spec/services/common_platform/api/errors/failed_dependency_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe CommonPlatform::Api::Errors::FailedDependency do
+  it "can be raised with a plain message" do
+    error = described_class.new("Common Platform connection failed")
+
+    expect(error.message).to eq("Common Platform connection failed")
+    expect(error.codes).to eq([:common_platform_connection_failed])
+  end
+
+  describe ".from_response" do
+    let(:response) { instance_double(Faraday::Response, status: 502, body: response_body) }
+    let(:response_body) { "Bad Gateway" }
+
+    it "includes the service name, status and body in the message" do
+      error = described_class.from_response(service: "MyService", response:)
+
+      expect(error).to be_a(described_class)
+      expect(error.message).to eq("MyService - Unsuccessful response from Common Platform: status: 502, body: Bad Gateway")
+    end
+
+    it "appends the context when provided" do
+      error = described_class.from_response(service: "MyService", response:, context: "posting LAA Reference")
+
+      expect(error.message).to end_with("status: 502, body: Bad Gateway (posting LAA Reference)")
+    end
+
+    context "when Common Platform responds with an HTML error page" do
+      let(:response_body) { "<html><body>Service unavailable</body></html>" }
+
+      it "strips the HTML tags from the body" do
+        error = described_class.from_response(service: "MyService", response:)
+
+        expect(error.message).to eq("MyService - Unsuccessful response from Common Platform: status: 502, body: Service unavailable")
+      end
+    end
+
+    context "when the body is very long" do
+      let(:response_body) { "a" * 600 }
+
+      it "truncates the body" do
+        error = described_class.from_response(service: "MyService", response:)
+
+        expect(error.message).to include("#{'a' * 497}...")
+        expect(error.message).not_to include("a" * 501)
+      end
+    end
+
+    context "when the body is nil" do
+      let(:response_body) { nil }
+
+      it "builds the message with an empty body" do
+        error = described_class.from_response(service: "MyService", response:)
+
+        expect(error.message).to eq("MyService - Unsuccessful response from Common Platform: status: 502, body: ")
+      end
+    end
+  end
+end

--- a/spec/services/common_platform/api/search_prosecution_case_spec.rb
+++ b/spec/services/common_platform/api/search_prosecution_case_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CommonPlatform::Api::SearchProsecutionCase do
     it "raises FailedDependency exception" do
       expect { search_prosecution_case }.to raise_error(
         CommonPlatform::Api::Errors::FailedDependency,
-        "Common Platform API status: 424, body: error message",
+        "CommonPlatform::Api::SearchProsecutionCase - Unsuccessful response from Common Platform: status: 424, body: error message",
       )
     end
   end

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe CommonPlatform::Connection do
       expect(connection).to receive(:request).with(:retry, retry_options)
       expect(connection).to receive(:request).with(:json)
       expect(connection).to receive(:use).with(CommonPlatform::Connection::FailureMiddleware)
-      expect(connection).to receive(:response).with(:logger, TaggedLogger, { headers: false })
+      expect(connection).to receive(:use).with(CommonPlatform::Connection::ErrorLoggingMiddleware)
+      expect(connection).to receive(:response).with(:logger, TaggedLogger, { headers: false, formatter: CommonPlatform::Connection::LogFormatter })
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
       expect(connection).to receive(:response).with(:json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json")
       expect(connection).to receive(:response).with(:json, content_type: "text/plain")
@@ -77,6 +78,72 @@ RSpec.describe CommonPlatform::Connection do
       })
 
       connect_to_common_platform
+    end
+  end
+
+  describe CommonPlatform::Connection::LogFormatter do
+    subject(:test_connection) do
+      Faraday.new("https://example.com") do |connection|
+        connection.response :logger, TaggedLogger, { headers: false, formatter: described_class } do |logger|
+          logger.filter(/(defendantName=)([^&]+)/, '\1[FILTERED]')
+        end
+        connection.adapter :test do |stub|
+          stub.get("/search?defendantName=John") { [200, {}, "all good"] }
+        end
+      end
+    end
+
+    it "logs the request and response with a Common Platform prefix, filtering PII" do
+      expect(TaggedLogger).to receive(:info) do |&block|
+        expect(block.call).to eq("Common Platform request: GET https://example.com/search?defendantName=[FILTERED]")
+      end
+      expect(TaggedLogger).to receive(:info) do |&block|
+        expect(block.call).to eq("Common Platform response: Status 200")
+      end
+
+      test_connection.get("/search?defendantName=John")
+    end
+  end
+
+  describe CommonPlatform::Connection::ErrorLoggingMiddleware do
+    subject(:test_connection) do
+      Faraday.new("https://example.com") do |connection|
+        connection.use described_class
+        connection.adapter :test do |stub|
+          stub.get("/success") { [200, {}, "all good"] }
+          stub.get("/failure") { [500, {}, "Internal Server Error"] }
+          stub.get("/failure-with-long-body") { [502, {}, "a" * 600] }
+          stub.get("/search?defendantName=John&defendantDOB=1990-01-01&defendantNINO=AB123456C&page=1") { [403, {}, "Forbidden"] }
+        end
+      end
+    end
+
+    it "does not log successful responses" do
+      expect(TaggedLogger).not_to receive(:error)
+
+      test_connection.get("/success")
+    end
+
+    it "logs the method, url, status and body of unsuccessful responses" do
+      expect(TaggedLogger).to receive(:error).with(
+        "Common Platform request failed: GET https://example.com/failure status: 500, body: Internal Server Error",
+      )
+
+      test_connection.get("/failure")
+    end
+
+    it "truncates long response bodies" do
+      expect(TaggedLogger).to receive(:error).with(/body: a{497}\.\.\.\z/)
+
+      test_connection.get("/failure-with-long-body")
+    end
+
+    it "filters defendant PII from the url" do
+      expect(TaggedLogger).to receive(:error).with(
+        "Common Platform request failed: GET https://example.com/search?defendantDOB=[FILTERED]&defendantNINO=[FILTERED]&defendantName=[FILTERED]&page=1 status: 403, body: Forbidden",
+      )
+
+      test_connection.get("/search?defendantName=John&defendantDOB=1990-01-01&defendantNINO=AB123456C&page=1")
     end
   end
 end

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe CommonPlatform::Connection do
       expect(connection).to receive(:request).with(:retry, retry_options)
       expect(connection).to receive(:request).with(:json)
       expect(connection).to receive(:use).with(CommonPlatform::Connection::FailureMiddleware)
-      expect(connection).to receive(:use).with(CommonPlatform::Connection::ErrorLoggingMiddleware)
       expect(connection).to receive(:response).with(:logger, TaggedLogger, { headers: false, formatter: CommonPlatform::Connection::LogFormatter })
       expect(connection).to receive(:response).with(:json, content_type: "application/json")
       expect(connection).to receive(:response).with(:json, content_type: "application/vnd.unifiedsearch.query.laa.cases+json")
@@ -89,61 +88,42 @@ RSpec.describe CommonPlatform::Connection do
         end
         connection.adapter :test do |stub|
           stub.get("/search?defendantName=John") { [200, {}, "all good"] }
+          stub.get("/failure?defendantName=John") { [500, {}, "Internal Server Error"] }
+          stub.get("/failure-with-long-body") { [502, {}, "a" * 600] }
         end
       end
     end
 
-    it "logs the request and response with a Common Platform prefix, filtering PII" do
+    it "logs the request and response with a Common Platform prefix and duration, filtering PII" do
+      expect(TaggedLogger).not_to receive(:error)
       expect(TaggedLogger).to receive(:info) do |&block|
         expect(block.call).to eq("Common Platform request: GET https://example.com/search?defendantName=[FILTERED]")
       end
       expect(TaggedLogger).to receive(:info) do |&block|
-        expect(block.call).to eq("Common Platform response: Status 200")
+        expect(block.call).to match(/\ACommon Platform response: Status 200 \(duration: \d+\.\d+s\)\z/)
       end
 
       test_connection.get("/search?defendantName=John")
     end
-  end
 
-  describe CommonPlatform::Connection::ErrorLoggingMiddleware do
-    subject(:test_connection) do
-      Faraday.new("https://example.com") do |connection|
-        connection.use described_class
-        connection.adapter :test do |stub|
-          stub.get("/success") { [200, {}, "all good"] }
-          stub.get("/failure") { [500, {}, "Internal Server Error"] }
-          stub.get("/failure-with-long-body") { [502, {}, "a" * 600] }
-          stub.get("/search?defendantName=John&defendantDOB=1990-01-01&defendantNINO=AB123456C&page=1") { [403, {}, "Forbidden"] }
-        end
+    it "logs an extra error line, with the response body, for unsuccessful responses" do
+      allow(TaggedLogger).to receive(:info)
+      expect(TaggedLogger).to receive(:error) do |&block|
+        expect(block.call).to match(
+          %r{\ACommon Platform request failed: GET https://example\.com/failure\?defendantName=\[FILTERED\] status: 500, body: Internal Server Error \(duration: \d+\.\d+s\)\z},
+        )
       end
-    end
 
-    it "does not log successful responses" do
-      expect(TaggedLogger).not_to receive(:error)
-
-      test_connection.get("/success")
-    end
-
-    it "logs the method, url, status and body of unsuccessful responses" do
-      expect(TaggedLogger).to receive(:error).with(
-        "Common Platform request failed: GET https://example.com/failure status: 500, body: Internal Server Error",
-      )
-
-      test_connection.get("/failure")
+      test_connection.get("/failure?defendantName=John")
     end
 
     it "truncates long response bodies" do
-      expect(TaggedLogger).to receive(:error).with(/body: a{497}\.\.\.\z/)
+      allow(TaggedLogger).to receive(:info)
+      expect(TaggedLogger).to receive(:error) do |&block|
+        expect(block.call).to match(/body: a{497}\.\.\. \(duration: /)
+      end
 
       test_connection.get("/failure-with-long-body")
-    end
-
-    it "filters defendant PII from the url" do
-      expect(TaggedLogger).to receive(:error).with(
-        "Common Platform request failed: GET https://example.com/search?defendantDOB=[FILTERED]&defendantNINO=[FILTERED]&defendantName=[FILTERED]&page=1 status: 403, body: Forbidden",
-      )
-
-      test_connection.get("/search?defendantName=John&defendantDOB=1990-01-01&defendantNINO=AB123456C&page=1")
     end
   end
 end

--- a/spec/services/court_application_laa_reference_unlinker_spec.rb
+++ b/spec/services/court_application_laa_reference_unlinker_spec.rb
@@ -195,7 +195,10 @@ RSpec.describe CourtApplicationLaaReferenceUnlinker do
     end
 
     it "raises an error" do
-      expect { call_unlinker }.to raise_error(StandardError, "Error posting LAA Reference to Common Platform")
+      expect { call_unlinker }.to raise_error(
+        CommonPlatform::Api::Errors::FailedDependency,
+        /CourtApplicationLaaReferenceUnlinker - Unsuccessful response from Common Platform: status: 500/,
+      )
     end
   end
 end

--- a/spec/services/court_application_maat_link_creator_spec.rb
+++ b/spec/services/court_application_maat_link_creator_spec.rb
@@ -227,7 +227,10 @@ RSpec.describe CourtApplicationMaatLinkCreator do
     end
 
     it "raises an error" do
-      expect { call_link_creator }.to raise_error "Error posting LAA Reference to Common Platform"
+      expect { call_link_creator }.to raise_error(
+        CommonPlatform::Api::Errors::FailedDependency,
+        /CourtApplicationMaatLinkCreator - Unsuccessful response from Common Platform: status: 500/,
+      )
     end
 
     it "reports to Sentry" do

--- a/spec/services/prosecution_case_maat_link_creator_spec.rb
+++ b/spec/services/prosecution_case_maat_link_creator_spec.rb
@@ -202,7 +202,10 @@ RSpec.describe ProsecutionCaseMaatLinkCreator do
     end
 
     it "raises an error" do
-      expect { create_maat_link }.to raise_error "Error posting LAA Reference to Common Platform"
+      expect { create_maat_link }.to raise_error(
+        CommonPlatform::Api::Errors::FailedDependency,
+        /ProsecutionCaseMaatLinkCreator - Unsuccessful response from Common Platform: status: 500/,
+      )
     end
 
     it "reports to Sentry" do


### PR DESCRIPTION
When a call to HMCTS Common Platform failed, CDA raised generic errors ("Error posting LAA Reference to Common Platform") and logged only the HTTP status, discarding what Common Platform actually said. 

Every Common Platform call is now clearly identifiable in the logs with its duration, and failures carry the full detail of the response.

