### PR TITLE
(LAACONNNECT-1357) Implement auto linking scenario for unlinked maat application

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ RSpec/VariableName:
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/**/*.rb'
+
+Rails/Delegate:
+  Enabled: false

--- a/app/models/maat_api/court_application_laa_reference.rb
+++ b/app/models/maat_api/court_application_laa_reference.rb
@@ -7,10 +7,11 @@ module MaatApi
     delegate :subject_summary, :case_summary, to: :court_application_summary
     delegate :defendant_asn, to: :subject_summary
 
-    def initialize(user_name:, maat_reference:, court_application_summary:)
+    def initialize(user_name:, maat_reference:, court_application_summary:, can_update_laa_status: false)
       @maat_reference = maat_reference
       @user_name = user_name
       @court_application_summary = court_application_summary
+      @can_update_laa_status = can_update_laa_status
     end
 
     def case_urn
@@ -26,6 +27,10 @@ module MaatApi
       return true if case_summary.blank?
 
       case_summary.first.case_status == "ACTIVE"
+    end
+
+    def can_update_laa_status?
+      @can_update_laa_status
     end
 
     def cjs_location

--- a/app/models/maat_api/laa_reference.rb
+++ b/app/models/maat_api/laa_reference.rb
@@ -4,11 +4,12 @@ module MaatApi
 
     attr_reader :prosecution_case_summary, :defendant_summary, :user_name, :maat_reference
 
-    def initialize(prosecution_case_summary:, defendant_summary:, user_name:, maat_reference:)
+    def initialize(prosecution_case_summary:, defendant_summary:, user_name:, maat_reference:, can_update_laa_status: false)
       @prosecution_case_summary = prosecution_case_summary
       @maat_reference = maat_reference
       @defendant_summary = defendant_summary
       @user_name = user_name
+      @can_update_laa_status = can_update_laa_status
     end
 
     def case_urn
@@ -25,6 +26,10 @@ module MaatApi
 
     def is_active?
       prosecution_case_summary.case_status == "ACTIVE"
+    end
+
+    def can_update_laa_status?
+      @can_update_laa_status
     end
 
     def cjs_location

--- a/app/models/maat_api/laa_reference_message.rb
+++ b/app/models/maat_api/laa_reference_message.rb
@@ -16,6 +16,7 @@ module MaatApi
         cjsLocation: object.cjs_location,
         docLanguage: object.doc_language,
         isActive: object.is_active?,
+        canUpdateLaaStatus: object.can_update_laa_status?,
         defendant: object.defendant,
         sessions: object.sessions,
       }.compact

--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -16,11 +16,31 @@ module MaatApi
       response["maatId"]
     end
 
+    def no_existing_link?
+      !is_linked? && !libra_id && !case_urn
+    end
+
   private
 
     attr_reader :faraday_response
 
     def_delegators :faraday_response, :status, :success?
+
+    def libra_id
+      linking_detail["libraId"]
+    end
+
+    def case_urn
+      linking_detail["caseUrn"]
+    end
+
+    def is_linked?
+      response["isLinked"] == true
+    end
+
+    def linking_detail
+      response["linkingDetail"] || {}
+    end
 
     # Return the first item in the array by default, as this is the happy path
     # going forward, we'll handle the case of multiple results

--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -1,11 +1,19 @@
 module MaatApi
   class SearchResponse
-    extend Forwardable
-
-    def_delegator :faraday_response, :body
-
     def initialize(faraday_response)
       @faraday_response = faraday_response
+    end
+
+    def body
+      faraday_response.body
+    end
+
+    def status
+      faraday_response.status
+    end
+
+    def success?
+      faraday_response.success?
     end
 
     def not_found?
@@ -23,8 +31,6 @@ module MaatApi
   private
 
     attr_reader :faraday_response
-
-    def_delegators :faraday_response, :status, :success?
 
     def libra_id
       linking_detail["libraId"]

--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -1,19 +1,19 @@
 module MaatApi
   class SearchResponse
-    def initialize(faraday_response)
-      @faraday_response = faraday_response
+    def initialize(http_response)
+      @http_response = http_response
     end
 
     def body
-      faraday_response.body
+      http_response.body
     end
 
     def status
-      faraday_response.status
+      http_response.status
     end
 
     def success?
-      faraday_response.success?
+      http_response.success?
     end
 
     def not_found?
@@ -30,7 +30,7 @@ module MaatApi
 
   private
 
-    attr_reader :faraday_response
+    attr_reader :http_response
 
     def libra_id
       linking_detail["libraId"]
@@ -51,7 +51,7 @@ module MaatApi
     # Return the first item in the array by default, as this is the happy path
     # going forward, we'll handle the case of multiple results
     def response
-      faraday_response&.body&.first || {}
+      http_response&.body&.first || {}
     end
   end
 end

--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -12,10 +12,20 @@ module MaatApi
       status == 404
     end
 
+    def maat_id
+      response["maatId"]
+    end
+
   private
 
     attr_reader :faraday_response
 
     def_delegators :faraday_response, :status, :success?
+
+    # Return the first item in the array by default, as this is the happy path
+    # going forward, we'll handle the case of multiple results
+    def response
+      faraday_response&.body&.first || {}
+    end
   end
 end

--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -1,0 +1,21 @@
+module MaatApi
+  class SearchResponse
+    extend Forwardable
+
+    def_delegator :faraday_response, :body
+
+    def initialize(faraday_response)
+      @faraday_response = faraday_response
+    end
+
+    def not_found?
+      status == 404
+    end
+
+  private
+
+    attr_reader :faraday_response
+
+    def_delegators :faraday_response, :status, :success?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  SYSTEM_USERNAME = "SYSTEM"
+
   has_secure_password :auth_token
 
   validates :name, presence: true

--- a/app/models/xhibit_migrated_case.rb
+++ b/app/models/xhibit_migrated_case.rb
@@ -21,7 +21,7 @@ class XhibitMigratedCase < ApplicationRecord
   validates :defendant_id, presence: true
   validates :defendant_first_name, presence: true
   validates :defendant_last_name, presence: true
-  validates :maat_id, :linked_at, :linked_by, presence: true, if: -> { manually_linked? }
+  validates :maat_id, :linked_at, :linked_by, presence: true, if: -> { manually_linked? || auto_linked? }
 
   validate :defendant_date_of_birth_format, if: -> { defendant_date_of_birth_before_type_cast.present? }
   validate :committal_date_format, if: -> { committal_date_before_type_cast.present? }

--- a/app/services/court_application_maat_link_creator.rb
+++ b/app/services/court_application_maat_link_creator.rb
@@ -1,13 +1,14 @@
 class CourtApplicationMaatLinkCreator < ApplicationService
   attr_reader :laa_reference, :subject_id
 
-  def initialize(subject_id, user_name, maat_reference)
+  def initialize(subject_id, user_name, maat_reference, can_update_laa_status: false)
     @laa_reference = LaaReference.new(
       defendant_id: subject_id,
       user_name:,
       maat_reference: maat_reference.presence || LaaReference.generate_linking_dummy_maat_reference,
     )
     @subject_id = subject_id
+    @can_update_laa_status = can_update_laa_status
   end
 
   def call
@@ -26,6 +27,7 @@ private
       maat_reference: laa_reference.maat_reference,
       user_name: laa_reference.user_name,
       court_application_summary:,
