### PR TITLE
Fix Circle CI deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orbs:
 executors:
   newman-latest:
     docker:
-      - image: postman/newman:latest
+      - image: postman/newman:6.1.3-alpine
   snyk-executor:
     working_directory: ~/repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,8 @@ jobs:
             --build-arg APP_BRANCH=${CIRCLE_BRANCH}
 
   install_on_dev_live:
-    executor: aws-eks/python
+    docker:
+      - image: cimg/python:3.12
     steps:
       - checkout_and_decrypt
       - kubernetes/install-kubectl
@@ -176,7 +177,8 @@ jobs:
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_test_live:
-    executor: aws-eks/python
+    docker:
+      - image: cimg/python:3.12
     steps:
       - checkout_and_decrypt
       - kubernetes/install-kubectl
@@ -201,7 +203,8 @@ jobs:
           values-to-override: image.tag=$CIRCLE_SHA1
 
   install_on_uat_live:
-    executor: aws-eks/python
+    docker:
+      - image: cimg/python:3.12
     steps:
       - checkout_and_decrypt
       - kubernetes/install-kubectl
@@ -223,7 +226,8 @@ jobs:
             .circleci/deploy.sh laa-court-data-adaptor-uat ./helm_deploy/laa-court-data-adaptor/public-values/uat.yaml $CIRCLE_SHA1
 
   install_on_prod_live:
-    executor: aws-eks/python
+    docker:
+      - image: cimg/python:3.12
     steps:
       - checkout_and_decrypt
       - kubernetes/install-kubectl


### PR DESCRIPTION
We're seeing the following error when trying to deploy to any environment:

```
Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
Get:2 http://security.debian.org/debian-security bullseye-security InRelease [27.2 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
Get:5 http://deb.debian.org/debian bullseye-updates/main amd64 Packages.diff/Index [26.3 kB]
Ign:5 http://deb.debian.org/debian bullseye-updates/main amd64 Packages.diff/Index
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
Reading package lists... Done                              
N: Repository 'http://deb.debian.org/debian bullseye InRelease' changed its 'Version' value from '11.1' to '11.11'
N: Repository 'http://deb.debian.org/debian bullseye InRelease' changed its 'Suite' value from 'stable' to 'oldoldstable'
N: Repository 'http://deb.debian.org/debian bullseye-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldoldstable-updates'
E: Release file for http://security.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 11h 14min 17s). Updates for this repository will not be applied.

Exited with code exit status 100
```

We think the root cause is the `live-deploy` jobs using the legacy `aws-eks/python` executor, which is built on an old CircleCI convenience image. That image hits Debian Bullseye apt metadata expiry during `sudo apt-get update`, causing the failure.

Hopefully updating the images to use CircleCI images should fix the issue.