### PR TITLE
(LAACONNECT-1498) Route LAA Status Update API Calls Based on With/Without Offences

### DIFF
--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -9,6 +9,10 @@ class CourtApplication < ApplicationRecord
     body["hearingSummary"]
   end
 
+  def has_offences?
+    body.dig("subjectSummary", "offenceSummary")&.present?
+  end
+
   def appeal?
     application_type = body["applicationType"]
     category = SupportedCourtApplicationTypes.get_category_by_code(application_type)

--- a/app/services/common_platform/api/record_application_representation_order_with_offence.rb
+++ b/app/services/common_platform/api/record_application_representation_order_with_offence.rb
@@ -2,9 +2,9 @@
 
 module CommonPlatform
   module Api
-    class RecordApplicationRepresentationOrderForAppeal < ApplicationService
+    class RecordApplicationRepresentationOrderWithOffence < ApplicationService
       # This records via Common Platform API a representation order
-      # for 'appeal' applications
+      # against a specific offence
 
       def initialize(court_application_id:,
                      subject_id:,

--- a/app/services/common_platform/api/record_application_representation_order_without_offence.rb
+++ b/app/services/common_platform/api/record_application_representation_order_without_offence.rb
@@ -2,9 +2,9 @@
 
 module CommonPlatform
   module Api
-    class RecordApplicationRepresentationOrderForBreach < ApplicationService
+    class RecordApplicationRepresentationOrderWithoutOffence < ApplicationService
       # This records via Common Platform API a representation order
-      # for application in the 'breach' and 'poca' categories
+      # for an application without offences
 
       def initialize(court_application_id:,
                      status_code:,

--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -46,30 +46,36 @@ module CommonPlatform
       end
 
       def record_court_application_representation_order(court_application)
-        if court_application.appeal?
+        if court_application.has_offences?
           offences.each do |offence|
-            params = offence.merge(
+            # Call CP API /prosecutionCases/representationOrder/applications/.../subject/.../offences/...
+            CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence.call(
               court_application_id: court_application.id,
               subject_id: defendant_id,
+              offence_id: offence[:offence_id],
+              status_code: offence[:status_code],
               application_reference: maat_reference,
+              status_date: offence[:status_date],
+              effective_start_date: offence[:effective_start_date],
               defence_organisation:,
+              effective_end_date: offence[:effective_end_date],
             )
-
-            # Call CP API /prosecutionCases/representationOrder/applications/.../subject/.../offences/...
-            CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence.call(**params)
           end
         else
-          offence = offences.first    # Breach or POCA contains only a Dummy offence
-          offence.delete(:offence_id) # Dummy id, not required for this call
-
-          params = offence.merge(
-            court_application_id: court_application.id,
-            application_reference: maat_reference,
-            defence_organisation:,
-          )
+          # If there are no offences present in CP, then we know the offence we have is a dummy offence, so we can
+          # use the first one to create the representation order without an offence
+          dummy_offence = offences.first
 
           # Call CP API /prosecutionCases/representationOrder/applications/...
-          CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence.call(**params.deep_symbolize_keys)
+          CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence.call(
+            court_application_id: court_application.id,
+            status_code: dummy_offence[:status_code],
+            application_reference: maat_reference,
+            status_date: dummy_offence[:status_date],
+            effective_start_date: dummy_offence[:effective_start_date],
+            defence_organisation:,
+            effective_end_date: dummy_offence[:effective_end_date],
+          )
         end
       end
 

--- a/app/services/common_platform/api/representation_order_creator.rb
+++ b/app/services/common_platform/api/representation_order_creator.rb
@@ -56,7 +56,7 @@ module CommonPlatform
             )
 
             # Call CP API /prosecutionCases/representationOrder/applications/.../subject/.../offences/...
-            CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal.call(**params)
+            CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence.call(**params)
           end
         else
           offence = offences.first    # Breach or POCA contains only a Dummy offence
@@ -69,7 +69,7 @@ module CommonPlatform
           )
 
           # Call CP API /prosecutionCases/representationOrder/applications/...
-          CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach.call(**params.deep_symbolize_keys)
+          CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence.call(**params.deep_symbolize_keys)
         end
       end
 

--- a/spec/models/court_application_spec.rb
+++ b/spec/models/court_application_spec.rb
@@ -1,17 +1,71 @@
 # frozen_string_literal: true
 
 RSpec.describe CourtApplication, type: :model do
-  subject(:court_application) { described_class.new(body: { applicationType: application_type }) }
+  let(:court_application) { described_class.new(body:) }
 
-  context "when category is appeal" do
-    let(:application_type) { "MC80801" }
+  describe "appeal?" do
+    subject { court_application.appeal? }
 
-    it { expect(court_application.appeal?).to be(true) }
+    let(:body) { { applicationType: application_type } }
+
+    context "when category is appeal" do
+      let(:application_type) { "MC80801" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when category is breach" do
+      let(:application_type) { "CJ03510" }
+
+      it { is_expected.to be_falsey }
+    end
   end
 
-  context "when category is breach" do
-    let(:application_type) { "CJ03510" }
+  describe "has_offences?" do
+    subject { court_application.has_offences? }
 
-    it { expect(court_application.appeal?).to be(false) }
+    context "when offenceSummary contains an offence" do
+      let(:body) do
+        {
+          subjectSummary: {
+            offenceSummary: [
+              {
+                something: "here",
+              },
+            ],
+          },
+        }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when offenceSummary is empty" do
+      let(:body) do
+        {
+          subjectSummary: {
+            offenceSummary: [],
+          },
+        }
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when offenceSummary does not exist" do
+      let(:body) do
+        {
+          subjectSummary: {},
+        }
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when subjectSummary does not exist" do
+      let(:body) { {} }
+
+      it { is_expected.to be_falsey }
+    end
   end
 end

--- a/spec/services/common_platform/api/record_application_representation_order_with_offence_spec.rb
+++ b/spec/services/common_platform/api/record_application_representation_order_with_offence_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal do
+RSpec.describe CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence do
   subject(:record_representation_order) do
     described_class.call(
       court_application_id: court_application.id,

--- a/spec/services/common_platform/api/record_application_representation_order_without_offence_spec.rb
+++ b/spec/services/common_platform/api/record_application_representation_order_without_offence_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach do
+RSpec.describe CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence do
   subject(:record_representation_order) do
     described_class.call(
       court_application_id: court_application.id,

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -53,14 +53,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
 
   context "when there is no court application" do
     it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
-      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+      allow(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
         .to receive(:call)
-        .once
-        .with(hash_including(application_reference: maat_reference,
-                             defendant_id:,
-                             defence_organisation: transformed_defence_organisation))
 
       create_rep_order
+
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+          .to have_received(:call).once
+                                  .with(hash_including(application_reference: maat_reference,
+                                                       defendant_id:,
+                                                       defence_organisation: transformed_defence_organisation))
     end
   end
 
@@ -77,14 +79,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       end
 
       it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence service once" do
-        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence)
-          .to receive(:call)
-          .once
-          .with(hash_including(application_reference: maat_reference,
-                               subject_id: defendant_id,
-                               defence_organisation: transformed_defence_organisation))
+        allow(CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence).to receive(:call)
 
         create_rep_order
+
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence)
+          .to have_received(:call)
+                .once
+                .with(hash_including(application_reference: maat_reference,
+                                     subject_id: defendant_id,
+                                     defence_organisation: transformed_defence_organisation))
       end
     end
 
@@ -92,13 +96,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       let(:offence_summary) { [] }
 
       it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence service once" do
-        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
+        allow(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
           .to receive(:call)
-          .once
-          .with(hash_including(application_reference: maat_reference,
-                               defence_organisation: transformed_defence_organisation))
 
         create_rep_order
+
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
+          .to have_received(:call)
+                .once
+                .with(hash_including(application_reference: maat_reference,
+                                     defence_organisation: transformed_defence_organisation))
       end
 
       context "when no offence has a status date" do
@@ -128,15 +135,16 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       }
     end
 
-    let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
-
     it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence service without offence ID" do
-      expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
+      allow(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
         .to receive(:call)
-        .once
-        .with(hash_not_including(:offence_id))
 
       create_rep_order
+
+      expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
+        .to have_received(:call)
+              .once
+              .with(hash_not_including(:offence_id))
     end
   end
 
@@ -159,16 +167,36 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
 
     it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service twice" do
-      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).twice.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      allow(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call)
+
       create_rep_order
+
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+        .to have_received(:call)
+       .twice
+       .with(hash_including(
+               application_reference: maat_reference,
+               defence_organisation: transformed_defence_organisation,
+             ))
     end
 
     context "when one offence does not have a status date" do
       before { offence_two.delete(:status_date) }
 
       it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
-        expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+        allow(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call)
+
         create_rep_order
+
+        expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+          .to have_received(:call)
+                .once
+                .with(
+                  hash_including(
+                    application_reference: maat_reference,
+                    defence_organisation: transformed_defence_organisation,
+                  ),
+                )
       end
     end
   end
@@ -185,8 +213,19 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
 
     it "calls the CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder service once" do
-      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      allow(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call)
+
       create_rep_order
+
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+        .to have_received(:call)
+        .once
+        .with(
+          hash_including(
+            application_reference: maat_reference,
+            defence_organisation: transformed_defence_organisation,
+          ),
+        )
     end
   end
 
@@ -223,8 +262,19 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     end
 
     it "sanitises the data" do
-      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call).once.with(hash_including(application_reference: maat_reference, defence_organisation: transformed_defence_organisation))
+      allow(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder).to receive(:call)
+
       create_rep_order
+
+      expect(CommonPlatform::Api::RecordProsecutionCaseRepresentationOrder)
+        .to have_received(:call)
+              .once
+              .with(
+                hash_including(
+                  application_reference: maat_reference,
+                  defence_organisation: transformed_defence_organisation,
+                ),
+              )
     end
   end
 end

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     context "when this is for an appeal application" do
       let(:application_type) { "MC80801" } # This is an appeal code. See supported_court_application_types.yaml
 
-      it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal service once" do
-        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal)
+      it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence service once" do
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence)
           .to receive(:call)
           .once
           .with(hash_including(application_reference: maat_reference,
@@ -87,8 +87,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
     context "when this is for a breach or poca application" do
       let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
 
-      it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach service once" do
-        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach)
+      it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence service once" do
+        expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
           .to receive(:call)
           .once
           .with(hash_including(application_reference: maat_reference,
@@ -100,8 +100,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       context "when no offence has a status date" do
         before { offence_one.delete(:status_date) }
 
-        it "does not call the CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach service" do
-          expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach).not_to receive(:call)
+        it "does not call the CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence service" do
+          expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence).not_to receive(:call)
 
           expect { create_rep_order }.not_to raise_error
         end
@@ -126,8 +126,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
 
     let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
 
-    it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderForAppeal service without offence ID" do
-      expect(CommonPlatform::Api::RecordApplicationRepresentationOrderForBreach)
+    it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence service without offence ID" do
+      expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)
         .to receive(:call)
         .once
         .with(hash_not_including(:offence_id))