+      can_update_laa_status: @can_update_laa_status,
     )
 
     Sqs::MessagePublisher.call(

--- a/app/services/link_xhibit_case.rb
+++ b/app/services/link_xhibit_case.rb
@@ -1,0 +1,27 @@
+class LinkXhibitCase < ApplicationService
+  class LinkFailure < StandardError; end
+
+  def call(maat_search_response, xhibit_case)
+    create_maat_link!(xhibit_case.defendant_id, maat_search_response.maat_id)
+    update_xhibit_case!(xhibit_case, maat_search_response.maat_id)
+  end
+
+private
+
+  def create_maat_link!(defendant_id, maat_id)
+    CourtApplicationMaatLinkCreator.call(
+      defendant_id,
+      "SYSTEM",
+      maat_id,
+    )
+  end
+
+  def update_xhibit_case!(xhibit_case, maat_id)
+    xhibit_case.update!(
+      maat_id: maat_id,
+      status: :auto_linked,
+      linked_at: Time.zone.now,
+      linked_by: "SYSTEM",
+    )
+  end
+end

--- a/app/services/link_xhibit_case.rb
+++ b/app/services/link_xhibit_case.rb
@@ -1,27 +1,43 @@
 class LinkXhibitCase < ApplicationService
-  class LinkFailure < StandardError; end
+  TRIAL = "T".freeze
+  SENTENCE = "S".freeze
+  APPEAL = "A".freeze
+  USER_NAME = "SYSTEM".freeze
 
-  def call(maat_search_response, xhibit_case)
-    create_maat_link!(xhibit_case.defendant_id, maat_search_response.maat_id)
-    update_xhibit_case!(xhibit_case, maat_search_response.maat_id)
+  def initialize(maat_search_response, xhibit_case, court_data)
+    @maat_search_response = maat_search_response
+    @xhibit_case = xhibit_case
+    @court_data = court_data
+  end
+
+  def call
+    case xhibit_case.case_type
+    when TRIAL
+      ProsecutionCaseMaatLinkCreator.call(court_data.defendant_id, USER_NAME, maat_id)
+    when SENTENCE, APPEAL
+      CourtApplicationMaatLinkCreator.call(subject_id, USER_NAME, maat_id)
+    else
+      raise ArgumentError, "Unsupported case type: #{xhibit_case.case_type.inspect}"
+    end
+
+    xhibit_case.update!(
+      maat_id:,
+      status: :auto_linked,
+      linked_at: Time.zone.now,
+      linked_by: USER_NAME,
+    )
   end
 
 private
 
-  def create_maat_link!(defendant_id, maat_id)
-    CourtApplicationMaatLinkCreator.call(
-      defendant_id,
-      "SYSTEM",
-      maat_id,
-    )
+  attr_reader :maat_search_response, :xhibit_case, :court_data
+
+  def subject_id
+    court_data.application_summaries.first&.subject_summary&.subject_id ||
+      raise(ArgumentError, "No court application found for defendant #{court_data.defendant_id}")
   end
 
-  def update_xhibit_case!(xhibit_case, maat_id)
-    xhibit_case.update!(
-      maat_id: maat_id,
-      status: :auto_linked,
-      linked_at: Time.zone.now,
-      linked_by: "SYSTEM",
-    )
+  def maat_id
+    maat_search_response.maat_id
   end
 end

--- a/app/services/link_xhibit_case.rb
+++ b/app/services/link_xhibit_case.rb
@@ -2,7 +2,6 @@ class LinkXhibitCase < ApplicationService
   TRIAL = "T".freeze
   SENTENCE = "S".freeze
   APPEAL = "A".freeze
-  USER_NAME = "SYSTEM".freeze
 
   def initialize(maat_search_response, xhibit_case, court_data)
     @maat_search_response = maat_search_response
@@ -13,9 +12,9 @@ class LinkXhibitCase < ApplicationService
   def call
     case xhibit_case.case_type
     when TRIAL
-      ProsecutionCaseMaatLinkCreator.call(court_data.defendant_id, USER_NAME, maat_id)
+      ProsecutionCaseMaatLinkCreator.call(court_data.defendant_id, User::SYSTEM_USERNAME, maat_id, can_update_laa_status: true)
     when SENTENCE, APPEAL
-      CourtApplicationMaatLinkCreator.call(subject_id, USER_NAME, maat_id)
+      CourtApplicationMaatLinkCreator.call(subject_id, User::SYSTEM_USERNAME, maat_id, can_update_laa_status: true)
     else
       raise ArgumentError, "Unsupported case type: #{xhibit_case.case_type.inspect}"
     end
@@ -24,7 +23,7 @@ class LinkXhibitCase < ApplicationService
       maat_id:,
       status: :auto_linked,
       linked_at: Time.zone.now,
-      linked_by: USER_NAME,
+      linked_by: User::SYSTEM_USERNAME,
     )
   end
 

--- a/app/services/maat_api/maat_application_searcher.rb
+++ b/app/services/maat_api/maat_application_searcher.rb
@@ -23,7 +23,9 @@ module MaatApi
     end
 
     def call
-      @connection.presence&.post(URL, @search_request)
+      MaatApi::SearchResponse.new(
+        @connection.presence&.post(URL, @search_request),
+      )
     end
   end
 end

--- a/app/services/maat_api/maat_application_searcher.rb
+++ b/app/services/maat_api/maat_application_searcher.rb
@@ -23,9 +23,7 @@ module MaatApi
     end
 
     def call
-      MaatApi::SearchResponse.new(
-        @connection.presence&.post(URL, @search_request),
-      )
+      MaatApi::SearchResponse.new(@connection.post(URL, @search_request))
     end
   end
 end

--- a/app/services/maat_api/maat_reference_validator.rb
+++ b/app/services/maat_api/maat_reference_validator.rb
@@ -10,7 +10,7 @@ module MaatApi
     end
 
     def call
-      connection.presence&.post(URL, { maatId: maat_reference, caseUrn: "XYZ" })
+      connection.post(URL, { maatId: maat_reference, caseUrn: "XYZ" })
     end
 
   private

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -38,6 +38,8 @@ private
 
   def handle_success(response, xhibit_case)
     LinkXhibitCase.call(response, xhibit_case) if response.no_existing_link?
+  rescue ActiveRecord::RecordInvalid => e
+    record_error(xhibit_case, message: "Validation failed: #{e.record.errors.full_messages.join(', ')}")
   end
 
   def handle_not_found(xhibit_case)

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -1,19 +1,21 @@
 class ProcessXhibitCases < ApplicationService
   def call
     XhibitMigratedCase.pending.find_each do |xhibit_case|
-      process_case(xhibit_case)
+      response = maat_search(xhibit_case)
+
+      if response.success?
+        handle_success(response, xhibit_case)
+      elsif response.not_found?
+        handle_not_found(xhibit_case)
+      else
+        record_error(xhibit_case, :maat, error: response&.status, message: response&.body)
+      end
+    rescue StandardError => e
+      record_error(xhibit_case, :unexpected, error: e.class.name, message: e.message)
     end
   end
 
 private
-
-  def process_case(xhibit_case)
-    response = maat_search(xhibit_case)
-
-    handle_response(response, xhibit_case)
-  rescue Faraday::Error => e
-    record_error(xhibit_case, error: e.class.name, message: e.message)
-  end
 
   def maat_search(xhibit_case)
     MaatApi::MaatApplicationSearcher.call(
@@ -26,28 +28,63 @@ private
     )
   end
 
-  def handle_response(response, xhibit_case)
-    if response.success?
-      handle_success(response, xhibit_case)
-    elsif response.not_found?
-      handle_not_found(xhibit_case)
-    else
-      record_error(xhibit_case, error: response&.status, message: response&.body)
-    end
+  def handle_success(response, xhibit_case)
+    return handle_existing_link(xhibit_case) unless response.no_existing_link?
+
+    defendant_summary = fetch_defendant_summary(xhibit_case)
+    return handle_not_on_common_platform(xhibit_case) if defendant_summary.nil?
+
+    LinkXhibitCase.call(response, xhibit_case, defendant_summary)
+  rescue ActiveRecord::RecordInvalid => e
+    record_error(xhibit_case, :link, message: "Validation failed: #{e.record.errors.full_messages.join(', ')}")
   end
 
-  def handle_success(response, xhibit_case)
-    LinkXhibitCase.call(response, xhibit_case) if response.no_existing_link?
-  rescue ActiveRecord::RecordInvalid => e
-    record_error(xhibit_case, message: "Validation failed: #{e.record.errors.full_messages.join(', ')}")
+  # Both MAAT link creators read from the local database, so the case has to be
+  # searched for (and therefore recorded) before anything can be linked.
+  # Searching also records the offences the link is posted against.
+  def fetch_defendant_summary(xhibit_case)
+    prosecution_case = search_prosecution_case(xhibit_case)
+    return if prosecution_case.nil?
+
+    HmctsCommonPlatform::ProsecutionCaseSummary
+      .new(prosecution_case.body)
+      .defendant_summary(xhibit_case.defendant_id)
+  end
+
+  # Common Platform's URN search is case insensitive and strips spaces, so it can
+  # return more than one case
+  def search_prosecution_case(xhibit_case)
+    cases = Array(
+      CommonPlatform::Api::SearchProsecutionCase.call(
+        prosecution_case_reference: xhibit_case.case_urn,
+      ),
+    )
+
+    cases.find { it.prosecution_case_reference == xhibit_case.case_urn } ||
+      (cases.first if cases.one?)
   end
 
   def handle_not_found(xhibit_case)
     xhibit_case.action_required!
-    record_error(xhibit_case, message: "MAAT application not found")
+    record_error(xhibit_case, :maat, message: "MAAT application not found")
   end
 
-  def record_error(xhibit_case, **process_errors)
-    xhibit_case.update!(process_errors: process_errors)
+  def handle_existing_link(xhibit_case)
+    xhibit_case.action_required!
+    record_error(xhibit_case, :maat, message: "MAAT application is already linked")
+  end
+
+  def handle_not_on_common_platform(xhibit_case)
+    xhibit_case.action_required!
+    record_error(xhibit_case, :common_platform, message: "Case not found on Common Platform")
+  end
+
+  # Errors are keyed by step and merged, so that a failure in one step does not
+  # discard what an earlier step recorded.
+  def record_error(xhibit_case, step, **details)
+    xhibit_case.reload.update_columns(
+      process_errors: (xhibit_case.process_errors || {}).merge(step.to_s => details.stringify_keys),
+      updated_at: Time.zone.now,
+    )
   end
 end

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -1,7 +1,4 @@
 class ProcessXhibitCases < ApplicationService
-  NOT_FOUND = 404
-  SUCCESS = 200..299
-
   def call
     XhibitMigratedCase.pending.find_each do |xhibit_case|
       process_case(xhibit_case)
