### PR TITLE
ACD-1481: Fix NoMethodError for rep orders with no dated offences

### DIFF
--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -27,6 +27,8 @@ module CommonPlatform
       end
 
       def call
+        return if offences.empty?
+
         call_common_platform_endpoint
       end
 

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
 
         create_rep_order
       end
+
+      context "when no offence has a status date" do
+        before { offence_one.delete(:status_date) }
+
+        it "does not call the CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach service" do
+          expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach).not_to receive(:call)
+
+          expect { create_rep_order }.not_to raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Sentry reported `NoMethodError: undefined method 'delete' for nil` in `RepresentationOrderCreator` when recording a representation order for a Breach/POCA court application.

With no granted representation order there is nothing to record on Common Platform, so the service now skips the call, matching the existing behaviour of the appeal and prosecution-case paths. 