### PR TITLE
ACD-1508: alert when a court centre code cannot be resolved

### DIFF
--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -12,11 +12,4 @@ class CourtApplication < ApplicationRecord
   def has_offences?
     body.dig("subjectSummary", "offenceSummary")&.present?
   end
-
-  def appeal?
-    application_type = body["applicationType"]
-    category = SupportedCourtApplicationTypes.get_category_by_code(application_type)
-
-    category == "appeal"
-  end
 end

--- a/app/models/hmcts_common_platform/court_centre.rb
+++ b/app/models/hmcts_common_platform/court_centre.rb
@@ -45,7 +45,7 @@ module HmctsCommonPlatform
     end
 
     def code
-      data[:code] || CourtCentreCodeLookup.find(id)
+      data[:code].presence || lookup_code
     end
 
     def address
@@ -57,6 +57,14 @@ module HmctsCommonPlatform
     end
 
   private
+
+    def lookup_code
+      Sentry.capture_message("Court centre code is null for #{id} (#{name})", level: :warning)
+
+      CourtCentreCodeLookup.find(id).tap do |court_centre|
+        Sentry.capture_message("Court centre code not present in the 'organisation_unit.csv'. id:#{id} - name:#{name}", level: :error) unless court_centre
+      end
+    end
 
     def to_builder
       Jbuilder.new do |court_centre|

--- a/spec/models/court_application_spec.rb
+++ b/spec/models/court_application_spec.rb
@@ -3,24 +3,6 @@
 RSpec.describe CourtApplication, type: :model do
   let(:court_application) { described_class.new(body:) }
 
-  describe "appeal?" do
-    subject { court_application.appeal? }
-
-    let(:body) { { applicationType: application_type } }
-
-    context "when category is appeal" do
-      let(:application_type) { "MC80801" }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context "when category is breach" do
-      let(:application_type) { "CJ03510" }
-
-      it { is_expected.to be_falsey }
-    end
-  end
-
   describe "has_offences?" do
     subject { court_application.has_offences? }
 

--- a/spec/models/hmcts_common_platform/court_centre_spec.rb
+++ b/spec/models/hmcts_common_platform/court_centre_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
   end
 
   describe "when there is no code" do
-    let(:data) { { "id" => id } }
+    let(:data) { { "id" => id, "name" => "Derby Justice Centre" } }
+
+    before { allow(Sentry).to receive(:capture_message) }
 
     context "when ID is recognised" do
       let(:id) { "14876ea1-5f7c-32ef-9fbd-aa0b63193550" }
@@ -60,6 +62,20 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
       it { expect(court_centre.code).to eq("B30PI00") }
       it { expect(court_centre.short_oucode).to eq("B30PI") }
       it { expect(court_centre.oucode_l2_code).to eq("30") }
+
+      it "reports a warning to Sentry" do
+        court_centre.code
+
+        expect(Sentry).to have_received(:capture_message).with(
+          "Court centre code is null for #{id} (Derby Justice Centre)", level: :warning
+        )
+      end
+
+      it "does not report an error to Sentry" do
+        court_centre.code
+
+        expect(Sentry).not_to have_received(:capture_message).with(anything, level: :error)
+      end
     end
 
     context "when ID is not recognised" do
@@ -68,6 +84,14 @@ RSpec.describe HmctsCommonPlatform::CourtCentre, type: :model do
       it { expect(court_centre.code).to be_nil }
       it { expect(court_centre.short_oucode).to be_nil }
       it { expect(court_centre.oucode_l2_code).to be_nil }
+
+      it "reports an error to Sentry" do
+        court_centre.code
+
+        expect(Sentry).to have_received(:capture_message).with(
+          /Court centre code not present/, level: :error
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This adds visibility, **not a fix**: 

- a Sentry warning when Common Platform omits the code
- and a Sentry error when it cannot be resolved from our reference data either.