@@ -30,10 +27,9 @@ private
   end
 
   def handle_response(response, xhibit_case)
-    case response&.status
-    when SUCCESS
+    if response.success?
       handle_success(response, xhibit_case)
-    when NOT_FOUND
+    elsif response.not_found?
       handle_not_found(xhibit_case)
     else
       record_error(xhibit_case, error: response&.status, message: response&.body)

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -36,8 +36,8 @@ private
     end
   end
 
-  def handle_success(_response, _xhibit_case)
-    # TODO: process the maat applications matching the case.
+  def handle_success(response, xhibit_case)
+    LinkXhibitCase.call(response, xhibit_case) if response.no_existing_link?
   end
 
   def handle_not_found(xhibit_case)

--- a/app/services/prosecution_case_maat_link_creator.rb
+++ b/app/services/prosecution_case_maat_link_creator.rb
@@ -3,13 +3,14 @@
 class ProsecutionCaseMaatLinkCreator < ApplicationService
   attr_reader :laa_reference, :defendant_id, :prosecution_case_id
 
-  def initialize(defendant_id, user_name, maat_reference)
+  def initialize(defendant_id, user_name, maat_reference, can_update_laa_status: false)
     @laa_reference = LaaReference.new(
       defendant_id:,
       user_name:,
       maat_reference: maat_reference.presence || LaaReference.generate_linking_dummy_maat_reference,
     )
     @defendant_id = defendant_id
+    @can_update_laa_status = can_update_laa_status
     @prosecution_case_id = verify_prosecution_case_id
   end
 
@@ -29,6 +30,7 @@ private
       user_name: laa_reference.user_name,
       defendant_summary:,
       prosecution_case_summary:,
+      can_update_laa_status: @can_update_laa_status,
     )
 
     Sqs::MessagePublisher.call(

--- a/lib/tasks/xhibit_cases.rake
+++ b/lib/tasks/xhibit_cases.rake
@@ -34,4 +34,14 @@ namespace :xhibit_cases do
     puts "[INFO  - #{Time.zone.now}] Import completed — #{results[:success_count]} inserted, #{results[:errors].count} error(s)."
     puts "[INFO  - #{Time.zone.now}] Error details written to #{errors_file}"
   end
+
+  desc "Process imported XHIBIT cases: search MAAT and link where possible. Example: rake xhibit_cases:process"
+
+  task process: :environment do
+    puts "[INFO - #{Time.zone.now}] Processing #{XhibitMigratedCase.pending.count} pending XHIBIT case(s)..."
+
+    ProcessXhibitCases.call
+
+    puts "[INFO  - #{Time.zone.now}] Processing completed."
+  end
 end

--- a/spec/cassettes/laa_reference_recorder/xhibit_auto_link_offence_failure.yml
+++ b/spec/cassettes/laa_reference_recorder/xhibit_auto_link_offence_failure.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases/laaReference/cases/6fc1f2cb-4a93-4116-84db-f87cc86ec3b8/defendant/cfc4281f-cdea-494d-8179-3173d30736fd/offences/997ba1dd-e1e2-46cb-ad4d-2c570af869cd"
+    body:
+      encoding: UTF-8
+      string: '{"statusCode":"AP","applicationReference":"6559879","statusDate":"2026-09-03"}'
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      content-length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 03 Sep 2026 10:00:00 GMT
+- request:
+    method: post
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases/laaReference/cases/6fc1f2cb-4a93-4116-84db-f87cc86ec3b8/defendant/cfc4281f-cdea-494d-8179-3173d30736fd/offences/9085871a-797b-4ab8-8072-05ca6deeaac9"
+    body:
+      encoding: UTF-8
+      string: '{"statusCode":"AP","applicationReference":"6559879","statusDate":"2026-09-03"}'
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"error":"Internal Server Error"}'
+  recorded_at: Wed, 03 Sep 2026 10:00:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/laa_reference_recorder/xhibit_auto_link_success.yml
+++ b/spec/cassettes/laa_reference_recorder/xhibit_auto_link_success.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases/laaReference/cases/6fc1f2cb-4a93-4116-84db-f87cc86ec3b8/defendant/cfc4281f-cdea-494d-8179-3173d30736fd/offences/997ba1dd-e1e2-46cb-ad4d-2c570af869cd"
+    body:
+      encoding: UTF-8
+      string: '{"statusCode":"AP","applicationReference":"6559879","statusDate":"2026-09-03"}'
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      content-length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 03 Sep 2026 10:00:00 GMT
+- request:
+    method: post
+    uri: "<COMMON_PLATFORM_URL>/prosecutionCases/laaReference/cases/6fc1f2cb-4a93-4116-84db-f87cc86ec3b8/defendant/cfc4281f-cdea-494d-8179-3173d30736fd/offences/9085871a-797b-4ab8-8072-05ca6deeaac9"
+    body:
+      encoding: UTF-8
+      string: '{"statusCode":"AP","applicationReference":"6559879","statusDate":"2026-09-03"}'
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "<SHARED_SECRET_KEY>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      content-length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 03 Sep 2026 10:00:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/maat_api/search_maat_application_multiple_results.yml
+++ b/spec/cassettes/maat_api/search_maat_application_multiple_results.yml
@@ -105,6 +105,6 @@ http_interactions:
           - DENY
       body:
         encoding: UTF-8
-        string: '[{"maatId":6559879,"linkingDetail":null,"linked":false,"isLinked":false}]'
+        string: '[{"maatId":6559879,"linkingDetail":null,"linked":false,"isLinked":false},{"maatId":6672961,"linkingDetail":{"libraId":"2600000358","caseId":1022118,"caseUrn":null,"cjsAreaCode":"01","cjsLocation":"B01OB"},"linked":true,"isLinked":true},{"maatId":6541616,"linkingDetail":{"libraId":"CP665948","caseId":1022017,"caseUrn":"CEXOFJTQ2F","cjsAreaCode":"01","cjsLocation":"B01BH"},"linked":true,"isLinked":true}]'
     recorded_at: Fri, 31 Jul 2026 15:22:23 GMT
 recorded_with: VCR 6.4.0

--- a/spec/cassettes/maat_api/search_maat_application_success_linked_result.yml
+++ b/spec/cassettes/maat_api/search_maat_application_success_linked_result.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: <MAAT_API_OAUTH_URL>/oauth2/token
+      body:
+        encoding: UTF-8
+        string: grant_type=client_credentials
+      headers:
+        User-Agent:
+          - Faraday v2.14.3
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Authorization:
+          - "<AUTH>"
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        Date:
+          - Fri, 31 Jul 2026 15:22:22 GMT
+        Content-Type:
+          - application/json;charset=UTF-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        X-Amz-Cognito-Request-Id:
+          - 6b1d4aa5-d0b5-4a2a-b7e1-f12918b68e85
+        Vary:
+          - Access-Control-Request-Headers
+          - Access-Control-Request-Method
+          - Origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - "0"
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Pragma:
+          - no-cache
+        Expires:
+          - "0"
+        Strict-Transport-Security:
+          - max-age=31536000 ; includeSubDomains
+        X-Frame-Options:
+          - DENY
+        Server:
+          - Server
+      body:
+        encoding: UTF-8
+        string: '{"access_token":"<access_token>","expires_in":3600,"token_type":"Bearer"}'
+    recorded_at: Fri, 31 Jul 2026 15:22:22 GMT
+  - request:
+      method: post
+      uri: <MAAT_API_API_URL>/api/internal/v1/assessment/rep-orders/search-maat-application
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Tango","lastName":"JF-LAA-T"}'
+      headers:
+        User-Agent:
+          - Faraday v2.14.3
+        Authorization:
+          - "<AUTH>"
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        Date:
+          - Fri, 31 Jul 2026 15:22:23 GMT
+        Content-Type:
+          - application/json
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Set-Cookie:
+          - INGRESSCOOKIE=1785511343.432.31305.664596|55b9a069646b5e4eb9ec5bafd08dbaec;
+            Max-Age=300; Path=/; Secure; HttpOnly
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - "0"
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Pragma:
+          - no-cache
+        Expires:
+          - "0"
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        X-Frame-Options:
+          - DENY
+      body:
+        encoding: UTF-8
+        string: '[{"maatId":6559879,"linkingDetail":null,"linked":true,"isLinked":true}]'
+    recorded_at: Fri, 31 Jul 2026 15:22:23 GMT
+recorded_with: VCR 6.4.0

--- a/spec/factories/xhibit_migrated_case.rb
+++ b/spec/factories/xhibit_migrated_case.rb
@@ -21,6 +21,14 @@ FactoryBot.define do
     sent_date { Date.new(2019, 10, 25) }
     status { "pending" }
 
+    after(:build) do |migrated_case|
+      if migrated_case.auto_linked? || migrated_case.manually_linked?
+        migrated_case.maat_id ||= "1234567"
+        migrated_case.linked_at ||= Time.zone.now
+        migrated_case.linked_by ||= "SYSTEM"
+      end
+    end
+
     trait :pending do
       status { "pending" }
     end

