### PR TITLE
Acd 1359 Implement auto-linking scenario for MAAT application linked to a Libra case

### DIFF
--- a/app/models/maat_api/search_response.rb
+++ b/app/models/maat_api/search_response.rb
@@ -34,8 +34,20 @@ module MaatApi
       libra_id.to_s.start_with?(COMMON_PLATFORM_PREFIX) && case_urn.present?
     end
 
-    def linked_case_urn
-      case_urn
+    def linked_to_libra?
+      libra_id.present? && !libra_id.start_with?(COMMON_PLATFORM_PREFIX)
+    end
+
+    def case_urn
+      linking_detail["caseUrn"]
+    end
+
+    def link_state
+      return :unlinked unless existing_link?
+      return :linked_to_common_platform if linked_to_common_platform?
+      return :linked_to_libra if is_linked? && linked_to_libra?
+
+      :link_state_unknown
     end
 
   private
@@ -44,10 +56,6 @@ module MaatApi
 
     def libra_id
       linking_detail["libraId"]
-    end
-
-    def case_urn
-      linking_detail["caseUrn"]
     end
 
     def is_linked?

--- a/app/services/process_xhibit_cases.rb
+++ b/app/services/process_xhibit_cases.rb
@@ -29,12 +29,22 @@ private
   end
 
   def handle_success(response, xhibit_case)
-    if response.existing_link?
-      xhibit_case.action_required!
-      record_error(xhibit_case, :maat, message: existing_link_message(response))
-      return
+    case response.link_state
+    when :linked_to_common_platform
+      flag_manual_action_required(
+        xhibit_case, "MAAT ID already linked with other CP case (#{response.case_urn})"
+      )
+    when :link_state_unknown
+      flag_manual_action_required(xhibit_case, "MAAT link status could not be determined")
+    when :linked_to_libra
+      RequestLibraUnlink.call(response, xhibit_case)
+      link_to_common_platform(response, xhibit_case)
+    when :unlinked
+      link_to_common_platform(response, xhibit_case)
     end
+  end
 
+  def link_to_common_platform(response, xhibit_case)
     defendant_summary = fetch_defendant_summary(xhibit_case)
 
     if defendant_summary.nil?
@@ -75,16 +85,12 @@ private
   end
 
   def handle_not_found(xhibit_case)
-    xhibit_case.action_required!
-    record_error(xhibit_case, :maat, message: "MAAT application not found")
+    flag_manual_action_required(xhibit_case, "MAAT application not found")
   end
 
-  def existing_link_message(response)
-    if response.linked_to_common_platform?
-      "MAAT ID already linked with other CP case (#{response.linked_case_urn})"
-    else
-      "MAAT application is already linked"
-    end
+  def flag_manual_action_required(xhibit_case, message)
+    xhibit_case.action_required!
+    record_error(xhibit_case, :maat, message:)
   end
 
   # Errors are keyed by step and merged, so that a failure in one step does not

--- a/app/services/request_libra_unlink.rb
+++ b/app/services/request_libra_unlink.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RequestLibraUnlink < ApplicationService
+  REASON_TEXT = "XHIBIT migration: unlinking from LIBRA case"
+
+  def initialize(maat_search_response, xhibit_case)
+    @xhibit_case = xhibit_case
+    @maat_id = maat_search_response.maat_id.to_s
+  end
+
+  def call
+    Sqs::MessagePublisher.call(
+      message: {
+        defendantId: @xhibit_case.defendant_id,
+        maatId: @maat_id,
+        userId: User::SYSTEM_USERNAME,
+        reasonId: LaaReference::OTHER_REASON_CODE,
+        otherReasonText: REASON_TEXT,
+      },
+      queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+      log_info: { maat_reference: @maat_id },
+    )
+  end
+end

--- a/spec/fixtures/files/maat_api/search/linked_to_libra_case.json
+++ b/spec/fixtures/files/maat_api/search/linked_to_libra_case.json
@@ -1,0 +1,13 @@
+[
+  {
+    "maatId": 6672961,
+    "linkingDetail": {
+      "libraId": "2600000358",
+      "caseId": 1022118,
+      "caseUrn": null,
+      "cjsAreaCode": "01",
+      "cjsLocation": "B01OB"
+    },
+    "isLinked": true
+  }
+]

