### PR TITLE
Add support for isCivil flag on hearing resulted messages

### DIFF
--- a/app/models/hmcts_common_platform/prosecution_case.rb
+++ b/app/models/hmcts_common_platform/prosecution_case.rb
@@ -28,6 +28,10 @@ module HmctsCommonPlatform
       data[:caseStatus]
     end
 
+    def is_civil
+      data[:isCivil]
+    end
+
     def statement_of_facts
       data[:statementOfFacts]
     end
@@ -57,6 +61,7 @@ module HmctsCommonPlatform
         pc.id id
         pc.prosecution_case_identifier prosecution_case_identifier.to_json
         pc.status status
+        pc.is_civil is_civil
         pc.statement_of_facts statement_of_facts
         pc.statement_of_facts_welsh statement_of_facts_welsh
         pc.defendants defendants.map(&:to_json)

--- a/app/models/maat_api/court_application.rb
+++ b/app/models/maat_api/court_application.rb
@@ -38,6 +38,10 @@ module MaatApi
       false
     end
 
+    def is_civil
+      false
+    end
+
     def inactive
       "Y"
     end

--- a/app/models/maat_api/message.rb
+++ b/app/models/maat_api/message.rb
@@ -19,6 +19,7 @@ module MaatApi
         docLanguage: doc_language,
         proceedingsConcluded: object.proceedings_concluded || false,
         inActive: object.inactive,
+        isCivil: object.is_civil || false,
         functionType: object.function_type,
         defendant: object.defendant,
         session: object.session,

--- a/app/models/maat_api/prosecution_case.rb
+++ b/app/models/maat_api/prosecution_case.rb
@@ -1,12 +1,13 @@
 module MaatApi
   class ProsecutionCase
-    attr_reader :hearing_resulted, :hmcts_common_platform_defendant, :maat_reference, :case_urn
+    attr_reader :hearing_resulted, :hmcts_common_platform_defendant, :maat_reference, :case_urn, :is_civil
 
-    def initialize(hearing_resulted, case_urn, defendant, maat_reference)
+    def initialize(hearing_resulted, case_urn, defendant, maat_reference, is_civil)
       @hearing_resulted = hearing_resulted
       @case_urn = case_urn
       @hmcts_common_platform_defendant = defendant
       @maat_reference = maat_reference
+      @is_civil = is_civil || false
     end
 
     def hearing_id

--- a/app/services/hearings_creator.rb
+++ b/app/services/hearings_creator.rb
@@ -31,6 +31,7 @@ private
           prosecution_case.urn,
           defendant,
           laa_reference.maat_reference,