--- a/spec/lib/tasks/xhibit_cases_spec.rb
+++ b/spec/lib/tasks/xhibit_cases_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "xhibit_cases:process task" do
+  subject(:process_task) { Rake::Task["xhibit_cases:process"].execute }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+    allow($stdout).to receive(:puts)
+    allow(ProcessXhibitCases).to receive(:call)
+  end
+
+  after { Rake::Task["xhibit_cases:process"].reenable }
+
+  context "with pending and already-linked cases" do
+    before do
+      create(:xhibit_migrated_case)
+      create(:xhibit_migrated_case, suffix: 2)
+      create(:xhibit_migrated_case, :auto_linked, suffix: 3)
+
+      process_task
+    end
+
+    it "hands the processing over to ProcessXhibitCases" do
+      expect(ProcessXhibitCases).to have_received(:call).once
+    end
+
+    it "reports the pending count, ignoring the linked case" do
+      expect($stdout).to have_received(:puts).with(/Processing 2 pending XHIBIT case/)
+    end
+
+    it "reports completion" do
+      expect($stdout).to have_received(:puts).with(/Processing completed/)
+    end
+  end
+end

--- a/spec/models/maat_api/court_application_laa_reference_spec.rb
+++ b/spec/models/maat_api/court_application_laa_reference_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe MaatApi::CourtApplicationLaaReference, type: :model do
     expect(laa_reference.is_active?).to be true
   end
 
+  it "cannot update the LAA status by default" do
+    expect(laa_reference.can_update_laa_status?).to be false
+  end
+
+  context "when created with can_update_laa_status" do
+    subject(:laa_reference) do
+      described_class.new(
+        user_name:,
+        maat_reference:,
+        court_application_summary:,
+        can_update_laa_status: true,
+      )
+    end
+
+    it "can update the LAA status" do
+      expect(laa_reference.can_update_laa_status?).to be true
+    end
+  end
+
   it "has a defendant payload" do
     expected = {
       dateOfBirth: "1999-02-06",

--- a/spec/models/maat_api/laa_reference_message_spec.rb
+++ b/spec/models/maat_api/laa_reference_message_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe MaatApi::LaaReferenceMessage do
+  subject(:message) { described_class.new(laa_reference).generate }
+
+  let(:laa_reference) do
+    instance_double(
+      MaatApi::LaaReference,
+      maat_reference: "1234567",
+      case_urn: "30DI0570888",
+      defendant_asn: "ARREST123",
+      cjs_area_code: "1",
+      user_name: "test-user",
+      cjs_location: "B01LY",
+      doc_language: "EN",
+      is_active?: true,
+      can_update_laa_status?: can_update_laa_status,
+      defendant: { defendantId: "4b463e6a-105b-433b-a88d-057d6e645bfb" },
+      sessions: [{ courtLocation: "B01LY", dateOfHearing: "2020-08-17" }],
+    )
+  end
+
+  context "when the LAA status cannot be updated" do
+    let(:can_update_laa_status) { false }
+
+    it "builds the MAAT link payload" do
+      expect(message).to eq(
+        maatId: "1234567",
+        caseUrn: "30DI0570888",
+        asn: "ARREST123",
+        cjsAreaCode: "1",
+        createdUser: "test-user",
+        cjsLocation: "B01LY",
+        docLanguage: "EN",
+        isActive: true,
+        canUpdateLaaStatus: false,
+        defendant: { defendantId: "4b463e6a-105b-433b-a88d-057d6e645bfb" },
+        sessions: [{ courtLocation: "B01LY", dateOfHearing: "2020-08-17" }],
+      )
+    end
+  end
+
+  context "when the LAA status can be updated" do
+    let(:can_update_laa_status) { true }
+
+    it "flags it in the payload" do
+      expect(message).to include(canUpdateLaaStatus: true)
+    end
+  end
+end

--- a/spec/models/maat_api/laa_reference_spec.rb
+++ b/spec/models/maat_api/laa_reference_spec.rb
@@ -46,6 +46,26 @@ RSpec.describe MaatApi::LaaReference, type: :model do
     expect(laa_reference.is_active?).to be true
   end
 
+  it "cannot update the LAA status by default" do
+    expect(laa_reference.can_update_laa_status?).to be false
+  end
+
+  context "when created with can_update_laa_status" do
+    let(:laa_reference) do
+      described_class.new(
+        prosecution_case_summary:,
+        defendant_summary:,
+        user_name:,
+        maat_reference:,
+        can_update_laa_status: true,
+      )
+    end
+
+    it "can update the LAA status" do
+      expect(laa_reference.can_update_laa_status?).to be true
+    end
+  end
+
   it "has a defendant payload" do
     expected = {
       dateOfBirth: "1986-11-10",

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -107,4 +107,87 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
       expect(response.maat_id).to eq("MAT001")
     end
   end
+
+  describe "#no_existing_link?" do
+    it "returns true when is_linked is false, libra_id is nil, and case_urn is nil" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => {} },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be true
+    end
+
+    it "returns true when response is empty" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [{}])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be true
+    end
+
+    it "returns false when is_linked is true" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => {} },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be false
+    end
+
+    it "returns false when libra_id is present" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123" } },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be false
+    end
+
+    it "returns false when case_urn is present" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => { "caseUrn" => "URN123" } },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be false
+    end
+
+    it "returns false when both libra_id and case_urn are present" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123", "caseUrn" => "URN123" } },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be false
+    end
+
+    it "returns true when body is empty array" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be true
+    end
+
+    it "returns true when body is nil" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: nil)
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be true
+    end
+
+    it "returns true when faraday_response is nil" do
+      response = described_class.new(nil)
+
+      expect(response.no_existing_link?).to be true
+    end
+
+    it "returns true when is_linked is present but not strictly true" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => "yes", "linkingDetail" => {} },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.no_existing_link?).to be true
+    end
+  end
 end

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe MaatApi::SearchResponse, type: :model do
+  describe "#initialize" do
+    it "extracts status and body from Faraday response" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: { id: "123" })
+      response = described_class.new(faraday_response)
+
+      expect(response.body).to eq({ id: "123" })
+    end
+
+    it "handles nil faraday response" do
+      response = described_class.new(nil)
+
+      expect(response.body).to be_nil
+    end
+  end
+
+  describe "#success?" do
+    it "returns true when Faraday success is true" do
+      faraday_response = instance_double(Faraday::Response, success?: true, body: {})
+      response = described_class.new(faraday_response)
+
+      expect(response.success?).to be true
+    end
+
+    it "returns false when Faraday success is false" do
+      faraday_response = instance_double(Faraday::Response, success?: false, body: {})
+      response = described_class.new(faraday_response)
+
+      expect(response.success?).to be false
+    end
+  end
+
+  describe "#not_found?" do
+    it "returns true for 404 status" do
+      faraday_response = instance_double(Faraday::Response, status: 404, body: {})
+      response = described_class.new(faraday_response)
+
+      expect(response.not_found?).to be true
+    end
+
+    it "returns false for 200" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: {})
+      response = described_class.new(faraday_response)
+
+      expect(response.not_found?).to be false
+    end
+
+    it "returns false for other 4xx status codes" do
+      [400, 401, 403, 422].each do |status|
+        faraday_response = instance_double(Faraday::Response, status: status, body: {})
+        response = described_class.new(faraday_response)
+
+        expect(response.not_found?).to be false
+      end
+    end
+
+    it "returns false when status is nil" do
+      faraday_response = instance_double(Faraday::Response, status: nil, body: {})
+      response = described_class.new(faraday_response)
+
+      expect(response.not_found?).to be false
+    end
+  end
+end

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe MaatApi::SearchResponse, type: :model do
   describe "#initialize" do
     it "extracts status and body from Faraday response" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: { id: "123" })
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: { id: "123" })
+      response = described_class.new(http_response)
 
       expect(response.body).to eq({ id: "123" })
     end
@@ -16,15 +16,15 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
 
   describe "#success?" do
     it "returns true when Faraday success is true" do
-      faraday_response = instance_double(Faraday::Response, success?: true, body: {})
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, success?: true, body: {})
+      response = described_class.new(http_response)
 
       expect(response.success?).to be true
     end
 
     it "returns false when Faraday success is false" do
-      faraday_response = instance_double(Faraday::Response, success?: false, body: {})
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, success?: false, body: {})
+      response = described_class.new(http_response)
 
       expect(response.success?).to be false
     end
@@ -32,31 +32,31 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
 
   describe "#not_found?" do
     it "returns true for 404 status" do
-      faraday_response = instance_double(Faraday::Response, status: 404, body: {})
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 404, body: {})
+      response = described_class.new(http_response)
 
       expect(response.not_found?).to be true
     end
 
     it "returns false for 200" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: {})
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: {})
+      response = described_class.new(http_response)
 
       expect(response.not_found?).to be false
     end
 
     it "returns false for other 4xx status codes" do
       [400, 401, 403, 422].each do |status|
-        faraday_response = instance_double(Faraday::Response, status: status, body: {})
-        response = described_class.new(faraday_response)
+        http_response = instance_double(Faraday::Response, status: status, body: {})
+        response = described_class.new(http_response)
 
         expect(response.not_found?).to be false
       end
     end
 
     it "returns false when status is nil" do
