### PR TITLE
ACD-1480: Fix undefined defendant_id

### DIFF
--- a/app/services/common_platform/api/record_prosecution_case_representation_order.rb
+++ b/app/services/common_platform/api/record_prosecution_case_representation_order.rb
@@ -14,6 +14,7 @@ module CommonPlatform
                      effective_end_date: nil,
                      connection: CommonPlatform::Connection.instance.call)
         @case_defendant_offence = case_defendant_offence
+        @defendant_id = defendant_id
         @offence_id = offence_id
         @status_code = status_code
         @application_reference = application_reference.to_s
@@ -36,6 +37,8 @@ module CommonPlatform
       end
 
     private
+
+      attr_reader :url, :case_defendant_offence, :defendant_id, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
 
       def request_body
         {
@@ -74,8 +77,6 @@ module CommonPlatform
           },
         )
       end
-
-      attr_reader :url, :case_defendant_offence, :offence_id, :status_code, :application_reference, :status_date, :effective_start_date, :effective_end_date, :defence_organisation, :connection
     end
   end
 end

--- a/spec/services/common_platform/api/record_prosecution_case_representation_order_spec.rb
+++ b/spec/services/common_platform/api/record_prosecution_case_representation_order_spec.rb
@@ -76,4 +76,30 @@ RSpec.describe CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder do
     expect(case_defendant_offence.response_status).to eq(202)
     expect(case_defendant_offence.response_body).to eq({ "test" => "test" })
   end
+
+  context "when Common Platform returns an unsuccessful response" do
+    before do
+      allow(connection)
+        .to receive(:post)
+        .and_return(Faraday::Response.new(status: 400, body: { "error" => "Bad request" }))
+    end
+
+    it "reports the failure to Sentry with the defendant and offence ids" do
+      expect(Sentry).to receive(:capture_exception) do |error, options|
+        expect(error).to be_a(CommonPlatform::Api::Errors::UnsuccessfulHttpResponse)
+        expect(options[:extra]).to eq(defendant_id:, offence_id:)
+      end
+
+      record_representation_order
+    end
+
+    it "still updates the database record for the offence" do
+      allow(Sentry).to receive(:capture_exception)
+
+      record_representation_order
+      case_defendant_offence.reload
+      expect(case_defendant_offence.response_status).to eq(400)
+      expect(case_defendant_offence.response_body).to eq({ "error" => "Bad request" })
+    end
+  end
 end


### PR DESCRIPTION
When recording a representation order on Common Platform failed, reporting the error to Sentry crashed with an undefined `defendant_id`, masking the original failure.

The service now stores the defendant ID, so failures are reported to Sentry with the defendant and offence IDs.
