### PR TITLE
Point UAT to HMCTS dev for civil proceedings testing

### DIFF
--- a/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
+++ b/helm_deploy/laa-court-data-adaptor/public-values/uat.yaml
@@ -16,7 +16,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-common_platform_url: https://apigw.sit.cjscp.org.uk/LAA/V1
+common_platform_url: https://apigw.dev.cjscp.org.uk/LAA/V1
 sqs_region: eu-west-2
 sqs_messaging_enabled: true
 maat_api:


### PR DESCRIPTION
This PR points CDA UAT to the HMCTS dev environment which they are using specifically for civil proceedings testing.