### PR TITLE
1358: implement auto-linking sceneario for MAAT application linked to a common platform case

### DIFF
--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -1,5 +1,7 @@
 module MaatApi
   class SearchResponse
+    COMMON_PLATFORM_PREFIX = "CP".freeze
+
     def initialize(http_response)
       @http_response = http_response
     end
@@ -24,8 +26,16 @@ module MaatApi
       response["maatId"]
     end
 
-    def no_existing_link?
-      !is_linked? && !libra_id && !case_urn
+    def existing_link?
+      is_linked? || libra_id.present? || case_urn.present?
+    end
+
+    def linked_to_common_platform?
+      libra_id.to_s.start_with?(COMMON_PLATFORM_PREFIX) && case_urn.present?
+    end
+
+    def linked_case_urn
+      case_urn
     end
 
   private

--- a/app/services/maat_api/maat_application_searcher.rb
+++ b/app/services/maat_api/maat_application_searcher.rb
@@ -19,11 +19,11 @@ module MaatApi
                           niNumber: national_insurance_number,
                           asn: arrest_summons_number,
                           committalDate: committal_date,
-                          caseType: case_type }.compact
+                          caseType: case_type }
     end
 
     def call
-      MaatApi::SearchResponse.new(@connection.post(URL, @search_request))
+      MaatApi::SearchResponse.new(@connection.post(URL, @search_request.compact_blank))
     end
   end
 end

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -29,10 +29,20 @@ private
   end
 
   def handle_success(response, xhibit_case)
-    return handle_existing_link(xhibit_case) unless response.no_existing_link?
+    if response.existing_link?
+      xhibit_case.action_required!
+      record_error(xhibit_case, :maat, message: existing_link_message(response))
+      return
+    end
 
     defendant_summary = fetch_defendant_summary(xhibit_case)
-    return handle_not_on_common_platform(xhibit_case) if defendant_summary.nil?
+
+    if defendant_summary.nil?
+      # Handle not on common_platform
+      xhibit_case.action_required!
+      record_error(xhibit_case, :common_platform, message: "Case not found on Common Platform")
+      return
+    end
 
     LinkXhibitCase.call(response, xhibit_case, defendant_summary)
   rescue ActiveRecord::RecordInvalid => e
@@ -69,14 +79,12 @@ private
     record_error(xhibit_case, :maat, message: "MAAT application not found")
   end
 
-  def handle_existing_link(xhibit_case)
-    xhibit_case.action_required!
-    record_error(xhibit_case, :maat, message: "MAAT application is already linked")
-  end
-
-  def handle_not_on_common_platform(xhibit_case)
-    xhibit_case.action_required!
-    record_error(xhibit_case, :common_platform, message: "Case not found on Common Platform")
+  def existing_link_message(response)
+    if response.linked_to_common_platform?
+      "MAAT ID already linked with other CP case (#{response.linked_case_urn})"
+    else
+      "MAAT application is already linked"
+    end
   end
 
   # Errors are keyed by step and merged, so that a failure in one step does not

--- a/spec/cassettes/maat_api/search_maat_application_linked_to_cp_case.yml
+++ b/spec/cassettes/maat_api/search_maat_application_linked_to_cp_case.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: <MAAT_API_OAUTH_URL>/oauth2/token
+      body:
+        encoding: UTF-8
+        string: grant_type=client_credentials
+      headers:
+        User-Agent:
+          - Faraday v2.14.3
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Authorization:
+          - "<AUTH>"
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        Date:
+          - Fri, 31 Jul 2026 15:22:22 GMT
+        Content-Type:
+          - application/json;charset=UTF-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        X-Amz-Cognito-Request-Id:
+          - 6b1d4aa5-d0b5-4a2a-b7e1-f12918b68e85
+        Vary:
+          - Access-Control-Request-Headers
+          - Access-Control-Request-Method
+          - Origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - "0"
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Pragma:
+          - no-cache
+        Expires:
+          - "0"
+        Strict-Transport-Security:
+          - max-age=31536000 ; includeSubDomains
+        X-Frame-Options:
+          - DENY
+        Server:
+          - Server
+      body:
+        encoding: UTF-8
+        string: '{"access_token":"<access_token>","expires_in":3600,"token_type":"Bearer"}'
+    recorded_at: Fri, 31 Jul 2026 15:22:22 GMT
+  - request:
+      method: post
+      uri: <MAAT_API_API_URL>/api/internal/v1/assessment/rep-orders/search-maat-application
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Tango","lastName":"JF-LAA-T"}'
+      headers:
+        User-Agent:
+          - Faraday v2.14.3
+        Authorization:
+          - "<AUTH>"
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        Date:
+          - Fri, 31 Jul 2026 15:22:23 GMT
+        Content-Type:
+          - application/json
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Set-Cookie:
+          - INGRESSCOOKIE=1785511343.432.31305.664596|55b9a069646b5e4eb9ec5bafd08dbaec;
+            Max-Age=300; Path=/; Secure; HttpOnly
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - "0"
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Pragma:
+          - no-cache
+        Expires:
+          - "0"
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        X-Frame-Options:
+          - DENY
+      body:
+        encoding: UTF-8
+        string: '[{"maatId":6559879,"linkingDetail":{"libraId":"CP0001","caseUrn":"01AB1234567"},"isLinked":true}]'
+    recorded_at: Fri, 31 Jul 2026 15:22:23 GMT
+recorded_with: VCR 6.4.0

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -108,86 +108,166 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
     end
   end
 
