### PR TITLE
Add the CP url to spot the URL involved in the slow responses.

### DIFF
--- a/app/services/common_platform/connection.rb
+++ b/app/services/common_platform/connection.rb
@@ -59,7 +59,10 @@ module CommonPlatform
           end
         end
 
-        info { "Common Platform response: Status #{env.status} (duration: #{duration}s)" }
+        info do
+          "Common Platform response: #{env.method.to_s.upcase} #{apply_filters(env.url.to_s)} " \
+          "status: #{env.status} (duration: #{duration}s)"
+        end
       end
     end
 

--- a/spec/services/common_platform/connection_spec.rb
+++ b/spec/services/common_platform/connection_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe CommonPlatform::Connection do
         expect(block.call).to eq("Common Platform request: GET https://example.com/search?defendantName=[FILTERED]")
       end
       expect(TaggedLogger).to receive(:info) do |&block|
-        expect(block.call).to match(/\ACommon Platform response: Status 200 \(duration: \d+\.\d+s\)\z/)
+        expect(block.call).to match(
+          %r{\ACommon Platform response: GET https://example\.com/search\?defendantName=\[FILTERED\] status: 200 \(duration: \d+\.\d+s\)\z},
+        )
       end
 
       test_connection.get("/search?defendantName=John")


### PR DESCRIPTION
## What
Add the CP url to spot the URL involved in the slow responses.
