### PR TITLE
ACD-1483: Report to Sentry when a defendant cannot be linked

### DIFF
--- a/app/services/prosecution_case_link_validator.rb
+++ b/app/services/prosecution_case_link_validator.rb
@@ -6,10 +6,14 @@ class ProsecutionCaseLinkValidator < ApplicationService
   end
 
   def call
-    prosecution_case&.hearing_summaries.present? || false
+    if @prosecution_case&.hearing_summaries.blank?
+      message = "#{self.class.name} - prosecution_case: #{@prosecution_case ? 'present' : 'nil'} - hearing_summaries: empty!"
+      Rails.logger.error(message)
+      Sentry.capture_message(message)
+
+      return false
+    end
+
+    true
   end
-
-private
-
-  attr_reader :prosecution_case
 end

--- a/spec/services/prosecution_case_link_validator_spec.rb
+++ b/spec/services/prosecution_case_link_validator_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ProsecutionCaseLinkValidator do
     expect(link_validator_response).to be true
   end
 
+  it "does not report to Sentry" do
+    expect(Sentry).not_to receive(:capture_message)
+
+    link_validator_response
+  end
+
   context "when the hearing summary does not exist" do
     before do
       prosecution_case.body.delete("hearingSummary")
@@ -30,6 +36,14 @@ RSpec.describe ProsecutionCaseLinkValidator do
 
     it "returns false" do
       expect(link_validator_response).to be false
+    end
+
+    it "reports to Sentry" do
+      expect(Sentry).to receive(:capture_message).with(
+        "ProsecutionCaseLinkValidator - prosecution_case: present - hearing_summaries: empty!",
+      )
+
+      link_validator_response
     end
   end
 
@@ -40,6 +54,14 @@ RSpec.describe ProsecutionCaseLinkValidator do
 
     it "returns false" do
       expect(link_validator_response).to be false
+    end
+
+    it "reports to Sentry" do
+      expect(Sentry).to receive(:capture_message).with(
+        "ProsecutionCaseLinkValidator - prosecution_case: nil - hearing_summaries: empty!",
+      )
+
+      link_validator_response
     end
   end
 end


### PR DESCRIPTION
When a caseworker tries to link a defendant to a MAAT ID, the request is rejected if
Common Platform has not provided any hearings for the case. 

These failures are now reported to Sentry and to the application log, making it possible to spot how often this happens and which cases are affected, and to raise the missing data with HMCTS.

No change to what is returned to the client: linking behaves exactly as before.