--- a/spec/models/maat_api/search_response_spec.rb
+++ b/spec/models/maat_api/search_response_spec.rb
@@ -253,21 +253,108 @@ RSpec.describe MaatApi::SearchResponse, type: :model do
     end
   end
 
-  describe "#linked_case_urn" do
+  describe "#linked_to_libra?" do
+    it "returns true when the libra id does NOT start with CP" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "2600000358", "caseUrn" => nil } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_libra?).to be true
+    end
+
+    it "returns false when the libra id starts with CP" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => "01AB1234567" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_libra?).to be false
+    end
+
+    it "returns false when the libra id is blank" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => { "libraId" => "", "caseUrn" => "URN123" } },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_libra?).to be false
+    end
+
+    it "returns false when the application is linked without any linking detail" do
+      http_response = instance_double(Faraday::Response, status: 200, body: [
+        { "isLinked" => true, "linkingDetail" => nil },
+      ])
+      response = described_class.new(http_response)
+
+      expect(response.linked_to_libra?).to be false
+    end
+
+    it "returns false when http_response is nil" do
+      response = described_class.new(nil)
+
+      expect(response.linked_to_libra?).to be false
+    end
+  end
+
+  describe "#link_state" do
+    def link_state_for(result)
+      described_class.new(instance_double(Faraday::Response, status: 200, body: [result])).link_state
+    end
+
+    it "is 'unlinked' when nothing reports a link" do
+      expect(link_state_for("isLinked" => false, "linkingDetail" => nil)).to eq(:unlinked)
+    end
+
+    it "is 'linked_to_common_platform' for a CP libra id with a case urn" do
+      expect(link_state_for("isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => "01AB1234567" }))
+        .to eq(:linked_to_common_platform)
+    end
+
+    it "is 'linked_to_libra' for a libra id without the CP prefix" do
+      expect(link_state_for("isLinked" => true, "linkingDetail" => { "libraId" => "2600000358", "caseUrn" => nil }))
+        .to eq(:linked_to_libra)
+    end
+
+    it "is 'link_state_unknown' for a libra id when MAAT reports the application as not linked" do
+      expect(link_state_for("isLinked" => false, "linkingDetail" => { "libraId" => "2600000358", "caseUrn" => nil }))
+        .to eq(:link_state_unknown)
+    end
+
+    it "is 'link_state_unknown' when the application is linked without any linking detail" do
+      expect(link_state_for("isLinked" => true, "linkingDetail" => nil)).to eq(:link_state_unknown)
+    end
+
+    it "is 'link_state_unknown' when a libra id is not present" do
+      expect(link_state_for("isLinked" => false, "linkingDetail" => { "caseUrn" => "URN123" }))
+        .to eq(:link_state_unknown)
+    end
+
+    it "is 'link_state_unknown' when a CP case urn in nil" do
+      expect(link_state_for("isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => nil }))
+        .to eq(:link_state_unknown)
+    end
+
+    it "is unlinked when http_response is nil" do
+      expect(described_class.new(nil).link_state).to eq(:unlinked)
+    end
+  end
+
+  describe "#case_urn" do
     it "returns the case urn the MAAT application is linked to" do
       http_response = instance_double(Faraday::Response, status: 200, body: [
         { "isLinked" => true, "linkingDetail" => { "libraId" => "CP0001", "caseUrn" => "01AB1234567" } },
       ])
       response = described_class.new(http_response)
 
-      expect(response.linked_case_urn).to eq("01AB1234567")
+      expect(response.case_urn).to eq("01AB1234567")
     end
 
     it "returns nil when there is no linking detail" do
       http_response = instance_double(Faraday::Response, status: 200, body: [{ "isLinked" => true }])
       response = described_class.new(http_response)
 
-      expect(response.linked_case_urn).to be_nil
+      expect(response.case_urn).to be_nil
     end
   end
 end

--- a/spec/services/process_xhibit_cases_spec.rb
+++ b/spec/services/process_xhibit_cases_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe ProcessXhibitCases do
         process_cases
 
         expect(xhibit_case.reload.process_errors).to eq(
-          "maat" => { "message" => "MAAT application is already linked" },
+          "maat" => { "message" => "MAAT link status could not be determined" },
         )
       end
     end
@@ -170,6 +170,30 @@ RSpec.describe ProcessXhibitCases do
         )
       end
     end
+
+    context "when the MAAT application is already linked to a LIBRA case" do
+      before do
+        stub_maat_search("linked_to_libra_case")
+        allow(RequestLibraUnlink).to receive(:call)
+        allow(LinkXhibitCase).to receive(:call)
+      end
+
+      it "requests the LIBRA unlink" do
+        process_cases
+
+        expect(RequestLibraUnlink).to have_received(:call).with(an_instance_of(MaatApi::SearchResponse), xhibit_case)
+      end
+
+      it "calls the `LinkXhibitCase` class" do
+        process_cases
+
+        expect(LinkXhibitCase).to have_received(:call).with(
+          an_instance_of(MaatApi::SearchResponse),
+          xhibit_case,
+          defendant_summary,
+        )
+      end
+    end
   end
 
   context "when the search fails" do
@@ -193,7 +217,7 @@ RSpec.describe ProcessXhibitCases do
     let!(:failing_case) { create_case(first_name: "Failing", last_name: "Case") }
     let!(:succeeding_case) { create_case(first_name: "Succeeding", last_name: "Case") }
 
-    let(:response) { instance_double(MaatApi::SearchResponse, success?: true, existing_link?: false) }
+    let(:response) { instance_double(MaatApi::SearchResponse, success?: true, link_state: :unlinked) }
 
     before do
       allow(MaatApi::MaatApplicationSearcher).to receive(:call).and_return(response)

--- a/spec/services/request_libra_unlink_spec.rb
+++ b/spec/services/request_libra_unlink_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe RequestLibraUnlink, type: :service do
+  subject(:request_unlink) { described_class.call(maat_response, xhibit_case) }
+
+  let(:maat_response) { instance_double(MaatApi::SearchResponse, maat_id: 6_672_961) }
+
+  let(:xhibit_case) do
+    create(:xhibit_migrated_case,
+           defendant_id: "b7c8e2f0-0000-4000-8000-000000000001",
+           defendant_first_name: "Alice",
+           defendant_last_name: "Smith")
+  end
+
+  before { allow(Sqs::MessagePublisher).to receive(:call) }
+
+  it "publishes an unlink request to the MAAT unlink queue" do
+    request_unlink
+
+    expect(Sqs::MessagePublisher).to have_received(:call).with(
+      message: {
+        defendantId: "b7c8e2f0-0000-4000-8000-000000000001",
+        maatId: "6672961",
+        userId: User::SYSTEM_USERNAME,
+        reasonId: LaaReference::OTHER_REASON_CODE,
+        otherReasonText: "XHIBIT migration: unlinking from LIBRA case",
+      },
+      queue_url: Rails.configuration.x.aws.sqs_url_unlink,
+      log_info: { maat_reference: "6672961" },
+    )
+  end
+end

--- a/spec/services/xhibit_auto_linking_spec.rb
+++ b/spec/services/xhibit_auto_linking_spec.rb
@@ -1,6 +1,6 @@
 require "sidekiq/testing"
 
-RSpec.describe "XHIBIT auto-linking", type: :service do
+RSpec.describe ProcessXhibitCases, type: :service do
   subject(:process_cases) { ProcessXhibitCases.call }
 
   let(:case_urn) { "61GD7528225" }
@@ -37,19 +37,6 @@ RSpec.describe "XHIBIT auto-linking", type: :service do
   context "when every offence is linked" do
     let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_success" }
 
-    it "searches MAAT once for the case" do
-      process_cases
-
-      expect(a_request(:post, %r{search-maat-application})).to have_been_made.once
-    end
-
-    it "retrieves the offences associated with the defendant" do
-      process_cases
-
-      expect(ProsecutionCaseDefendantOffence.where(defendant_id:).pluck(:offence_id))
-        .to contain_exactly(first_offence_id, second_offence_id)
-    end
-
     it "posts an LAA reference to Common Platform for each offence" do
       process_cases
 
@@ -57,13 +44,6 @@ RSpec.describe "XHIBIT auto-linking", type: :service do
         .to have_been_made.once
       expect(a_request(:post, %r{/laaReference/cases/#{prosecution_case_id}/defendant/#{defendant_id}/offences/#{second_offence_id}}))
         .to have_been_made.once
-    end
-
-    it "records the Common Platform response against each offence" do
-      process_cases
-
-      expect(ProsecutionCaseDefendantOffence.where(defendant_id:).pluck(:rep_order_status, :response_status))
-        .to eq([%w[AP].push(202), %w[AP].push(202)])
     end
 
     it "creates a link between the MAAT application and the Common Platform case" do
@@ -104,24 +84,11 @@ RSpec.describe "XHIBIT auto-linking", type: :service do
   context "when one offence fails to link" do
     let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_offence_failure" }
 
-    it "still attempts the offence Common Platform rejects" do
-      process_cases
-
-      expect(a_request(:post, %r{/laaReference/cases/#{prosecution_case_id}/defendant/#{defendant_id}/offences/#{second_offence_id}}))
-        .to have_been_made.once
-    end
-
     it "does not mark the xhibit case as linked" do
       process_cases
 
       expect(xhibit_case.reload).to be_pending
       expect(xhibit_case).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
-    end
-
-    it "does not create the link" do
-      process_cases
-
-      expect(LaaReference.find_by(defendant_id:)).to be_nil
     end
 
     it "records the failure on the xhibit case" do
@@ -130,44 +97,36 @@ RSpec.describe "XHIBIT auto-linking", type: :service do
       expect(xhibit_case.reload.process_errors["unexpected"])
         .to include("error" => "CommonPlatform::Api::Errors::FailedDependency")
     end
-
-    it "does not publish a MAAT link message" do
-      process_cases
-
-      expect(Sqs::MessagePublisher).not_to have_received(:call)
-    end
   end
 
-  context "when the MAAT application is already linked to another Common Platform case" do
+  context "when the MAAT application is already linked to a LIBRA case" do
     let(:laa_reference_cassette_name) { "laa_reference_recorder/xhibit_auto_link_success" }
+    let(:libra_maat_id) { 6_672_961 }
+    let(:published_queues) { [] }
 
-    before { stub_maat_search("linked_to_cp_case") }
+    before do
+      stub_maat_search("linked_to_libra_case")
+      allow(Sqs::MessagePublisher).to receive(:call) { |**args| published_queues << args[:queue_url] }
+    end
 
-    it "flags the case for manual action with the linked case URN" do
+    it "publishes the unlink request before the link message" do
       process_cases
 
-      expect(xhibit_case.reload).to be_action_required
-      expect(xhibit_case.process_errors).to eq(
-        "maat" => { "message" => "MAAT ID already linked with other CP case (01AB1234567)" },
+      expect(published_queues).to eq([
+        Rails.configuration.x.aws.sqs_url_unlink,
+        Rails.configuration.x.aws.sqs_url_link,
+      ])
+    end
+
+    it "links the case" do
+      process_cases
+
+      expect(xhibit_case.reload).to be_auto_linked
+      expect(xhibit_case).to have_attributes(
+        maat_id: libra_maat_id.to_s,
+        linked_by: User::SYSTEM_USERNAME,
+        linked_at: within(1.minute).of(Time.zone.now),
       )
-    end
-
-    it "leaves the case unlinked" do
-      process_cases
-
-      expect(xhibit_case.reload).to have_attributes(maat_id: nil, linked_at: nil, linked_by: nil)
-    end
-
-    it "does not post an LAA reference to Common Platform" do
-      process_cases
-
-      expect(a_request(:post, %r{/laaReference/})).not_to have_been_made
-    end
-
-    it "does not publish a MAAT link message" do
-      process_cases
-
-      expect(Sqs::MessagePublisher).not_to have_received(:call)
     end
   end
 end

--- a/spec/support/sqs.rb
+++ b/spec/support/sqs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Aws::SQS::Client is instantiated as a default argument in Sqs::MessagePublisher,
+# so without this every publish would attempt a real request.
+Aws.config[:stub_responses] = true
+
+# Queue URLs have to be present and distinct in test: MessagePublisher no-ops on a
+# blank URL, which makes every `queue_url:` assertion in the suite vacuous.
+%i[sqs_url_link sqs_url_unlink sqs_url_hearing_resulted sqs_url_prosecution_concluded].each do |name|
+  Rails.configuration.x.aws[name] = "https://sqs.test/#{name}" if Rails.configuration.x.aws[name].blank?
+end


### PR DESCRIPTION
## What

Implement auto-linking scenario for MAAT application linked to a Libra case

https://dsdmoj.atlassian.net/browse/LAACONNECT-1359

---
I implemented the Scenario 1: MAAT record found, linked to a Libra case Preview).
I also cleaned up the code by defining a `link_state` to clearly differentiate the scenarios, which should make it easier to understand.