+          prosecution_case.is_civil,
         )
 
         Sqs::MessagePublisher.call(

--- a/lib/schemas/global/apiProsecutionCase.json
+++ b/lib/schemas/global/apiProsecutionCase.json
@@ -23,6 +23,9 @@
         "policeOfficerInCase": {
             "$ref": "http://justice.gov.uk/core/courts/external/apiPoliceOfficerInCase.json#"
         },
+        "isCivil": {
+          "type": "boolean"
+        },
         "statementOfFacts": {
             "type": "string"
         },

--- a/spec/fixtures/files/hearing/with_civil_prosecution_case.json
+++ b/spec/fixtures/files/hearing/with_civil_prosecution_case.json
@@ -1,0 +1,52 @@
+{
+    "hearing": {
+      "id": "b935a64a-6d03-4da4-bba6-4d32cc2e7fb4",
+      "jurisdictionType": "CROWN",
+      "courtCentre": {
+        "id": "bc4864ca-4b22-3449-9716-a8db1db89905",
+        "name": "Warrington CCU (Decom)",
+        "roomId": "bc4864ca-4b22-3449-9716-a8db1db89905",
+        "roomName": "Warrington CCU (Decom)",
+        "code": "A07AF00"
+      },
+      "type": {
+        "id": "63003e58-d753-46e2-a2c8-47fd15341592",
+        "description": "Mention - Defendant to Attend (MDA)"
+      },
+      "prosecutionCases": [
+        {
+          "id": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+          "prosecutionCaseIdentifier": {
+            "caseURN": "20GD0217100",
+            "prosecutionAuthorityReference": "UXJYGCVRXJ"
+          },
+          "initiationCode": "O",
+          "defendants": [
+            {
+              "id": "2ecc9feb-9407-482f-b081-d9e5c8ba3ed3",
+              "prosecutionCaseId": "5edd67eb-9d8c-44f2-a57e-c8d026defaa4",
+              "offences": [
+                {
+                  "id": "2571e09f-0023-4b54-a0a9-f995438e4f2c",
+                  "offenceDefinitionId": "fee1e552-3d2a-4dc4-a128-c3a6cf5e706b",
+                  "offenceCode": "FB89501",
+                  "offenceTitle": "Complaint for a football banning order",
+                  "wording": "Complaint for a football banning order",
+                  "startDate": "2026-08-01",
+                  "civilOffence":
+                  {
+                    "isExParte": false
+                  }
+                }
+              ]
+            }
+          ],
+          "isCivil": true,
+          "caseStatus": "ACTIVE",
+          "originatingOrganisation": "0010000",
+          "statementOfFacts": "statementOfFacts"
+        }
+      ]
+    },
+    "sharedTime": "2021-03-09T15:54:09.871Z"
+  }

--- a/spec/models/maat_api/court_application_spec.rb
+++ b/spec/models/maat_api/court_application_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
       expect(court_application.proceedings_concluded).to be(false)
     end
 
+    it "has an is_civil flag" do
+      expect(court_application.is_civil).to be(false)
+    end
+
     it "is always inactive" do
       expect(court_application.inactive).to eql("Y")
     end
@@ -158,6 +162,10 @@ RSpec.describe MaatApi::CourtApplication, type: :model do
 
     it "has proceedings_concluded flag" do
       expect(court_application.proceedings_concluded).to be(false)
+    end
+
+    it "has an is_civil flag" do
+      expect(court_application.is_civil).to be(false)
     end
 
     it "is always inactive" do

--- a/spec/models/maat_api/message_spec.rb
+++ b/spec/models/maat_api/message_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe MaatApi::Message do
       cjsLocation: "cjs location",
       docLanguage: "EN",
       proceedingsConcluded: false,
+      isCivil: false,
       inActive: "Y",
       functionType: "function type",
       defendant: "defendant",
@@ -87,6 +88,10 @@ class Messageable
 
   def proceedings_concluded
     attrs[:proceedings_concluded]
+  end
+
+  def is_civil
+    attrs[:is_civil]
   end
 
   def inactive

--- a/spec/models/maat_api/prosecution_case_spec.rb
+++ b/spec/models/maat_api/prosecution_case_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
   let(:prosecution_case_data) { hearing_resulted_data.dig(:hearing, :prosecutionCases).first }
   let(:case_urn) { prosecution_case_data[:prosecutionCaseIdentifier][:caseURN] }
   let(:defendant_data) { prosecution_case_data[:defendants].first }
+  let(:is_civil) { prosecution_case_data[:isCivil] }
 
   let(:prosecution_case) do
     described_class.new(
@@ -10,6 +11,7 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
       case_urn,
       HmctsCommonPlatform::Defendant.new(defendant_data),
       maat_reference,
+      is_civil,
     )
   end
 
@@ -54,6 +56,10 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
 
     it "has a proceedings_concluded flag" do
       expect(prosecution_case.proceedings_concluded).to be(false)
+    end
+
+    it "has an is_civil flag" do
+      expect(prosecution_case.is_civil).to be(false)
     end
 
     it "has an inactive" do
@@ -200,6 +206,10 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
       expect(prosecution_case.proceedings_concluded).to be(false)
     end
 
+    it "defaults is_civil to false" do
+      expect(prosecution_case.is_civil).to be(false)
+    end
+
     it "has an inactive" do
       expect(prosecution_case.inactive).to eql("Y")
     end
@@ -262,6 +272,14 @@ RSpec.describe MaatApi::ProsecutionCase, type: :model do
       }
 
       expect(prosecution_case.session).to eql(expected)
+    end
+  end
+
+  context "when prosecution case is a civil case" do
+    let(:hearing_resulted_data) { JSON.parse(file_fixture("hearing/with_civil_prosecution_case.json").read).deep_symbolize_keys }
+
+    it "has an is_civil flag" do
+      expect(prosecution_case.is_civil).to be(true)
     end
   end
 end

--- a/spec/services/hearings_creator_spec.rb
+++ b/spec/services/hearings_creator_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe HearingsCreator do
             :docLanguage,
             :proceedingsConcluded,
             :inActive,
+            :isCivil,
             :functionType,
             :defendant,
             :session,
@@ -250,6 +251,7 @@ RSpec.describe HearingsCreator do
             :cjsLocation,
             :docLanguage,
             :proceedingsConcluded,
+            :isCivil,
             :inActive,
             :functionType,
             :defendant,
@@ -312,7 +314,7 @@ RSpec.describe HearingsCreator do
       end
     end
 
-    context "with a linked suject" do
+    context "with a linked subject" do
       let(:prosecution_case_array) { nil }
 
       before do
@@ -338,6 +340,7 @@ RSpec.describe HearingsCreator do
             :cjsLocation,
             :docLanguage,
             :proceedingsConcluded,
+            :isCivil,
             :inActive,
             :functionType,
             :defendant,


### PR DESCRIPTION
This PR adds support for the existing `isCivil` flag that can be part of hearing resulted messages received from HMCTS. This flag has never needed to be supported before as CDA has only ever dealt with criminal cases, however with civil proceedings there is now a need to differentiate between criminal and civil cases.

The `isCivil` flag will only ever appear on civil cases and will not even be a property on a prosecution case object for criminal cases.

[Link to story](https://dsdmoj.atlassian.net/browse/LAACONNECT-1521)