-  describe "#no_existing_link?" do
-    it "returns true when is_linked is false, libra_id is nil, and case_urn is nil" do
+  describe "#existing_link?" do
+    it "returns false when is_linked is false, libra_id is nil, and case_urn is nil" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => {} },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
     end
 
-    it "returns true when response is empty" do
+    it "returns false when response is empty" do
       http_response = instance_double(Faraday::Response, status: 200, body: [{}])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
     end
 
-    it "returns false when is_linked is true" do
+    it "returns true when is_linked is true" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => true, "linkingDetail" => {} },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be false
+      expect(response.existing_link?).to be true
     end
 
-    it "returns false when libra_id is present" do
+    it "returns true when libra_id is present" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123" } },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be false
+      expect(response.existing_link?).to be true
     end
 
-    it "returns false when case_urn is present" do
+    it "returns true when case_urn is present" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "caseUrn" => "URN123" } },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be false
+      expect(response.existing_link?).to be true
     end
 
-    it "returns false when both libra_id and case_urn are present" do
+    it "returns true when both libra_id and case_urn are present" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => false, "linkingDetail" => { "libraId" => "LIBRA123", "caseUrn" => "URN123" } },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be false
+      expect(response.existing_link?).to be true
     end
 
-    it "returns true when body is empty array" do
+    it "returns false when libra_id is blank" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => { "libraId" => "", "caseUrn" => nil } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.existing_link?).to be false
+    end
+
+    it "returns false when case_urn is blank" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => false, "linkingDetail" => { "libraId" => nil, "caseUrn" => "" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.existing_link?).to be false
+    end
+
+    it "returns false when body is empty array" do
       http_response = instance_double(Faraday::Response, status: 200, body: [])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
     end
 
-    it "returns true when body is nil" do
+    it "returns false when body is nil" do
       http_response = instance_double(Faraday::Response, status: 200, body: nil)
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
     end
 
-    it "returns true when http_response is nil" do
+    it "returns false when http_response is nil" do
       response = described_class.new(nil)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
     end
 
-    it "returns true when is_linked is present but not strictly true" do
+    it "returns false when is_linked is present but not strictly true" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => "yes", "linkingDetail" => {} },
       ])
       response = described_class.new(http_response)
 
-      expect(response.no_existing_link?).to be true
+      expect(response.existing_link?).to be false
+    end
+  end
+
+  describe "#linked_to_common_platform?" do
+    it "returns true when the libra id carries the CP prefix and a case urn is present" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => "01AB1234567" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_common_platform?).to be true
+    end
+
+    it "returns false when the libra id does not carry the CP prefix" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "LIBRA123", "caseUrn" => "01AB1234567" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_common_platform?).to be false
+    end
+
+    it "returns false when the case urn is missing" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "CP0001" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_common_platform?).to be false
+    end
+
+    it "returns false when there is no linking detail" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => nil },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_common_platform?).to be false
+    end
+
+    it "returns false when http_response is nil" do
+      response = described_class.new(nil)
+
+      expect(response.linked_to_common_platform?).to be false
+    end
+  end
+
+  describe "#linked_case_urn" do
+    it "returns the case urn the MAAT application is linked to" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => "01AB1234567" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_case_urn).to eq("01AB1234567")
+    end
+
+    it "returns nil when there is no linking detail" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [{ "isLinked" => true }])
+      response = described_class.new(http_response)
+
+      expect(response.linked_case_urn).to be_nil
     end
   end
 end

--- a/spec/services/maat_api/maat_application_searcher_spec.rb
+++ b/spec/services/maat_api/maat_application_searcher_spec.rb
@@ -32,6 +32,28 @@ RSpec.describe MaatApi::MaatApplicationSearcher do
     end
   end
 