--- a/spec/services/common_platform/api/representation_order_creator_spec.rb
+++ b/spec/services/common_platform/api/representation_order_creator_spec.rb
@@ -66,11 +66,15 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
 
   context "when this is for a court application" do
     before do
-      create(:court_application, subject_id: defendant_id, body: { applicationType: application_type })
+      create(:court_application, subject_id: defendant_id, body: { subjectSummary: { offenceSummary: offence_summary } })
     end
 
-    context "when this is for an appeal application" do
-      let(:application_type) { "MC80801" } # This is an appeal code. See supported_court_application_types.yaml
+    context "when the application has an offence in the offence summary" do
+      let(:offence_summary) do
+        [
+          { something: "here" },
+        ]
+      end
 
       it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence service once" do
         expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithOffence)
@@ -84,8 +88,8 @@ RSpec.describe CommonPlatform::Api::RepresentationOrderCreator do
       end
     end
 
-    context "when this is for a breach or poca application" do
-      let(:applycation_type) { "CJ03510" } # This is an Breach code. See supported_court_application_types.yaml
+    context "when application has no offences in the offence summary" do
+      let(:offence_summary) { [] }
 
       it "calls the CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence service once" do
         expect(CommonPlatform::Api::RecordApplicationRepresentationOrderWithoutOffence)


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LAACONNECT-1498)

Under the original agreement with HMCTS:

- Appeal applications were expected to always contain offences.
- Breach and POCA applications were expected to never contain offences.

Based on these business rules, we used the application type to determine LAA Status Update API should be called.

However, during end-to-end testing of DLRM-migrated cases, we identified a Breach application that contained offence data. HMCTS subsequently confirmed that exceptions to the original business rules were required to support the migration of cases from XHIBIT to Common Platform.

This PR therefore changes the logic to inspect the body of an application - if it contains offences, we loop through the offences we have been given by MLRA and make a call to Common Platform for each offence. If it does not contain offences, we know that the offence we have been given is a dummy offence, and we use this to build the payload and call the API endpoint without offences.