-      faraday_response = instance_double(Faraday::Response, status: nil, body: {})
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: nil, body: {})
+      response = described_class.new(http_response)
 
       expect(response.not_found?).to be false
     end
@@ -64,45 +64,45 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
 
   describe "#maat_id" do
     it "returns maatId from the first response item" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [{ "maatId" => "MAT001", "name" => "John Doe" }])
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: [{ "maatId" => "MAT001", "name" => "John Doe" }])
+      response = described_class.new(http_response)
 
       expect(response.maat_id).to eq("MAT001")
     end
 
     it "returns nil when body is empty array" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [])
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: [])
+      response = described_class.new(http_response)
 
       expect(response.maat_id).to be_nil
     end
 
     it "returns nil when maatId is not present" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [{ "name" => "John Doe" }])
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: [{ "name" => "John Doe" }])
+      response = described_class.new(http_response)
 
       expect(response.maat_id).to be_nil
     end
 
     it "returns nil when body is nil" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: nil)
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: nil)
+      response = described_class.new(http_response)
 
       expect(response.maat_id).to be_nil
     end
 
-    it "returns nil when faraday_response is nil" do
+    it "returns nil when http_response is nil" do
       response = described_class.new(nil)
 
       expect(response.maat_id).to be_nil
     end
 
     it "handles multiple items and returns first maatId" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "maatId" => "MAT001", "name" => "John Doe" },
         { "maatId" => "MAT002", "name" => "Jane Doe" },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.maat_id).to eq("MAT001")
     end
@@ -110,82 +110,82 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
 
   describe "#no_existing_link?" do
     it "returns true when is_linked is false, libra_id is nil, and case_urn is nil" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => {} },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be true
     end
 
     it "returns true when response is empty" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [{}])
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: [{}])
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be true
     end
 
     it "returns false when is_linked is true" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => true, "linkingDetail" => {} },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be false
     end
 
     it "returns false when libra_id is present" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123" } },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be false
     end
 
     it "returns false when case_urn is present" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "caseUrn" => "URN123" } },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be false
     end
 
     it "returns false when both libra_id and case_urn are present" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123", "caseUrn" => "URN123" } },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be false
     end
 
     it "returns true when body is empty array" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [])
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: [])
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be true
     end
 
     it "returns true when body is nil" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: nil)
-      response = described_class.new(faraday_response)
+      http_response = instance_double(Faraday::Response, status: 200, body: nil)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be true
     end
 
-    it "returns true when faraday_response is nil" do
+    it "returns true when http_response is nil" do
       response = described_class.new(nil)
 
       expect(response.no_existing_link?).to be true
     end
 
     it "returns true when is_linked is present but not strictly true" do
-      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+      http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => "yes", "linkingDetail" => {} },
       ])
-      response = described_class.new(faraday_response)
+      response = described_class.new(http_response)
 
       expect(response.no_existing_link?).to be true
     end

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
       expect(response.body).to eq({ id: "123" })
     end
 
-    it "handles nil faraday response" do
+    it "handles nil Faraday response without raising error" do
       response = described_class.new(nil)
 
-      expect(response.body).to be_nil
+      expect { response.maat_id }.not_to raise_error
     end
   end
 
@@ -59,6 +59,52 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
       response = described_class.new(faraday_response)
 
       expect(response.not_found?).to be false
+    end
+  end
+
+  describe "#maat_id" do
+    it "returns maatId from the first response item" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [{ "maatId" => "MAT001", "name" => "John Doe" }])
+      response = described_class.new(faraday_response)
+
+      expect(response.maat_id).to eq("MAT001")
+    end
+
+    it "returns nil when body is empty array" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [])
+      response = described_class.new(faraday_response)
+
+      expect(response.maat_id).to be_nil
+    end
+
+    it "returns nil when maatId is not present" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [{ "name" => "John Doe" }])
+      response = described_class.new(faraday_response)
+
+      expect(response.maat_id).to be_nil
+    end
+
+    it "returns nil when body is nil" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: nil)
+      response = described_class.new(faraday_response)
+
+      expect(response.maat_id).to be_nil
+    end
+
+    it "returns nil when faraday_response is nil" do
+      response = described_class.new(nil)
+
+      expect(response.maat_id).to be_nil
+    end
+
+    it "handles multiple items and returns first maatId" do
+      faraday_response = instance_double(Faraday::Response, status: 200, body: [
+        { "maatId" => "MAT001", "name" => "John Doe" },
+        { "maatId" => "MAT002", "name" => "Jane Doe" },
+      ])
+      response = described_class.new(faraday_response)
+
+      expect(response.maat_id).to eq("MAT001")
     end
   end
 end

--- a/spec/models/xhibit_migrated_case_spec.rb
+++ b/spec/models/xhibit_migrated_case_spec.rb
@@ -79,8 +79,16 @@ RSpec.describe XhibitMigratedCase, type: :model do
       end
     end
 
+    context "when status is set to auto_linked" do
+      subject(:migrated_case) { described_class.new(valid_attributes.merge(status: "auto_linked")) }
+
+      it { is_expected.to validate_presence_of(:maat_id) }
+      it { is_expected.to validate_presence_of(:linked_at) }
+      it { is_expected.to validate_presence_of(:linked_by) }
+    end
+
     context "when status is set to `manually_linked`" do
-      subject(:migrated_case) { described_class.new(valid_attributes.merge(status: :manually_linked)) }
+      subject(:migrated_case) { described_class.new(valid_attributes.merge(status: "manually_linked")) }
 
       it { is_expected.to validate_presence_of(:maat_id) }
       it { is_expected.to validate_presence_of(:linked_at) }

--- a/spec/services/court_application_maat_link_creator_spec.rb
+++ b/spec/services/court_application_maat_link_creator_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe CourtApplicationMaatLinkCreator do
         cjsAreaCode: "1",
         cjsLocation: "B01LY",
         createdUser: "bob-smith",
+        canUpdateLaaStatus: false,
       )
 
       expect(arg[:log_info]).to include(
@@ -77,6 +78,24 @@ RSpec.describe CourtApplicationMaatLinkCreator do
     end
 
     call_link_creator
+  end
+
+  context "when the LAA status can be updated" do
+    subject(:call_link_creator) do
+      described_class.call(subject_id, user_name, maat_reference, can_update_laa_status: true)
+    end
+
+    it "flags it in the published message" do
+      allow(CommonPlatform::Api::RecordCourtApplicationLaaReference)
+        .to receive(:call)
+        .and_return(response)
+
+      expect(Sqs::MessagePublisher).to receive(:call).once do |arg|
+        expect(arg[:message]).to include(canUpdateLaaStatus: true)
+      end
+
+      call_link_creator
+    end
   end
 
   context "with multiple offences" do

--- a/spec/services/link_xhibit_case_spec.rb
+++ b/spec/services/link_xhibit_case_spec.rb
@@ -14,17 +14,12 @@ RSpec.describe LinkXhibitCase, type: :service do
     end
 
     let(:xhibit_case) do
-      XhibitMigratedCase.create!(
-        case_urn: "20GD021701",
-        xhibit_case_number: "T202540001",
-        court_name: "Derby Justice Centre",
-        ou_code: "B30PI00",
-        case_type:,
-        defendant_id: "defendant-1",
-        defendant_first_name: "Alice",
-        defendant_last_name: "Smith",
-        sent_date: Date.new(2019, 10, 25),
-      )
+      create(:xhibit_migrated_case,
+             case_urn: "20GD021701",
+             case_type:,
+             defendant_id: "defendant-1",
+             defendant_first_name: "Alice",
+             defendant_last_name: "Smith")
     end
 
     let(:link_case) { described_class.call(maat_response, xhibit_case, court_data) }
@@ -37,15 +32,18 @@ RSpec.describe LinkXhibitCase, type: :service do
     it "updates the xhibit case" do
       expect { link_case }.to change { xhibit_case.reload.status }.from("pending").to("auto_linked")
                           .and change { xhibit_case.reload.maat_id }.from(nil).to(maat_response.maat_id)
-                          .and change { xhibit_case.reload.linked_by }.from(nil).to("SYSTEM")
+                          .and change { xhibit_case.reload.linked_by }.from(nil).to(User::SYSTEM_USERNAME)
                           .and change { xhibit_case.reload.linked_at }.from(nil).to(within(1.second).of(Time.zone.now))
     end
 
-    it "links a trial using the defendant id" do
+    it "links a trial using the defendant id and enables LAA status updates" do
       link_case
 
       expect(ProsecutionCaseMaatLinkCreator).to have_received(:call).with(
-        court_data.defendant_id, "SYSTEM", maat_response.maat_id
+        court_data.defendant_id,
+        User::SYSTEM_USERNAME,
+        maat_response.maat_id,
+        can_update_laa_status: true,
       )
     end
 
@@ -61,11 +59,14 @@ RSpec.describe LinkXhibitCase, type: :service do
           ]
         end
 