+  context "when search criteria have blank values" do
+    let(:cassette) { "" } # Cassette is not necessary here
+    let(:connection) { instance_double(Faraday::Connection, post: nil) }
+    let(:criteria) do
+      { first_name: "Tango",
+        last_name: "JF-LAA-T",
+        date_of_birth: nil,
+        arrest_summons_number: "",
+        committal_date: "",
+        connection: }
+    end
+
+    it "omits them from the search request" do
+      search_response
+
+      expect(connection).to have_received(:post).with(
+        described_class::URL,
+        { firstName: "Tango", lastName: "JF-LAA-T" },
+      )
+    end
+  end
+
   context "when there is no matching maat application" do
     let(:cassette) { "maat_api/search_maat_application_not_found" }
     let(:criteria) { { first_name: "nonexistent-first-name", last_name: "nonexistent-last-name" } }

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -149,6 +149,33 @@ RSpec.describe ProcessXhibitCases do
         )
       end
     end
+
+    context "when the MAAT application is already linked to a Common Platform case" do
+      let(:cassette) { "maat_api/search_maat_application_linked_to_cp_case" }
+
+      before do
+        allow(LinkXhibitCase).to receive(:call)
+        process_cases
+      end
+
+      it "does not call the `LinkXhibitCase` class" do
+        expect(LinkXhibitCase).not_to have_received(:call)
+      end
+
+      it "sets status to (manual) action_required" do
+        expect(xhibit_case.reload).to be_action_required
+      end
+
+      it "leaves the case unlinked" do
+        expect(xhibit_case.reload).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
+      end
+
+      it "stores the error on the case" do
+        expect(xhibit_case.reload.process_errors).to eq(
+          "maat" => { "message" => "MAAT ID already linked with other CP case (01AB1234567)" },
+        )
+      end
+    end
   end
 
   context "when the search fails" do
@@ -171,7 +198,7 @@ RSpec.describe ProcessXhibitCases do
     let!(:failing_case) { create_case(first_name: "Failing", last_name: "Case") }
     let!(:succeeding_case) { create_case(first_name: "Succeeding", last_name: "Case") }
 
-    let(:response) { instance_double(MaatApi::SearchResponse, success?: true, no_existing_link?: true) }
+    let(:response) { instance_double(MaatApi::SearchResponse, success?: true, existing_link?: false) }
 
     before do
       allow(MaatApi::MaatApplicationSearcher).to receive(:call).and_return(response)

--- a/spec/services/xhibit_auto_linking_spec.rb
+++ b/spec/services/xhibit_auto_linking_spec.rb
@@ -138,4 +138,42 @@ RSpec.describe "XHIBIT auto-linking", type: :service do
       expect(Sqs::MessagePublisher).not_to have_received(:call)
     end
   end
+
+  context "when the MAAT application is already linked to another Common Platform case" do
+    let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_success" }
+
+    let(:maat_api_cassette) do
+      {
+        name: "maat_api/search_maat_application_linked_to_cp_case",
+        options: { tag: :maat_api, match_requests_on: %i[method uri] },
+      }
+    end
+
+    it "flags the case for manual action with the linked case URN" do
+      process_cases
+
+      expect(xhibit_case.reload).to be_action_required
+      expect(xhibit_case.process_errors).to eq(
+        "maat" => { "message" => "MAAT ID already linked with other CP case (01AB1234567)" },
+      )
+    end
+
+    it "leaves the case unlinked" do
+      process_cases
+
+      expect(xhibit_case.reload).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
+    end
+
+    it "does not post an LAA reference to Common Platform" do
+      process_cases
+
+      expect(a_request(:post, %r{/laaReference/})).not_to have_been_made
+    end
+
+    it "does not publish a MAAT link message" do
+      process_cases
+
+      expect(Sqs::MessagePublisher).not_to have_received(:call)
+    end
+  end
 end


### PR DESCRIPTION
The specific implementation details for this scenario can be found in the documented technical implementation ([DLRM Implementation Analysis | Scenario 2: MAAT record found, already linked to a Common Platform case](https://dsdmoj.atlassian.net/wiki/spaces/ACD2/pages/6092227492/DLRM+Implementation+Analysis#Scenario-2%3A-MAAT-record-found%2C-already-linked-to-a-Common-Platform-case) ).

To summarise what this says:

    update the corresponding row in the xhibit_migrated_cases table with the following information:

        status: MANUAL_ACTION_REQUIRED

        error_message: MAAT ID already linked with other CP case ({caseUrn})

A MAAT application can be determined to be linked to an existing Common Platform case so long as the libraId field contains the CP prefix and the caseUrn field is not null or empty.