-        it "links the court application using the subject id" do
+        it "links the court application using the subject id and enables LAA status updates" do
           link_case
 
           expect(CourtApplicationMaatLinkCreator).to have_received(:call).with(
-            subject_id, "SYSTEM", maat_response.maat_id
+            subject_id,
+            User::SYSTEM_USERNAME,
+            maat_response.maat_id,
+            can_update_laa_status: true,
           )
         end
       end
@@ -77,6 +78,19 @@ RSpec.describe LinkXhibitCase, type: :service do
       it "raises rather than marking the case linked" do
         expect { link_case }.to raise_error(ArgumentError, /No court application found/)
         expect(xhibit_case.reload).to be_pending
+      end
+    end
+
+    context "when the link creator fails" do
+      before do
+        allow(ProsecutionCaseMaatLinkCreator).to receive(:call)
+          .and_raise(CommonPlatform::Api::Errors::FailedDependency, "Unsuccessful response from Common Platform")
+      end
+
+      it "raises rather than marking the case linked" do
+        expect { link_case }.to raise_error(CommonPlatform::Api::Errors::FailedDependency)
+        expect(xhibit_case.reload).to be_pending
+        expect(xhibit_case).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
       end
     end
 

--- a/spec/services/link_xhibit_case_spec.rb
+++ b/spec/services/link_xhibit_case_spec.rb
@@ -1,13 +1,25 @@
 RSpec.describe LinkXhibitCase, type: :service do
   describe "#call" do
     let(:maat_response) { instance_double(MaatApi::SearchResponse, maat_id: "6559879") }
+    let(:case_type) { "T" }
+    let(:application_summaries) { [] }
+    let(:subject_id) { "b7c8e2f0-0000-4000-8000-000000000002" }
+
+    let(:court_data) do
+      instance_double(
+        HmctsCommonPlatform::DefendantSummary,
+        defendant_id: "b7c8e2f0-0000-4000-8000-000000000001",
+        application_summaries:,
+      )
+    end
+
     let(:xhibit_case) do
       XhibitMigratedCase.create!(
         case_urn: "20GD021701",
         xhibit_case_number: "T202540001",
         court_name: "Derby Justice Centre",
         ou_code: "B30PI00",
-        case_type: "T",
+        case_type:,
         defendant_id: "defendant-1",
         defendant_first_name: "Alice",
         defendant_last_name: "Smith",
@@ -15,9 +27,10 @@ RSpec.describe LinkXhibitCase, type: :service do
       )
     end
 
-    let(:link_case) { described_class.new.call(maat_response, xhibit_case) }
+    let(:link_case) { described_class.call(maat_response, xhibit_case, court_data) }
 
     before do
+      allow(ProsecutionCaseMaatLinkCreator).to receive(:call)
       allow(CourtApplicationMaatLinkCreator).to receive(:call)
     end
 
@@ -28,14 +41,52 @@ RSpec.describe LinkXhibitCase, type: :service do
                           .and change { xhibit_case.reload.linked_at }.from(nil).to(within(1.second).of(Time.zone.now))
     end
 
-    it "calls the CourtApplicationMaatLinkCreator" do
+    it "links a trial using the defendant id" do
       link_case
 
-      expect(CourtApplicationMaatLinkCreator).to have_received(:call).with(
-        xhibit_case.defendant_id,
-        "SYSTEM",
-        maat_response.maat_id,
+      expect(ProsecutionCaseMaatLinkCreator).to have_received(:call).with(
+        court_data.defendant_id, "SYSTEM", maat_response.maat_id
       )
+    end
+
+    %w[A S].each do |court_application_case_type|
+      context "when the case type is #{court_application_case_type}" do
+        let(:case_type) { court_application_case_type }
+        let(:application_summaries) do
+          [
+            instance_double(
+              HmctsCommonPlatform::ApplicationSummary,
+              subject_summary: instance_double(HmctsCommonPlatform::SubjectSummary, subject_id:),
+            ),
+          ]
+        end
+
+        it "links the court application using the subject id" do
+          link_case
+
+          expect(CourtApplicationMaatLinkCreator).to have_received(:call).with(
+            subject_id, "SYSTEM", maat_response.maat_id
+          )
+        end
+      end
+    end
+
+    context "when a court application case has no matching application" do
+      let(:case_type) { "A" }
+
+      it "raises rather than marking the case linked" do
+        expect { link_case }.to raise_error(ArgumentError, /No court application found/)
+        expect(xhibit_case.reload).to be_pending
+      end
+    end
+
+    context "when the case type is not recognised" do
+      let(:case_type) { "X" }
+
+      it "raises rather than marking the case linked" do
+        expect { link_case }.to raise_error(ArgumentError, /Unsupported case type/)
+        expect(xhibit_case.reload).to be_pending
+      end
     end
   end
 end

--- a/spec/services/link_xhibit_case_spec.rb
+++ b/spec/services/link_xhibit_case_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe LinkXhibitCase, type: :service do
+  describe "#call" do
+    let(:maat_response) { instance_double(MaatApi::SearchResponse, maat_id: "6559879") }
+    let(:xhibit_case) do
+      XhibitMigratedCase.create!(
+        case_urn: "20GD021701",
+        xhibit_case_number: "T202540001",
+        court_name: "Derby Justice Centre",
+        ou_code: "B30PI00",
+        case_type: "T",
+        defendant_id: "defendant-1",
+        defendant_first_name: "Alice",
+        defendant_last_name: "Smith",
+        sent_date: Date.new(2019, 10, 25),
+      )
+    end
+
+    let(:link_case) { described_class.new.call(maat_response, xhibit_case) }
+
+    before do
+      allow(CourtApplicationMaatLinkCreator).to receive(:call)
+    end
+
+    it "updates the xhibit case" do
+      expect { link_case }.to change { xhibit_case.reload.status }.from("pending").to("auto_linked")
+                          .and change { xhibit_case.reload.maat_id }.from(nil).to(maat_response.maat_id)
+                          .and change { xhibit_case.reload.linked_by }.from(nil).to("SYSTEM")
+                          .and change { xhibit_case.reload.linked_at }.from(nil).to(within(1.second).of(Time.zone.now))
+    end
+
+    it "calls the CourtApplicationMaatLinkCreator" do
+      link_case
+
+      expect(CourtApplicationMaatLinkCreator).to have_received(:call).with(
+        xhibit_case.defendant_id,
+        "SYSTEM",
+        maat_response.maat_id,
+      )
+    end
+  end
+end

--- a/spec/services/maat_api/maat_application_searcher_spec.rb
+++ b/spec/services/maat_api/maat_application_searcher_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe MaatApi::MaatApplicationSearcher do
   subject(:search_response) { described_class.call(**criteria) }
 
-  let(:cassette) { "maat_api/search_maat_application_success" }
+  let(:cassette) { "maat_api/search_maat_application_multiple_results" }
   let(:criteria) { { first_name: "Tango", last_name: "JF-LAA-T" } }
 
   around do |example|

--- a/spec/services/maat_api/maat_application_searcher_spec.rb
+++ b/spec/services/maat_api/maat_application_searcher_spec.rb
@@ -3,9 +3,6 @@
 RSpec.describe MaatApi::MaatApplicationSearcher do
   subject(:search_response) { described_class.call(**criteria) }
 
-  let(:cassette) { "maat_api/search_maat_application_multiple_results" }
-  let(:criteria) { { first_name: "Tango", last_name: "JF-LAA-T" } }
-
   around do |example|
     VCR.use_cassette(cassette,
                      tag: :maat_api,
@@ -14,20 +11,25 @@ RSpec.describe MaatApi::MaatApplicationSearcher do
     end
   end
 
-  it "returns the matching maat applications" do
-    expect(search_response.status).to eq(200)
-    expect(search_response.body.map { |application| application["maatId"] }).to eq([6_559_879, 6_672_961, 6_541_616])
-  end
+  context "when there are multiple matches" do
+    let(:cassette) { "maat_api/search_maat_application_multiple_results" }
+    let(:criteria) { { first_name: "Tango", last_name: "JF-LAA-T" } }
 
-  it "returns the linking detail of a linked maat application" do
-    expect(search_response.body.last).to include(
-      "isLinked" => true,
-      "linkingDetail" => include("libraId" => "CP665948", "caseUrn" => "CEXOFJTQ2F"),
-    )
-  end
+    it "returns the matching maat applications" do
+      expect(search_response.status).to eq(200)
+      expect(search_response.body.map { |application| application["maatId"] }).to eq([6_559_879, 6_672_961, 6_541_616])
+    end
 
-  it "returns no linking detail for an unlinked maat application" do
-    expect(search_response.body.first).to include("isLinked" => false, "linkingDetail" => nil)
+    it "returns the linking detail of a linked maat application" do
+      expect(search_response.body.last).to include(
+        "isLinked" => true,
+        "linkingDetail" => include("libraId" => "CP665948", "caseUrn" => "CEXOFJTQ2F"),
+      )
+    end
+
+    it "returns no linking detail for an unlinked maat application" do
+      expect(search_response.body.first).to include("isLinked" => false, "linkingDetail" => nil)
+    end
   end
 
   context "when there is no matching maat application" do

--- a/spec/services/maat_api/maat_reference_validator_spec.rb
+++ b/spec/services/maat_api/maat_reference_validator_spec.rb
@@ -22,12 +22,4 @@ RSpec.describe MaatApi::MaatReferenceValidator do
       end
     end
   end
-
-  context "when the connection is blank" do
-    subject(:call_validator) { described_class.call(maat_reference:, connection: MaatApi::Connection.call(host: nil)) }
-
-    it "does not make a validation request" do
-      call_validator
-    end
-  end
 end

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ProcessXhibitCases do
   subject(:process_cases) { described_class.call }
 
-  shared_context "with maat api cassette" do
+  shared_context "with MAAT api cassette" do
     around do |example|
       VCR.use_cassette(cassette,
                        tag: :maat_api,
@@ -13,8 +13,8 @@ RSpec.describe ProcessXhibitCases do
     end
   end
 
-  context "when there is no matching maat application" do
-    include_context "with maat api cassette"
+  context "when there is no matching MAAT application" do
+    include_context "with MAAT api cassette"
 
     let(:cassette) { "maat_api/search_maat_application_not_found" }
     let!(:xhibit_case) { create_case(first_name: "nonexistent-first-name", last_name: "nonexistent-last-name") }
@@ -32,8 +32,8 @@ RSpec.describe ProcessXhibitCases do
     end
   end
 
-  context "when there is a matching maat application" do
-    include_context "with maat api cassette"
+  context "when there is a matching MAAT application" do
+    include_context "with MAAT api cassette"
 
     let!(:xhibit_case) { create_case(first_name: "Tango", last_name: "JF-LAA-T") }
     let(:defendant_summary) { instance_double(HmctsCommonPlatform::DefendantSummary) }
@@ -46,7 +46,7 @@ RSpec.describe ProcessXhibitCases do
       )
     end
 
-    context "when the maat application has no existing link" do
+    context "when the MAAT application has no existing link" do
       let(:cassette) { "maat_api/search_maat_application_success" }
 
       before do
@@ -119,9 +119,15 @@ RSpec.describe ProcessXhibitCases do
           },
         )
       end
+
+      it "does not mark the case as linked" do
+        process_cases
+
+        expect(xhibit_case.reload).not_to be_auto_linked
+      end
     end
 
-    context "when the maat application has an existing link" do
+    context "when the MAAT application has an existing link" do
       let(:cassette) { "maat_api/search_maat_application_success_linked_result" }
 
       before do
@@ -187,6 +193,18 @@ RSpec.describe ProcessXhibitCases do
     it "still processes the remaining cases" do
       expect(LinkXhibitCase).to have_received(:call).twice
       expect(succeeding_case.reload.process_errors).to be_nil
+    end
+  end
+
+  context "when the cases are not pending" do
+    before do
+      create(:xhibit_migrated_case, :auto_linked, defendant_last_name: "AlreadyLinked")
+      create(:xhibit_migrated_case, :action_required, defendant_last_name: "NeedsAttention")
+      process_cases
+    end
+
+    it "does not search MAAT for them" do
+      expect(a_request(:post, /search-maat-application/)).not_to have_been_made
     end
   end
 

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe ProcessXhibitCases do
 
     let!(:xhibit_case) { create_case(first_name: "Tango", last_name: "JF-LAA-T") }
 
-    before do
-      allow(LinkXhibitCase).to receive(:call)
-      process_cases
-    end
-
     context "when the maat application has no existing link" do
       let(:cassette) { "maat_api/search_maat_application_success" }
+
+      before do
+        allow(LinkXhibitCase).to receive(:call)
+        process_cases
+      end
 
       it "calls the `LinkXhibitCase` class" do
         expect(LinkXhibitCase).to have_received(:call).with(
@@ -53,8 +53,31 @@ RSpec.describe ProcessXhibitCases do
       end
     end
 
+    context "when LinkXhibitCase throws a validation error" do
+      let(:cassette) { "maat_api/search_maat_application_success" }
+
+      before do
+        allow(LinkXhibitCase).to receive(:call).and_raise(ActiveRecord::RecordInvalid, xhibit_case)
+        allow(xhibit_case).to receive(:errors).and_return(
+          instance_double(ActiveModel::Errors, full_messages: ["error message 1", "error message 2"]),
+        )
+        process_cases
+      end
+
+      it "stores the error on the case" do
+        expect(xhibit_case.reload.process_errors).to eq(
+          "message" => "Validation failed: error message 1, error message 2",
+        )
+      end
+    end
+
     context "when the maat application has an existing link" do
       let(:cassette) { "maat_api/search_maat_application_success_linked_result" }
+
+      before do
+        allow(LinkXhibitCase).to receive(:call)
+        process_cases
+      end
 
       it "does not call the `LinkXhibitCase` class" do
         expect(LinkXhibitCase).not_to have_received(:call)

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ProcessXhibitCases do
 
     it "stores a message on the case" do
       expect(xhibit_case.reload.process_errors).to eq(
-        "message" => "MAAT application not found",
+        "maat" => { "message" => "MAAT application not found" },
       )
     end
   end
@@ -36,6 +36,15 @@ RSpec.describe ProcessXhibitCases do
     include_context "with maat api cassette"
 
     let!(:xhibit_case) { create_case(first_name: "Tango", last_name: "JF-LAA-T") }
+    let(:defendant_summary) { instance_double(HmctsCommonPlatform::DefendantSummary) }
+    let(:prosecution_case) { instance_double(ProsecutionCase, body: {}, prosecution_case_reference: xhibit_case.case_urn) }
+
+    before do
+      allow(CommonPlatform::Api::SearchProsecutionCase).to receive(:call).and_return([prosecution_case])
+      allow(HmctsCommonPlatform::ProsecutionCaseSummary).to receive(:new).and_return(
+        instance_double(HmctsCommonPlatform::ProsecutionCaseSummary, defendant_summary:),
+      )
+    end
 
     context "when the maat application has no existing link" do
       let(:cassette) { "maat_api/search_maat_application_success" }
@@ -49,6 +58,27 @@ RSpec.describe ProcessXhibitCases do
         expect(LinkXhibitCase).to have_received(:call).with(
           an_instance_of(MaatApi::SearchResponse),
           xhibit_case,
+          defendant_summary,
+        )
+      end
+    end
+
+    context "when the case is not found on Common Platform" do
+      let(:cassette) { "maat_api/search_maat_application_success" }
+
+      before do
+        allow(CommonPlatform::Api::SearchProsecutionCase).to receive(:call).and_return([])
+        allow(LinkXhibitCase).to receive(:call)
+        process_cases
+      end
+
+      it "sets status to (manual) action_required" do
+        expect(xhibit_case.reload).to be_action_required
+      end
+
+      it "stores the error on the case" do
+        expect(xhibit_case.reload.process_errors).to eq(
+          "common_platform" => { "message" => "Case not found on Common Platform" },
         )
       end
     end
@@ -66,7 +96,27 @@ RSpec.describe ProcessXhibitCases do
 
       it "stores the error on the case" do
         expect(xhibit_case.reload.process_errors).to eq(
-          "message" => "Validation failed: error message 1, error message 2",
+          "link" => { "message" => "Validation failed: error message 1, error message 2" },
+        )
+      end
+    end
+
+    context "when LinkXhibitCase throws a non-Faraday error" do
+      let(:cassette) { "maat_api/search_maat_application_success" }
+
+      before do
+        allow(LinkXhibitCase).to receive(:call)
+          .and_raise(CommonPlatform::Api::Errors::FailedDependency, "Unsuccessful response from Common Platform")
+      end
+
+      it "stores the error on the case" do
+        process_cases
+
+        expect(xhibit_case.reload.process_errors).to eq(
+          "unexpected" => {
+            "error" => "CommonPlatform::Api::Errors::FailedDependency",
+            "message" => "Unsuccessful response from Common Platform",
+          },
         )
       end
     end
@@ -82,6 +132,16 @@ RSpec.describe ProcessXhibitCases do
       it "does not call the `LinkXhibitCase` class" do
         expect(LinkXhibitCase).not_to have_received(:call)
       end
+
+      it "sets status to (manual) action_required" do
+        expect(xhibit_case.reload).to be_action_required
+      end
+
+      it "stores the error on the case" do
+        expect(xhibit_case.reload.process_errors).to eq(
+          "maat" => { "message" => "MAAT application is already linked" },
+        )
+      end
     end
   end
 
@@ -96,8 +156,37 @@ RSpec.describe ProcessXhibitCases do
 
     it "stores the error on the case" do
       expect(xhibit_case.reload.process_errors).to eq(
-        "error" => "Faraday::ConnectionFailed", "message" => "connection refused",
+        "unexpected" => { "error" => "Faraday::ConnectionFailed", "message" => "connection refused" },
       )
+    end
+  end
+
+  context "when one case in the batch fails" do
+    let!(:failing_case) { create_case(first_name: "Failing", last_name: "Case") }
+    let!(:succeeding_case) { create_case(first_name: "Succeeding", last_name: "Case") }
+
+    let(:response) { instance_double(MaatApi::SearchResponse, success?: true, no_existing_link?: true) }
+
+    before do
+      allow(MaatApi::MaatApplicationSearcher).to receive(:call).and_return(response)
+      allow(CommonPlatform::Api::SearchProsecutionCase).to receive(:call).and_return(
+        [instance_double(ProsecutionCase, body: {}, prosecution_case_reference: failing_case.case_urn)],
+      )
+      allow(HmctsCommonPlatform::ProsecutionCaseSummary).to receive(:new).and_return(
+        instance_double(
+          HmctsCommonPlatform::ProsecutionCaseSummary,
+          defendant_summary: instance_double(HmctsCommonPlatform::DefendantSummary),
+        ),
+      )
+      allow(LinkXhibitCase).to receive(:call) do |_maat_response, xhibit_case, _defendant_summary|
+        raise CommonPlatform::Api::Errors::FailedDependency, "boom" if xhibit_case.id == failing_case.id
+      end
+      process_cases
+    end
+
+    it "still processes the remaining cases" do
+      expect(LinkXhibitCase).to have_received(:call).twice
+      expect(succeeding_case.reload.process_errors).to be_nil
     end
   end
 

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -35,11 +35,30 @@ RSpec.describe ProcessXhibitCases do
   context "when there is a matching maat application" do
     include_context "with maat api cassette"
 
-    let(:cassette) { "maat_api/search_maat_application_success" }
-    let(:xhibit_case) { create_case(first_name: "Tango", last_name: "JF-LAA-T") }
+    let!(:xhibit_case) { create_case(first_name: "Tango", last_name: "JF-LAA-T") }
 
-    it "process - WIP", skip: "processing a matching maat application is not implemented yet" do
+    before do
+      allow(LinkXhibitCase).to receive(:call)
       process_cases
+    end
+
+    context "when the maat application has no existing link" do
+      let(:cassette) { "maat_api/search_maat_application_success" }
+
+      it "calls the `LinkXhibitCase` class" do
+        expect(LinkXhibitCase).to have_received(:call).with(
+          an_instance_of(MaatApi::SearchResponse),
+          xhibit_case,
+        )
+      end
+    end
+
+    context "when the maat application has an existing link" do
+      let(:cassette) { "maat_api/search_maat_application_success_linked_result" }
+
+      it "does not call the `LinkXhibitCase` class" do
+        expect(LinkXhibitCase).not_to have_received(:call)
+      end
     end
   end
 

--- a/spec/services/prosecution_case_maat_link_creator_spec.rb
+++ b/spec/services/prosecution_case_maat_link_creator_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe ProsecutionCaseMaatLinkCreator do
         cjsAreaCode: "1",
         cjsLocation: "B01LY",
         createdUser: "bob-smith",
+        canUpdateLaaStatus: false,
       )
 
       expect(arg[:log_info]).to include(
@@ -80,6 +81,24 @@ RSpec.describe ProsecutionCaseMaatLinkCreator do
     end
 
     create_maat_link
+  end
+
+  context "when the LAA status can be updated" do
+    subject(:create_maat_link) do
+      described_class.call(defendant_id, user_name, maat_reference, can_update_laa_status: true)
+    end
+
+    it "flags it in the published message" do
+      allow(CommonPlatform::Api::RecordProsecutionCaseLaaReference)
+        .to receive(:call)
+        .and_return(response)
+
+      expect(Sqs::MessagePublisher).to receive(:call).once do |arg|
+        expect(arg[:message]).to include(canUpdateLaaStatus: true)
+      end
+
+      create_maat_link
+    end
   end
 
   context "with multiple offences" do

--- a/spec/services/xhibit_auto_linking_spec.rb
+++ b/spec/services/xhibit_auto_linking_spec.rb
@@ -1,0 +1,141 @@
+require "sidekiq/testing"
+
+RSpec.describe "XHIBIT auto-linking", type: :service do
+  subject(:process_cases) { ProcessXhibitCases.call }
+
+  let(:case_urn) { "61GD7528225" }
+  let(:prosecution_case_id) { "6fc1f2cb-4a93-4116-84db-f87cc86ec3b8" }
+  let(:defendant_id) { "cfc4281f-cdea-494d-8179-3173d30736fd" }
+  let(:first_offence_id) { "997ba1dd-e1e2-46cb-ad4d-2c570af869cd" }
+  let(:second_offence_id) { "9085871a-797b-4ab8-8072-05ca6deeaac9" }
+  let(:maat_id) { 6_559_879 }
+
+  let!(:xhibit_case) { create(:xhibit_migrated_case, case_urn:, defendant_id:, case_type: "T") }
+
+  let(:maat_api_cassette) do
+    {
+      name: "maat_api/search_maat_application_success",
+      options: { tag: :maat_api, match_requests_on: %i[method uri] },
+    }
+  end
+
+  let(:prosecution_case_cassette) do
+    { name: "search_prosecution_case/by_prosecution_case_reference_success_v2" }
+  end
+
+  let(:laa_reference_cassette) { { name: laa_reference_cassette_name } }
+
+  before do
+    # The service processes every pending case, so the cassettes only add up if
+    # this is the only one in the table.
+    XhibitMigratedCase.where.not(id: xhibit_case.id).delete_all
+
+    allow(Sqs::MessagePublisher).to receive(:call)
+  end
+
+  around do |example|
+    Sidekiq::Testing.fake! do
+      VCR.use_cassettes([maat_api_cassette,
+                         prosecution_case_cassette,
+                         laa_reference_cassette]) { example.run }
+    end
+  end
+
+  context "when every offence is linked" do
+    let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_success" }
+
+    it "retrieves the offences associated with the defendant" do
+      process_cases
+
+      expect(ProsecutionCaseDefendantOffence.where(defendant_id:).pluck(:offence_id))
+        .to contain_exactly(first_offence_id, second_offence_id)
+    end
+
+    it "posts an LAA reference to Common Platform for each offence" do
+      process_cases
+
+      expect(a_request(:post, %r{/laaReference/cases/#{prosecution_case_id}/defendant/#{defendant_id}/offences/#{first_offence_id}}))
+        .to have_been_made.once
+      expect(a_request(:post, %r{/laaReference/cases/#{prosecution_case_id}/defendant/#{defendant_id}/offences/#{second_offence_id}}))
+        .to have_been_made.once
+    end
+
+    it "records the Common Platform response against each offence" do
+      process_cases
+
+      expect(ProsecutionCaseDefendantOffence.where(defendant_id:).pluck(:rep_order_status, :response_status))
+        .to eq([%w[AP].push(202), %w[AP].push(202)])
+    end
+
+    it "creates a link between the MAAT application and the Common Platform case" do
+      process_cases
+
+      expect(LaaReference.find_by(defendant_id:)).to have_attributes(
+        maat_reference: maat_id.to_s,
+        user_name: User::SYSTEM_USERNAME,
+        linked: true,
+      )
+    end
+
+    it "marks the xhibit case as linked" do
+      process_cases
+
+      expect(xhibit_case.reload).to be_auto_linked
+      expect(xhibit_case).to have_attributes(
+        maat_id: maat_id.to_s,
+        linked_by: User::SYSTEM_USERNAME,
+        linked_at: within(1.minute).of(Time.zone.now),
+      )
+    end
+
+    it "publishes one MAAT link message with LAA status reinstatement enabled" do
+      process_cases
+
+      expect(Sqs::MessagePublisher).to have_received(:call).with(
+        message: hash_including(
+          maatId: maat_id.to_s,
+          canUpdateLaaStatus: true,
+        ),
+        queue_url: Rails.configuration.x.aws.sqs_url_link,
+        log_info: { maat_reference: maat_id.to_s },
+      ).once
+    end
+  end
+
+  context "when one offence fails to link" do
+    let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_offence_failure" }
+
+    it "still attempts the offence Common Platform rejects" do
+      process_cases
+
+      expect(a_request(:post, %r{/laaReference/cases/#{prosecution_case_id}/defendant/#{defendant_id}/offences/#{second_offence_id}}))
+        .to have_been_made.once
+    end
+
+    it "does not mark the xhibit case as linked" do
+      process_cases
+
+      expect(xhibit_case.reload).to be_pending
+      expect(xhibit_case).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
+    end
+
+    it "does not create the link" do
+      process_cases
+
+      expect(LaaReference.find_by(defendant_id:)).to be_nil
+    end
+
+    it "records the failure on the xhibit case" do
+      process_cases
+
+      expect(xhibit_case.reload.process_errors["unexpected"])
+        .to include("error" => "CommonPlatform::Api::Errors::FailedDependency")
+    end
+
+    it "does not publish a MAAT link message" do
+      process_cases
+
+      expect(Sqs::MessagePublisher).not_to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LAACONNECT-1357)

Describe what you did and why.

## Checklist

This handles the "happy path" for auto-linking when the MAAT API returns one result for an imported case. If this is the case we:

- Call `CourtApplicationMaatLinkCreator` (which updates the MAAT ID in Common Platform and posts a link message to the SQS MAAT queue)
- Updates the xhbit case record, setting the `status` to `AUTO_LINKED`, `linked_date` to the current timestamp, and `linked_by `to `SYSTEM`.
